### PR TITLE
[[ Bug 14316 ]] Allow infinite result in div, times and pow operations

### DIFF
--- a/docs/dictionary/command/add.lcdoc
+++ b/docs/dictionary/command/add.lcdoc
@@ -80,12 +80,16 @@ empty, the <add> <command> treats its contents as zero.
 If <container> is a <field> or <button>, the <format> of the sum is
 determined by the <numberFormat> <property>.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: combine (command), multiply (command), split (command),
 union (command), sum (function), value (function), array (glossary),
 command (glossary), container (glossary), element (glossary),
 evaluate (glossary), expression (glossary), format (glossary),
 property (glossary), element (keyword), button (object), field (object),
-numberFormat (property)
+numberFormat (property), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/command/divide.lcdoc
+++ b/docs/dictionary/command/divide.lcdoc
@@ -67,13 +67,15 @@ the <array>.
 If the <container> or an <element(keyword)> of the <arrayContainer> is
 empty, the <divide> <command> treats its contents as zero.
 
-Attempting to divide by zero causes an execution error.
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: multiply (command), format (function), value (function),
 property (glossary), element (glossary), container (glossary),
 expression (glossary), array (glossary), evaluate (glossary),
 command (glossary), field (keyword), element (keyword), button (keyword),
-/ (operator), numberFormat (property)
+/ (operator), numberFormat (property), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/command/multiply.lcdoc
+++ b/docs/dictionary/command/multiply.lcdoc
@@ -64,17 +64,21 @@ corresponding <element(keyword)> of the <array>.
 If the <container> or an <element(keyword)> of the <arrayContainer> is
 empty, the <multiply> <command> treats its contents as zero.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 Changes:
 The multiply arrayContainer form was introduced in version 1.1. In
 previous versions, only single numbers could be used with the multiply
-command. 
+command.
 
 References: add (command), divide (command), subtract (command),
 format (function), value (function), matrixMultiply (function),
 property (glossary), element (glossary), container (glossary),
 expression (glossary), array (glossary), evaluate (glossary),
 command (glossary), field (keyword), element (keyword), button (keyword),
-* (operator), numberFormat (property)
+* (operator), numberFormat (property), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/command/subtract.lcdoc
+++ b/docs/dictionary/command/subtract.lcdoc
@@ -73,11 +73,15 @@ empty, the <subtract> <command> treats its contents as zero.
 If <container> is a <field> or <button>, the <format> of the sum is
 determined by the <numberFormat> <property>.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: multiply (command), format (function), value (function),
 property (glossary), element (glossary), container (glossary),
 expression (glossary), array (glossary), evaluate (glossary),
 command (glossary), field (keyword), element (keyword), button (keyword),
-- (operator), numberFormat (property)
+- (operator), numberFormat (property), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/acos.lcdoc
+++ b/docs/dictionary/function/acos.lcdoc
@@ -48,9 +48,12 @@ The arc cosine of <number> is an angle whose cosine is equal to
 
     end acosInDegrees
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: pi (constant), function (control structure), cos (function),
-return (glossary), degree (glossary), inverse (keyword)
+return (glossary), degree (glossary), inverse (keyword), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/annuity.lcdoc
+++ b/docs/dictionary/function/annuity.lcdoc
@@ -55,8 +55,12 @@ For example, if the loan is for $2500 at an interest rate of 2% per
 month and is to be repaid in a year, the monthly payment is
 2500/annuity(.02,12) or $236.40.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), compound (function),
-value (function), return (glossary)
+value (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/asin.lcdoc
+++ b/docs/dictionary/function/asin.lcdoc
@@ -47,10 +47,13 @@ Use the <asin> <function> to find the arc sine of a number.
 The arc sine of <number> is an angle whose sine is equal to <number>. In
 other words, <asin> is an <inverse> of the <sin> <function>.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: pi (constant), function (control structure), sin (function),
 radian (glossary), custom function (glossary), return (glossary),
-degree (glossary), inverse (keyword)
+degree (glossary), inverse (keyword), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/atan.lcdoc
+++ b/docs/dictionary/function/atan.lcdoc
@@ -44,11 +44,15 @@ Use the <atan> <function> to find the arc tangent of a number.
 
 The arc tangent of <number> is an angle whose tangent is equal to
 <number>. In other words, <atan> is an <inverse> of the <tan>
-<function>. 
+<function>.
+
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: pi (constant), function (control structure), tan (function),
 radian (glossary), custom function (glossary), return (glossary),
-degree (glossary), inverse (keyword)
+degree (glossary), inverse (keyword), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/atan2.lcdoc
+++ b/docs/dictionary/function/atan2.lcdoc
@@ -48,9 +48,13 @@ y are negative, the sign of x/y is positive. In this case, the atan
 function <return|returns> an angle in the first quadrant, but the
 <atan2> <function> <return|returns> an angle in the third quadrant.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: pi (constant), function (control structure), sign (glossary),
 radian (glossary), custom function (glossary), return (glossary),
-degree (glossary)
+degree (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/average.lcdoc
+++ b/docs/dictionary/function/average.lcdoc
@@ -46,6 +46,10 @@ The <average> <function> can also be written like this:
 
 If the <numbersList> is empty, the <average> <function> returns zero.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 Changes:
 The ability to use an array was introduced in version 1.1. In previous
 versions, only lists of numbers could be used with the average function.
@@ -54,7 +58,7 @@ References: function (control structure), min (function),
 geometricMean (function), statRound (function), harmonicMean (function),
 variance (function), round (function), value (function), max (function),
 median (function), standardDeviation (function), return (glossary),
-value (glossary)
+value (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/averageDeviation.lcdoc
+++ b/docs/dictionary/function/averageDeviation.lcdoc
@@ -36,10 +36,14 @@ a list of numbers.
 The average deviation is a measure of how widely distributed the numbers
 in the <numbersList> are.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), populationVariance (function),
 variance (function), average (function), median (function),
 populationStandardDeviation (function), sum (function),
-standardDeviation (function), return (glossary)
+standardDeviation (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/compound.lcdoc
+++ b/docs/dictionary/function/compound.lcdoc
@@ -47,7 +47,11 @@ The <numberOfPeriods> and the <interestRate> must use the same unit of
 time. For example, if the periods are months, the <interestRate> is the
 interest per month.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), annuity (function),
-round (function), return (glossary)
+round (function), return (glossary), math operation (glossary)
 
 Tags: math

--- a/docs/dictionary/function/exp.lcdoc
+++ b/docs/dictionary/function/exp.lcdoc
@@ -33,9 +33,13 @@ Use the <exp> function to obtain a power of e, e^ <number>.
 
 The transcendental number e appears in many mathematical formulas.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: sqrt (function), exp10 (function), ln (function),
 exp2 (function), baseConvert (function), exp1 (function),
-return (glossary), ^ (operator)
+return (glossary), ^ (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/exp1.lcdoc
+++ b/docs/dictionary/function/exp1.lcdoc
@@ -32,7 +32,12 @@ ln1(exp1(x)) = x for any number x.
 
 The transcendental number e appears in many mathematical formulas.
 
-References: ln1 (function), exp (function), return (glossary)
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
+References: ln1 (function), exp (function), return (glossary),
+math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/exp10.lcdoc
+++ b/docs/dictionary/function/exp10.lcdoc
@@ -37,8 +37,12 @@ If <number> is a positive <integer>, exp10(number) is a 1 followed by
 <number> zeros. If <number> is a <negative> <integer>, exp10(number) is
 a decimal point followed by <number>-1 zeros and a one.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: exp (function), negative (glossary), return (glossary),
-integer (keyword)
+integer (keyword), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/exp2.lcdoc
+++ b/docs/dictionary/function/exp2.lcdoc
@@ -33,7 +33,12 @@ Use the <exp2> function to obtain a power of 2.
 
 The expression exp2(number) is equal to 2^number.
 
-References: exp (function), binary (glossary), return (glossary)
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
+References: exp (function), binary (glossary), return (glossary),
+math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/geometricMean.lcdoc
+++ b/docs/dictionary/function/geometricMean.lcdoc
@@ -37,13 +37,17 @@ The <geometricMean> <function> was added in version 6.1 to complement
 the <average> <function>.
 
 If the <numbersList> is empty, the <geometricMean> <function> returns
-zero. 
+zero.
+
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: function (control structure), min (function),
 statRound (function), round (function), harmonicMean (function),
 variance (function), average (function), value (function), max (function),
 median (function), standardDeviation (function), return (glossary),
-value (glossary)
+value (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/harmonicMean.lcdoc
+++ b/docs/dictionary/function/harmonicMean.lcdoc
@@ -36,13 +36,17 @@ The <harmonicMean> <function> was added in version 6.1 to complement the
 <average> <function>.
 
 If the <numbersList> is empty, the <harmonicMean> <function> returns
-zero. 
+zero.
+
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: function (control structure), min (function),
 geometricMean (function), statRound (function), variance (function),
 round (function), average (function), value (function), max (function),
 median (function), standardDeviation (function), return (glossary),
-value (glossary)
+value (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/ln.lcdoc
+++ b/docs/dictionary/function/ln.lcdoc
@@ -46,9 +46,12 @@ function:
         return ln(theNumber)/ln(theBase)
     end logarithm
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 References: function (control structure), ln1 (function), exp (function),
-return (glossary)
+return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/ln1.lcdoc
+++ b/docs/dictionary/function/ln1.lcdoc
@@ -37,8 +37,13 @@ raised to obtain the <number>.
 
 The transcendental number e appears in many mathematical formulas.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), ln (function), log10 (function),
-log2 (function), exp1 (function), return (glossary), ^ (operator)
+log2 (function), exp1 (function), return (glossary), ^ (operator),
+math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/log10.lcdoc
+++ b/docs/dictionary/function/log10.lcdoc
@@ -37,8 +37,12 @@ Use the <log10> <function> to obtain a logarithm.
 The logarithm of a <number> is the power to which 10 must be raised to
 obtain the <number> : 10^log10(<number>) is equal to number.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), ln1 (function),
-return (glossary)
+return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/log2.lcdoc
+++ b/docs/dictionary/function/log2.lcdoc
@@ -34,8 +34,12 @@ Use the <log2> <function> to obtain a base-2 logarithm.
 The base-2 logarithm of a <number> is the power to which 2 must be
 raised to obtain the <number> : 2^log2(<number>) is equal to number.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), ln1 (function),
-return (glossary)
+return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/median.lcdoc
+++ b/docs/dictionary/function/median.lcdoc
@@ -39,9 +39,13 @@ takes the two middle values and averages them to produce the median.
 If the list consists of fewer than three numbers, or if the numbers are
 evenly distributed, the <median> is equal to the <average>.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), average (function),
 standardDeviation (function), value (function), return (glossary),
-value (glossary)
+value (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/populationStandardDeviation.lcdoc
+++ b/docs/dictionary/function/populationStandardDeviation.lcdoc
@@ -38,9 +38,13 @@ complement the <standardDeviation> <function>. The population standard
 deviation is a measure of how widely distributed the numbers in the
 <numbersList> are.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), median (function),
 standardDeviation (function), sum (function), averageDeviation (function),
-average (function), return (glossary)
+average (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/populationVariance.lcdoc
+++ b/docs/dictionary/function/populationVariance.lcdoc
@@ -36,10 +36,14 @@ in a list of numbers.
 The population variance is a measure of how widely distributed the
 numbers in the <numbersList> are.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), populationVariance (function),
 averageDeviation (function), variance (function), average (function),
 median (function), populationStandardDeviation (function), sum (function),
-standardDeviation (function), return (glossary)
+standardDeviation (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/sqrt.lcdoc
+++ b/docs/dictionary/function/sqrt.lcdoc
@@ -35,9 +35,13 @@ Use the <sqrt> <function> to find the square root of a number.
 The square root of a <number> is the number which must be squared to
 obtain <number> : sqrt(<number>)^2 is equal to <number>.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), exp (function),
 number (function), return (glossary), non-negative (glossary),
-^ (operator)
+^ (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/standardDeviation.lcdoc
+++ b/docs/dictionary/function/standardDeviation.lcdoc
@@ -36,10 +36,14 @@ in a list of numbers.
 The sample standard deviation is a measure of how widely distributed the
 numbers in the <numbersList> are.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), populationVariance (function),
 averageDeviation (function), variance (function), average (function),
 median (function), populationStandardDeviation (function), sum (function),
-standardDeviation (function), return (glossary)
+standardDeviation (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/sum.lcdoc
+++ b/docs/dictionary/function/sum.lcdoc
@@ -40,6 +40,10 @@ The <sum> <function> is equivalent to the following
 
 If the <numbersList> is empty, the <sum> <function> returns zero.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 Changes:
 The ability to use an array was introduced in version 1.1. In previous
 versions, only lists of numbers could be used with the sum function.
@@ -47,4 +51,4 @@ versions, only lists of numbers could be used with the sum function.
 References: add (command), group (command), function (control structure),
 standardDeviation (function), min (function), max (function),
 extents (function), statement (glossary), return (glossary),
-value (glossary), + (operator)
+value (glossary), + (operator), math operation (glossary)

--- a/docs/dictionary/function/variance.lcdoc
+++ b/docs/dictionary/function/variance.lcdoc
@@ -37,10 +37,14 @@ The <variance> <function> was added in version 6.1 to complement the
 <standardDeviation> <function>. The variance is a measure of how widely
 distributed the numbers in the <numbersList> are.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: function (control structure), populationVariance (function),
 averageDeviation (function), variance (function), average (function),
 median (function), populationStandardDeviation (function), sum (function),
-standardDeviation (function), return (glossary)
+standardDeviation (function), return (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/asterisk.lcdoc
+++ b/docs/dictionary/operator/asterisk.lcdoc
@@ -57,13 +57,17 @@ the corresponding <element> of the other <array>.
 If an element of one array is empty, the <*> <operator> treats its
 contents as zero.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 Changes:
 The option to multiply arrays was introduced in version 1.1. In previous
 versions, only single numbers could be used with the * operator.
 
 References: multiply (command), operator (glossary), array (glossary),
 command (glossary), element (glossary), / (operator),
-() (operator), precedence (glossary)
+() (operator), precedence (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/caret.lcdoc
+++ b/docs/dictionary/operator/caret.lcdoc
@@ -44,8 +44,12 @@ If the <exponent> is a fraction, with 1 as the numerator, the <^>
 if the <exponent> is 1/4, the <operation> yields the 4th root of the
 <number>, and so on.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 References: ln1 (function), exp (function), sqrt (function),
-operator (glossary), operation (glossary)
+operator (glossary), operation (glossary), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/div.lcdoc
+++ b/docs/dictionary/operator/div.lcdoc
@@ -58,7 +58,9 @@ trunc(dividend/divisor).
 If dividend can be divided evenly into <divisor>, the <expression>
 dividend div divisor is equal to dividend/divisor.
 
-Attempting to divide by zero causes an execution error.
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 Changes:
 The option to divide arrays was introduced in version 1.1. In previous
@@ -66,7 +68,7 @@ versions, only single numbers could be used with the div operator.
 
 References: operator (glossary), array (glossary), element (glossary),
 return (glossary), expression (glossary), integer (keyword),
-element (keyword), / (operator)
+element (keyword), / (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/mod.lcdoc
+++ b/docs/dictionary/operator/mod.lcdoc
@@ -55,7 +55,9 @@ contents as zero.
 If <number> can be divided evenly into <divisor>, the <expression>
 number mod divisor is zero.
 
-Attempting to divide by zero causes an execution error.
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 Changes:
 The option to divide arrays was introduced in version 1.1. In previous
@@ -63,7 +65,7 @@ versions, only single numbers could be used with the mod operator.
 
 References: operator (glossary), remainder (glossary), array (glossary),
 element (glossary), expression (glossary), element (keyword),
-/ (operator)
+/ (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/plus.lcdoc
+++ b/docs/dictionary/operator/plus.lcdoc
@@ -58,13 +58,17 @@ number of <element(glossary)|elements> and the same dimension, and each
 If an element of one array is empty, the <+> <operator> treats its
 contents as zero.
 
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
 Changes:
 The option to add arrays was introduced in version 1.1. In previous
 versions, only single numbers could be used with the + operator.
 
 References: union (command), sum (function), operator (glossary),
 array (glossary), command (glossary), element (glossary),
-element (keyword), - (operator), () (operator)
+element (keyword), - (operator), () (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/slash.lcdoc
+++ b/docs/dictionary/operator/slash.lcdoc
@@ -63,17 +63,18 @@ number of <element(glossary)|elements> and the same dimension, and each
 If an element of an array is empty, the </> <operator> treats its 
 contents as zero.
 
-> *Important:* Attempting to divide by zero causes an execution error.
-
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
 
 Changes:
 The option to divide arrays was introduced in version 1.1. In previous
 versions, only single numbers could be used with the / operator.
 
 References: divide (command), operator (glossary), array (glossary),
-command (glossary), element (glossary), element (keyword), 
-div (operator), precedence (glossary), 
-mod (operator), * (operator), wrap (operator)
+command (glossary), element (glossary), element (keyword),
+div (operator), precedence (glossary),
+mod (operator), * (operator), wrap (operator), math operation (glossary)
 
 Tags: math
 

--- a/docs/dictionary/operator/wrap.lcdoc
+++ b/docs/dictionary/operator/wrap.lcdoc
@@ -50,5 +50,9 @@ The mathematical formula implemented by the wrap operator is:
     =      -((x-1) mod abs(y)) +1 if(x &lt; 0)
 
 
-References: / (operator)
+If a math operation on finite inputs produces a non-finite output, an
+execution error is thrown. See <math operation|math operations> for more
+information.
+
+References: / (operator), math operation (glossary)
 

--- a/docs/glossary/m/math-operation.lcdoc
+++ b/docs/glossary/m/math-operation.lcdoc
@@ -1,0 +1,31 @@
+Name: math operation
+
+Type: glossary
+
+Description:
+Any of the math operations in command, function or infix form, including
+arithmetic, exponential, logarithmic, trigonometric and statistical
+functions.
+
+A math operation can cause one of three different execution errors to be
+thrown:
+- "numeric: domain error"
+- "numeric: range error (overflow)"
+- "numeric: divide by zero"
+
+A domain error occurs when a math operation, given finite inputs, results
+in not-a-number (NaN) - this is the case when the function is not defined
+for the given inputs, for example `acos(2)`; or the output does not exist
+in the extended real line (`ℝ ∪ {−∞, +∞}`), for example, `sqrt(-1)`.
+
+A range error occurs when a math operation's output overflows given finite
+inputs, i.e. when the result is greater than the maximum value of a 64-bit
+floating point, for example `10^308 * 2`.
+
+A divide by zero error occurs when a math operation causes division by zero
+either directly, for example `1/0` or `0^-1` or as part of its computation,
+for example `10 wrap 0`.
+
+Math operations do not throw execution errors when any of the inputs are
+non-finite, for example neither of `(1^(-inf) + inf) / 2 = inf` or
+`sqrt(-inf) = NaN` causes an execution error.

--- a/docs/notes/bugfix-14316.md
+++ b/docs/notes/bugfix-14316.md
@@ -1,0 +1,1 @@
+# Don't throw error when infinity used innocuously in arithmetic expressions

--- a/docs/notes/feature-math_errors.md
+++ b/docs/notes/feature-math_errors.md
@@ -1,0 +1,27 @@
+# Math operation refactor
+
+The math operations have been refactored to use common code for error
+checking. One of three different execution errors can now be thrown:
+- "numeric: domain error"
+- "numeric: range error (overflow)"
+- "numeric: divide by zero"
+
+The error checking depends solely on the finiteness or otherwise of the
+operation's input(s) and output.
+
+A domain error occurs when a math operation, given finite inputs, results
+in not-a-number (NaN) - this is the case when the function is not defined
+for the given inputs, for example `acos(2)`; or the output does not exist
+in the extended real line (`ℝ ∪ {−∞, +∞}`), for example, `sqrt(-1)`.
+
+A range error occurs when a math operation's output overflows given finite
+inputs, i.e. when the result is greater than the maximum value of a 64-bit
+floating point, for example `10^308 * 2`.
+
+A divide by zero error occurs when a math operation causes division by zero
+either directly, for example `1/0` or `0^-1` or as part of its computation,
+for example `10 wrap 0`.
+
+Math operations now do not throw execution errors when any of the inputs
+are non-finite, for example neither of `(1^(-inf) + inf) / 2 = inf` or
+`sqrt(-inf) = NaN` causes an execution error.

--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -482,7 +482,7 @@ void MCMathEvalDiv(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real6
 
 	r_result = p_left / p_right;
 
-	if (r_result == MCinfinity || MCS_geterrno() != 0)
+	if (MCS_geterrno() != 0)
 	{
 		MCS_seterrno(0);
 		ctxt.LegacyThrow(EE_DIV_RANGE);
@@ -587,7 +587,7 @@ void MCMathEvalMultiply(MCExecContext& ctxt, real64_t p_left, real64_t p_right, 
 	MCS_seterrno(0);
 	r_result = p_left * p_right;
 
-	if (r_result == MCinfinity || MCS_geterrno() != 0)
+	if (MCS_geterrno() != 0)
 	{
 		MCS_seterrno(0);
 		ctxt.LegacyThrow(EE_MULTIPLY_RANGE);
@@ -600,7 +600,7 @@ void MCMathEvalPower(MCExecContext& ctxt, real64_t p_left, real64_t p_right, rea
 	MCS_seterrno(0);
 	r_result = pow(p_left, p_right);
 
-	if (r_result == MCinfinity || MCS_geterrno() != 0)
+	if (MCS_geterrno() != 0)
 	{
 		MCS_seterrno(0);
 		ctxt.LegacyThrow(EE_POW_RANGE);

--- a/engine/src/exec-math.cpp
+++ b/engine/src/exec-math.cpp
@@ -147,289 +147,411 @@ void MCMathEvalCeil(MCExecContext& ctxt, real64_t p_number, real64_t& r_result)
 
 //////////
 
+static bool MCMathCheckBinaryResult(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t p_result)
+{
+    // If the result is finite, we're fine
+    if (MCS_isfinite(p_result))
+    {
+        return true;
+    }
+    
+    // Otherwise, if any of the inputs were not finite, we just allow
+    // whatever result was obtained to flow through
+    if (!MCS_isfinite(p_left) || !MCS_isfinite(p_right))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+static bool MCMathCheckUnaryResult(MCExecContext& ctxt, real64_t p_operand, real64_t p_result)
+{
+    // If the result is finite, we're fine
+    if (MCS_isfinite(p_result))
+    {
+        return true;
+    }
+    
+    // Otherwise, if the input not finite, we just allow whatever result was
+    // obtained to flow through
+    if (!MCS_isfinite(p_operand))
+    {
+        return true;
+    }
+    
+    return false;
+}
+
+static bool MCMathCheckNaryResult(MCExecContext& ctxt, real64_t* p_values, uindex_t p_count, real64_t p_result)
+{
+    // If the result is finite, we're fine
+    if (MCS_isfinite(p_result))
+    {
+        return true;
+    }
+    
+    // Otherwise, if any inputs are not finite, we just allow whatever result was
+    // obtained to flow through
+    for (uindex_t i = 0; i < p_count; i++)
+    {
+        if (!MCS_isfinite(p_values[i]))
+        {
+            return true;
+        }
+    }
+    
+    return false;
+}
+
+static void MCMathThrowFloatingPointException(MCExecContext& ctxt, real64_t p_result)
+{
+    if (MCS_isnan(p_result))
+    {
+        ctxt.LegacyThrow(EE_MATH_DOMAIN);
+    }
+    else
+    {
+        ctxt.LegacyThrow(EE_MATH_RANGE);
+    }
+}
+
+template <real64_t (*Func)(real64_t)>
+void MCMathEvalCheckedUnaryFunction(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
+{
+    real64_t t_result = Func(p_in);
+    if (!MCMathCheckUnaryResult(ctxt, p_in, t_result))
+    {
+        MCMathThrowFloatingPointException(ctxt, t_result);
+        return;
+    }
+    r_result = t_result;
+}
+
+template <real64_t (*Func)(real64_t), bool (*CheckDivideByZero)(real64_t)>
+void MCMathEvalCheckedUnaryFunction(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
+{
+    real64_t t_result = Func(p_in);
+    if (!MCMathCheckUnaryResult(ctxt, p_in, t_result))
+    {
+        if (CheckDivideByZero(p_in))
+        {
+            ctxt.LegacyThrow(EE_MATH_ZERO);
+        }
+        else
+        {
+            MCMathThrowFloatingPointException(ctxt, t_result);
+        }
+    }
+    r_result = t_result;
+}
+
+template <real64_t (*Func)(real64_t, real64_t)>
+void MCMathEvalCheckedBinaryFunction(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+{
+    real64_t t_result = Func(p_left, p_right);
+    if (!MCMathCheckBinaryResult(ctxt, p_left, p_right, t_result))
+    {
+        MCMathThrowFloatingPointException(ctxt, t_result);
+        return;
+    }
+    r_result = t_result;
+}
+
+template <real64_t (*Func)(real64_t, real64_t), bool (*CheckDivideByZero)(real64_t, real64_t)>
+void MCMathEvalCheckedBinaryFunction(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+{
+    real64_t t_result = Func(p_left, p_right);
+    if (!MCMathCheckBinaryResult(ctxt, p_left, p_right, t_result))
+    {
+        if (CheckDivideByZero(p_left, p_right))
+        {
+            ctxt.LegacyThrow(EE_MATH_ZERO);
+        }
+        else
+        {
+            MCMathThrowFloatingPointException(ctxt, t_result);
+        }
+        return;
+    }
+    r_result = t_result;
+}
+
+template <real64_t (*Func)(real64_t*, uindex_t)>
+void MCMathEvalCheckedNaryFunction(MCExecContext& ctxt, real64_t* p_values, uindex_t p_count, real64_t& r_result)
+{
+    if (p_count == 0)
+    {
+        r_result = 0.0;
+        return;
+    }
+    
+    real64_t t_result = Func(p_values, p_count);
+    if (!MCMathCheckNaryResult(ctxt, p_values, p_count, t_result))
+    {
+        MCMathThrowFloatingPointException(ctxt, t_result);
+        return;
+    }
+    r_result = t_result;
+}
+
 void MCMathEvalAcos(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	if (p_in < -1.0 || p_in > 1.0)
-	{
-		ctxt.LegacyThrow(EE_ACOS_DOMAIN);
-		return;
-	}
-
-	r_result = acos(p_in);
+    MCMathEvalCheckedUnaryFunction<acos>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalAsin(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	if (p_in < -1.0 || p_in > 1.0)
-	{
-		ctxt.LegacyThrow(EE_ASIN_DOMAIN);
-		return;
-	}
-
-	r_result = asin(p_in);
+    MCMathEvalCheckedUnaryFunction<asin>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalAtan(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	r_result = atan(p_in);
+	MCMathEvalCheckedUnaryFunction<atan>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalAtan2(MCExecContext& ctxt, real64_t p_y, real64_t p_x, real64_t& r_result)
 {
-	r_result = atan2(p_y, p_x);
+	MCMathEvalCheckedBinaryFunction<atan2>(ctxt, p_y, p_x, r_result);
 }
 
 void MCMathEvalCos(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	r_result = cos(p_in);
+	MCMathEvalCheckedUnaryFunction<cos>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalSin(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	r_result = sin(p_in);
+	MCMathEvalCheckedUnaryFunction<sin>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalTan(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	r_result = tan(p_in);
+	MCMathEvalCheckedUnaryFunction<tan>(ctxt, p_in, r_result);
 }
 
 //////////
 
 void MCMathEvalExp(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = exp(p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_EXP_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<exp>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalExp1(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = exp(p_in) - 1.0;
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_EXP1_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<expm1>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalExp2(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = pow(2.0, p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_EXP2_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<exp2>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalExp10(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = pow(10.0, p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_EXP10_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedBinaryFunction<pow>(ctxt, 10.0, p_in, r_result);
 }
 
 //////////
 
+static bool mc_log_check_divide_by_zero(real64_t p_in)
+{
+    return (p_in == 0);
+}
+
+static bool mc_log1_check_divide_by_zero(real64_t p_in)
+{
+    return (p_in == -1);
+}
+
+static real64_t mc_log2(real64_t p_in)
+{
+#ifdef TARGET_SUBPLATFORM_ANDROID
+    return (log(p_in) / log(2.0));
+#else
+    return log2(p_in);
+#endif
+}
+
+
 void MCMathEvalLn(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = log(p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_LN_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<log,mc_log_check_divide_by_zero>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalLn1(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = log(p_in + 1.0);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_LN1_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<log1p,mc_log1_check_divide_by_zero>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalLog2(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = log(p_in) / log(2.0);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_LOG2_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<mc_log2,mc_log_check_divide_by_zero>(ctxt, p_in, r_result);
 }
 
 void MCMathEvalLog10(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = log10(p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_LOG10_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<log10,mc_log_check_divide_by_zero>(ctxt, p_in, r_result);
 }
 
 //////////
 
 void MCMathEvalSqrt(MCExecContext& ctxt, real64_t p_in, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = sqrt(p_in);
-	if (MCS_geterrno() != 0 || MCS_isnan(r_result))
-	{
-		ctxt.LegacyThrow(EE_SQRT_DOMAIN);
-		MCS_seterrno(0);
-	}
+    MCMathEvalCheckedUnaryFunction<sqrt>(ctxt, p_in, r_result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static real64_t mc_annuity(real64_t p_rate, real64_t p_periods)
+{
+    if (p_rate == 0)
+        return p_periods;
+    return (1.0 - pow(1.0 + p_rate, -p_periods)) / p_rate;
+}
+
+static bool mc_annuity_check_divide_by_zero(real64_t p_rate, real64_t p_periods)
+{
+    return (p_rate == -1 && p_periods > 0);
+}
+
+static real64_t mc_compound(real64_t p_rate, real64_t p_periods)
+{
+    return pow(1.0 + p_rate, p_periods);
+}
+
+static bool mc_compound_check_divide_by_zero(real64_t p_rate, real64_t p_periods)
+{
+    return (p_rate == -1 && p_periods < 0);
+}
+
 void MCMathEvalAnnuity(MCExecContext& ctxt, real64_t p_rate, real64_t p_periods, real64_t& r_result)
 {
-	r_result = (1.0 - pow(1.0 + p_rate, -p_periods)) / p_rate;
+	MCMathEvalCheckedBinaryFunction<mc_annuity,mc_annuity_check_divide_by_zero>(ctxt, p_rate, p_periods, r_result);
 }
 
 void MCMathEvalCompound(MCExecContext& ctxt, real64_t p_rate, real64_t p_periods, real64_t& r_result)
 {
-	r_result = pow(1.0 + p_rate, p_periods);
+	MCMathEvalCheckedBinaryFunction<mc_compound,mc_compound_check_divide_by_zero>(ctxt, p_rate, p_periods, r_result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCMathEvalArithmeticMean(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t mc_arithmetic_mean(real64_t *p_values, uindex_t p_count)
 {
-	if (p_count == 0)
-	{
-		r_result = 0;
-		return;
-	}
+    real64_t t_total = 0.0;
+    for (uindex_t i = 0; i < p_count; i++)
+    {
+        t_total += p_values[i];
+    }
+    return t_total / p_count;
+}
 
-	real64_t t_total = 0.0;
-	for (uindex_t i = 0; i < p_count; i++)
-		t_total += p_values[i];
+static real64_t mc_geometric_mean(real64_t *p_values, uindex_t p_count)
+{
+    real64_t t_result = 1.0;
+    real64_t t_exponent = 1.0 / p_count;
+    for (uindex_t i = 0; i < p_count; i++)
+    {
+        t_result *= pow(p_values[i], t_exponent);
+    }
+    
+    return t_result;
+}
 
-	r_result = t_total / p_count;
+static real64_t mc_harmonic_mean(real64_t *p_values, uindex_t p_count)
+{
+    real64_t t_total = 0.0;
+    for (uindex_t i = 0; i < p_count; i++)
+    {
+        t_total += 1 / p_values[i];
+    }
+    return p_count / t_total;
 }
 
 int cmp_real64_t(const void* a, const void* b)
 {
-	real64_t t_a, t_b;
-	t_a = *(real64_t*)a;
-	t_b = *(real64_t*)b;
-	return (t_a > t_b) - (t_a < t_b);
+    real64_t t_a, t_b;
+    t_a = *(real64_t*)a;
+    t_b = *(real64_t*)b;
+    return (t_a > t_b) - (t_a < t_b);
 }
 
-void MCMathEvalMedian(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t mc_median(real64_t *p_values, uindex_t p_count)
 {
-	if (p_count == 0)
-	{
-		r_result = 0;
-		return;
-	}
-
-	qsort((void*)p_values, p_count, sizeof(real64_t), cmp_real64_t);
-	uindex_t t_index = p_count / 2;
-	if (p_count & 1) // odd
-		r_result = p_values[t_index];
-	else // even, return avg of two nearest-to-centre values
-		r_result = (p_values[t_index - 1] + p_values[t_index]) / 2.0;
+    qsort((void*)p_values, p_count, sizeof(real64_t), cmp_real64_t);
+    uindex_t t_index = p_count / 2;
+    if (p_count & 1) // odd
+        return p_values[t_index];
+    else // even, return avg of two nearest-to-centre values
+        return (p_values[t_index - 1] + p_values[t_index]) / 2.0;
 }
 
-void MCMathEvalMin(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t mc_min(real64_t *p_values, uindex_t p_count)
 {
-	if (p_count == 0)
-	{
-		r_result = 0.0;
-		return;
-	}
-
-	r_result = p_values[0];
-	for (uindex_t i = 1; i < p_count; i++)
-	{
-		if (p_values[i] < r_result)
-			r_result = p_values[i];
-	}
+    real64_t t_result = p_values[0];
+    for (uindex_t i = 1; i < p_count; i++)
+    {
+        if (p_values[i] < t_result)
+            t_result = p_values[i];
+    }
+    return t_result;
 }
 
-void MCMathEvalMax(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t mc_max(real64_t *p_values, uindex_t p_count)
 {
-	if (p_count == 0)
-	{
-		r_result = 0.0;
-		return;
-	}
-
-	r_result = p_values[0];
-	for (uindex_t i = 1; i < p_count; i++)
-	{
-		if (p_values[i] > r_result)
-			r_result = p_values[i];
-	}
+    real64_t t_result = p_values[0];
+    for (uindex_t i = 1; i < p_count; i++)
+    {
+        if (p_values[i] > t_result)
+            t_result = p_values[i];
+    }
+    return t_result;
 }
 
-// IM-2012-08-16: Note: this computes the sample standard deviation rather than
-// the population standard deviation, hence the division by n - 1 rather than n.
-void MCMathEvalSampleStdDev(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t mc_sum(real64_t *p_values, uindex_t p_count)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_SMP_STD_DEV, p_values, p_count, r_result);
+    real64_t t_total = 0.0;
+    for (uindex_t i = 0; i < p_count; i++)
+        t_total += p_values[i];
+    
+    return t_total;
 }
 
-void MCMathEvalSum(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+void MCMathEvalArithmeticMean(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-	real64_t t_total = 0.0;
-	for (uindex_t i = 0; i < p_count; i++)
-		t_total += p_values[i];
-
-	r_result = t_total;
-}
-
-void MCMathEvalAverageDeviation(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
-{
-    MCMathEvaluateStatsFunction(ctxt, F_AVG_DEV, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_arithmetic_mean>(ctxt, p_values, p_count, r_result);
 }
 
 void MCMathEvalGeometricMean(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_GEO_MEAN, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_geometric_mean>(ctxt, p_values, p_count, r_result);
 }
 
 void MCMathEvalHarmonicMean(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_HAR_MEAN, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_harmonic_mean>(ctxt, p_values, p_count, r_result);
 }
 
-void MCMathEvalPopulationStdDev(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+void MCMathEvalMedian(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_POP_STD_DEV, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_median>(ctxt, p_values, p_count, r_result);
 }
 
-void MCMathEvalPopulationVariance(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+void MCMathEvalMin(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_POP_VARIANCE, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_min>(ctxt, p_values, p_count, r_result);
 }
 
-void MCMathEvalSampleVariance(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+void MCMathEvalMax(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
 {
-    MCMathEvaluateStatsFunction(ctxt, F_SMP_VARIANCE, p_values, p_count, r_result);
+    MCMathEvalCheckedNaryFunction<mc_max>(ctxt, p_values, p_count, r_result);
 }
 
+void MCMathEvalSum(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedNaryFunction<mc_sum>(ctxt, p_values, p_count, r_result);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -471,141 +593,90 @@ void MCMathEvalBitwiseXor(MCExecContext& ctxt, uinteger_t p_left, uinteger_t p_r
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCMathEvalDiv(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+static real64_t mc_div(real64_t p_left, real64_t p_right)
 {
-	MCS_seterrno(0);
-	if (p_right == 0.0)
-	{
-		ctxt.LegacyThrow(EE_DIV_ZERO);
-		return;
-	}
-
-	r_result = p_left / p_right;
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_DIV_RANGE);
-		return;
-	}
-
-	if (r_result < 0.0)
-		r_result = ceil(r_result);
-	else
-		r_result = floor(r_result);
+    real64_t t_result = p_left / p_right;
+    if (t_result < 0.0)
+        return ceil(t_result);
+    else
+        return floor(t_result);
 }
 
-void MCMathEvalSubtract(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+static bool mc_mod_check_divide_by_zero(real64_t p_left, real64_t p_right)
 {
-	MCS_seterrno(0);
-	r_result = p_left - p_right;
+    return (p_right == 0);
+}
 
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_MINUS_RANGE);
-		return;
-	}
+static bool mc_over_check_divide_by_zero(real64_t p_left, real64_t p_right)
+{
+    return (p_right == 0);
+}
+
+void MCMathEvalDiv(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+{
+    MCMathEvalCheckedBinaryFunction<mc_div,mc_over_check_divide_by_zero>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalMod(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	if (p_right == 0.0)
-	{
-		ctxt.LegacyThrow(EE_MOD_ZERO);
-		return;
-	}
-
-	MCS_seterrno(0);
-	r_result = p_left / p_right;
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_MOD_RANGE);
-		return;
-	}
-
-	r_result = fmod(p_left, p_right);
+    MCMathEvalCheckedBinaryFunction<fmod,mc_mod_check_divide_by_zero>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalWrap(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	if (p_right == 0.0)
-	{
-		ctxt.LegacyThrow(EE_WRAP_ZERO);
-		return;
-	}
+    MCMathEvalCheckedBinaryFunction<MCU_fwrap,mc_mod_check_divide_by_zero>(ctxt, p_left, p_right, r_result);
+}
 
-	MCS_seterrno(0);
-	r_result = p_left / p_right;
+////////////////////////////////////////////////////////////////////////////////
 
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_WRAP_RANGE);
-		return;
-	}
+static real64_t mc_minus(real64_t p_left, real64_t p_right)
+{
+    return p_left - p_right;
+}
 
-	r_result = MCU_fwrap(p_left, p_right);
+static real64_t mc_over(real64_t p_left, real64_t p_right)
+{
+    return p_left / p_right;
+}
+
+static real64_t mc_plus(real64_t p_left, real64_t p_right)
+{
+    return p_left + p_right;
+}
+
+static real64_t mc_multiply(real64_t p_left, real64_t p_right)
+{
+    return p_left * p_right;
+}
+
+static bool mc_pow_check_divide_by_zero(real64_t p_left, real64_t p_right)
+{
+    return (p_left == 0 && p_right < 0);
+}
+
+void MCMathEvalSubtract(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
+{
+    MCMathEvalCheckedBinaryFunction<mc_minus>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalOver(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	if (p_right == 0.0)
-	{
-		ctxt.LegacyThrow(EE_OVER_ZERO);
-		return;
-	}
-
-	MCS_seterrno(0);
-	r_result = p_left / p_right;
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_OVER_RANGE);
-		return;
-	}
+    MCMathEvalCheckedBinaryFunction<mc_over,mc_over_check_divide_by_zero>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalAdd(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = p_left + p_right;
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_PLUS_RANGE);
-		return;
-	}
+    MCMathEvalCheckedBinaryFunction<mc_plus>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalMultiply(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = p_left * p_right;
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_MULTIPLY_RANGE);
-		return;
-	}
+    MCMathEvalCheckedBinaryFunction<mc_multiply>(ctxt, p_left, p_right, r_result);
 }
 
 void MCMathEvalPower(MCExecContext& ctxt, real64_t p_left, real64_t p_right, real64_t& r_result)
 {
-	MCS_seterrno(0);
-	r_result = pow(p_left, p_right);
-
-	if (MCS_geterrno() != 0)
-	{
-		MCS_seterrno(0);
-		ctxt.LegacyThrow(EE_POW_RANGE);
-		return;
-	}
+    MCMathEvalCheckedBinaryFunction<pow, mc_pow_check_divide_by_zero>(ctxt, p_left, p_right, r_result);
 }
 
 //////////
@@ -899,52 +970,110 @@ void MCMathSetRandomSeed(MCExecContext& ctxt, integer_t p_value)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCMathEvaluateStatsFunction(MCExecContext& ctxt, Functions p_func, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+static real64_t MCMathEvaluateStatsFunction(Functions p_func, real64_t *p_values, uindex_t p_count)
 {
-	r_result = 0.0;
-	if (p_count == 0)
-	{
-		return;
-	}
+    if ((p_func == F_SMP_STD_DEV || p_func == F_SMP_VARIANCE)
+        && p_count == 1)
+    {
+        return 0;
+    }
     
-    real64_t t_mean;
-	MCMathEvalArithmeticMean(ctxt, p_values, p_count, t_mean);
-	if (ctxt.HasError())
-		return;
+    real64_t t_mean = mc_arithmetic_mean(p_values, p_count);
     
-    // TODO - move action of MCU_dofunc here
     real64_t t_result = 0.0;
     for (uindex_t i = 0; i < p_count; i++)
-        MCU_dofunc(p_func, i, t_result, p_values[i], p_func == F_GEO_MEAN ? p_count : t_mean, nil);
+    {
+        real64_t t_value = p_values[i] - t_mean;
+        switch (p_func)
+        {
+                // JS-2013-06-19: [[ StatsFunctions ]] Support for 'averageDeviation'
+            case F_AVG_DEV:
+                // IM-2014-02-28: [[ Bug 11778 ]] Make sure we're using the floating-point version of 'abs'
+                t_result += fabs(t_value);
+                break;
+                // JS-2013-06-19: [[ StatsFunctions ]] Support for 'populationStdDev', 'populationVariance', 'sampleStdDev' (was stdDev), 'sampleVariance'
+            case F_POP_STD_DEV:
+            case F_POP_VARIANCE:
+            case F_SMP_STD_DEV:
+            case F_SMP_VARIANCE:
+                t_result += t_value * t_value;
+                break;
+            default:
+                MCUnreachableReturn(0.0);
+                break;
+        }
+    }
     
     switch (p_func)
-	{
+    {
             // JS-2013-06-19: [[ StatsFunctions ]] Support for averageDeviation
-		case F_AVG_DEV:
-			t_result /= p_count;
-			break;
-            // JS-2013-06-19: [[ StatsFunctions ]] Support for harmonicMean
-		case F_HAR_MEAN:
-			t_result = p_count/t_result;
-			break;
-            // JS-2013-06-19: [[ StatsFunctions ]] Support for populationStandardDeviation
-		case F_POP_STD_DEV:
-			t_result = sqrt(t_result/p_count);
-			break;
-            // JS-2013-06-19: [[ StatsFunctions ]] Support for populationVariance
-		case F_POP_VARIANCE:
+        case F_AVG_DEV:
             t_result /= p_count;
-			break;
+            break;
+            // JS-2013-06-19: [[ StatsFunctions ]] Support for populationStandardDeviation
+        case F_POP_STD_DEV:
+            t_result = sqrt(t_result/p_count);
+            break;
+            // JS-2013-06-19: [[ StatsFunctions ]] Support for populationVariance
+        case F_POP_VARIANCE:
+            t_result /= p_count;
+            break;
             // JS-2013-06-19: [[ StatsFunctions ]] Support for sampleStandardDeviation (was stdDev)
-		case F_SMP_STD_DEV:
-			t_result = sqrt(t_result/(p_count - 1));
-			break;
+        case F_SMP_STD_DEV:
+            t_result = sqrt(t_result/(p_count - 1));
+            break;
             // JS-2013-06-19: [[ StatsFunctions ]] Support for sampleVariance
-		case F_SMP_VARIANCE:
-			t_result /= p_count - 1;
-			break;
-		default:
-			break;
+        case F_SMP_VARIANCE:
+            t_result /= p_count - 1;
+            break;
+        default:
+            MCUnreachableReturn(0.0);
+            break;
+    }
+    return t_result;
+}
+
+template <Functions Function>
+void MCMathEvalCheckedStatsFunction(MCExecContext& ctxt, real64_t* p_values, uindex_t p_count, real64_t& r_result)
+{
+    if (p_count == 0)
+    {
+        r_result = 0.0;
+        return;
+    }
+    
+    real64_t t_result = MCMathEvaluateStatsFunction(Function, p_values, p_count);
+    if (!MCMathCheckNaryResult(ctxt, p_values, p_count, t_result))
+    {
+        MCMathThrowFloatingPointException(ctxt, t_result);
+        return;
     }
     r_result = t_result;
+}
+
+// IM-2012-08-16: Note: this computes the sample standard deviation rather than
+// the population standard deviation, hence the division by n - 1 rather than n.
+void MCMathEvalSampleStdDev(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedStatsFunction<F_SMP_STD_DEV>(ctxt, p_values, p_count, r_result);
+}
+
+void MCMathEvalAverageDeviation(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedStatsFunction<F_AVG_DEV>(ctxt, p_values, p_count, r_result);
+}
+
+void MCMathEvalPopulationStdDev(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedStatsFunction<F_POP_STD_DEV>(ctxt, p_values, p_count, r_result);
+}
+
+void MCMathEvalPopulationVariance(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedStatsFunction<F_POP_VARIANCE>(ctxt, p_values, p_count, r_result);
+}
+
+void MCMathEvalSampleVariance(MCExecContext& ctxt, real64_t *p_values, uindex_t p_count, real64_t& r_result)
+{
+    MCMathEvalCheckedStatsFunction<F_SMP_VARIANCE>(ctxt, p_values, p_count, r_result);
 }

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1941,8 +1941,7 @@ void MCMathEvalIsNotANumber(MCExecContext& ctxt, MCValueRef p_value, bool& r_res
 
 void MCMathGetRandomSeed(MCExecContext& ctxt, integer_t& r_value);
 void MCMathSetRandomSeed(MCExecContext& ctxt, integer_t p_value);
-void MCMathEvaluateStatsFunction(MCExecContext& ctxt, Functions p_func, real64_t *p_values, uindex_t p_count, real64_t& r_result);
-                                 
+                            
 #define MCMathExecAddNumberToNumber(ctxt, a, b, r) MCMathEvalAdd(ctxt, a, b, r)
 #define MCMathExecAddNumberToArray(ctxt, a, b, r) MCMathEvalAddNumberToArray(ctxt, b, a, r)
 #define MCMathExecAddArrayToArray(ctxt, a, b, r) MCMathEvalAddArrayToArray(ctxt, a, b, r)

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -47,8 +47,8 @@ enum Exec_errors
 	// {EE-0006} acos: error in source expression
 	EE_ACOS_BADSOURCE,
 	
-	// {EE-0007} acos: domain error
-	EE_ACOS_DOMAIN,
+	// {EE-0007} numeric: domain error
+	EE_MATH_DOMAIN,
 	
 	// {EE-0008} add: error in matrix operation
 	EE_ADD_BADARRAY,
@@ -107,8 +107,8 @@ enum Exec_errors
 	// {EE-0026} asin: error in source expression
 	EE_ASIN_BADSOURCE,
 	
-	// {EE-0027} asin: domain error
-	EE_ASIN_DOMAIN,
+	// {EE-0027} UNUSED
+	EE_UNUSED_0027,
 	
 	// {EE-0028} ask: error in question expression
 	EE_ASK_BADQUESTION,
@@ -125,14 +125,14 @@ enum Exec_errors
 	// {EE-0032} atan2: error in second expression
 	EE_ATAN2_BADS2,
 	
-	// {EE-0033} atan2: domain error
-	EE_ATAN2_DOMAIN,
+	// {EE-0033} UNUSED
+	EE_UNUSED_0033,
 	
 	// {EE-0034} atan: error in source expression
 	EE_ATAN_BADSOURCE,
 	
-	// {EE-0035} atan: domain error
-	EE_ATAN_DOMAIN,
+	// {EE-0035} UNUSED
+	EE_UNUSED_0035,
 	
 	// {EE-0036} average: error in source expression
 	EE_AVERAGE_BADSOURCE,
@@ -416,8 +416,8 @@ enum Exec_errors
 	// {EE-0129} cos: error in source expression
 	EE_COS_BADSOURCE,
 	
-	// {EE-0130} cos: domain error
-	EE_COS_DOMAIN,
+	// {EE-0130} UNUSED
+	EE_UNUSED_0130,
 	
 	// {EE-0131} create: error in bad parent or background expression
 	EE_CREATE_BADBGORCARD,
@@ -482,11 +482,11 @@ enum Exec_errors
 	// {EE-0151} divide: can't divide scalar by array
 	EE_DIVIDE_MISMATCH,
 	
-	// {EE-0152} divide: range error (overflow)
-	EE_DIVIDE_RANGE,
+	// {EE-0152} numeric: range error (overflow)
+	EE_MATH_RANGE,
 	
-	// {EE-0153} divide: divide by zero
-	EE_DIVIDE_ZERO,
+	// {EE-0153} numeric: divide by zero
+	EE_MATH_ZERO,
 	
 	// {EE-0154} Operators div: error in matrix operation
 	EE_DIV_BADARRAY,
@@ -500,11 +500,11 @@ enum Exec_errors
 	// {EE-0157} Operators div: can't divide scalar by matrix
 	EE_DIV_MISMATCH,
 	
-	// {EE-0158} Operators div: range error (overflow)
-	EE_DIV_RANGE,
+	// {EE-0158} UNUSED
+	EE_UNUSED_0158,
 	
-	// {EE-0159} Operators div: divide by zero
-	EE_DIV_ZERO,
+	// {EE-0159} UNUSED
+	EE_UNUSED_0159,
 	
 	// {EE-0160} do: aborted
 	EE_DO_ABORT,
@@ -575,20 +575,20 @@ enum Exec_errors
 	// {EE-0182} exp10: error in source expression
 	EE_EXP10_BADSOURCE,
 	
-	// {EE-0183} exp10: domain error
-	EE_EXP10_DOMAIN,
+	// {EE-0183} UNUSED
+	EE_UNUSED_0183,
 	
 	// {EE-0184} exp1: error in source expression
 	EE_EXP1_BADSOURCE,
 	
-	// {EE-0185} exp1: domain error
-	EE_EXP1_DOMAIN,
+	// {EE-0185} UNUSED
+	EE_UNUSED_0185,
 	
 	// {EE-0186} exp2: error in source expression
 	EE_EXP2_BADSOURCE,
 	
-	// {EE-0187} exp2: domain error
-	EE_EXP2_DOMAIN,
+	// {EE-0187} UNUSED
+	EE_UNUSED_0187,
 	
 	// {EE-0188} export: error in file (or mask file) name expression
 	EE_EXPORT_BADNAME,
@@ -614,8 +614,8 @@ enum Exec_errors
 	// {EE-0195} exp: error in source expression
 	EE_EXP_BADSOURCE,
 	
-	// {EE-0196} exp: domain error
-	EE_EXP_DOMAIN,
+	// {EE-0196} UNUSED
+	EE_UNUSED_0196,
 	
 	// {EE-0197} extents: error in variable expression
 	EE_EXTENTS_BADSOURCE,
@@ -881,14 +881,14 @@ enum Exec_errors
 	// {EE-0284} ln1: error in source expression
 	EE_LN1_BADSOURCE,
 	
-	// {EE-0285} ln1: domain error
-	EE_LN1_DOMAIN,
+	// {EE-0285} UNUSED
+	EE_UNUSED_0285,
 	
 	// {EE-0286} ln: error in source expression
 	EE_LN_BADSOURCE,
 	
-	// {EE-0287} ln: domain error
-	EE_LN_DOMAIN,
+	// {EE-0287} UNUSED
+	EE_UNUSED_0287,
 	
 	// {EE-0288} load: error in url expression
 	EE_LOAD_BADURLEXP,
@@ -902,14 +902,14 @@ enum Exec_errors
 	// {EE-0291} log10: error in source expression
 	EE_LOG10_BADSOURCE,
 	
-	// {EE-0292} log10: domain error
-	EE_LOG10_DOMAIN,
+	// {EE-0292} UNUSED
+	EE_UNUSED_0292,
 	
 	// {EE-0293} log2: error in source expression
 	EE_LOG2_BADSOURCE,
 	
-	// {EE-0294} log2: domain error
-	EE_LOG2_DOMAIN,
+	// {EE-0294} UNUSED
+	EE_UNUSED_0294,
 	
 	// {EE-0295} longFilePath: error in file expression
 	EE_LONGFILEPATH_BADSOURCE,
@@ -971,8 +971,8 @@ enum Exec_errors
 	// {EE-0314} Operators -: range error (overflow) in array operation
 	EE_MINUS_MISMATCH,
 	
-	// {EE-0315} Operators -: range error (overflow)
-	EE_MINUS_RANGE,
+	// {EE-0315} UNUSED
+	EE_UNUSED_0315,
 	
 	// {EE-0316} min: error in source expression
 	EE_MIN_BADSOURCE,
@@ -989,11 +989,11 @@ enum Exec_errors
 	// {EE-0320} Operators mod: can't divide scalar by matrix
 	EE_MOD_MISMATCH,
 	
-	// {EE-0321} Operators mod: range error (overflow)
-	EE_MOD_RANGE,
+	// {EE-0321} UNUSED
+	EE_UNUSED_0321,
 	
-	// {EE-0322} Operators mod: divide by zero
-	EE_MOD_ZERO,
+	// {EE-0322} UNUSED
+	EE_UNUSED_0322,
 	
 	// {EE-0323} mouse: error in source expression
 	EE_MOUSE_BADSOURCE,
@@ -1037,8 +1037,8 @@ enum Exec_errors
 	// {EE-0336} multiply: can't multiply scalar by array
 	EE_MULTIPLY_MISMATCH,
 	
-	// {EE-0337} multiply: range error (overflow)
-	EE_MULTIPLY_RANGE,
+	// {EE-0337} UNUSED
+	EE_UNUSED_0337,
 	
 	// {EE-0338} Operators <>: error in operands
 	EE_NOTEQUAL_OPS,
@@ -1160,11 +1160,11 @@ enum Exec_errors
 	// {EE-0377} Operators /: can't divide scalar by matrix
 	EE_OVER_MISMATCH,
 	
-	// {EE-0378} Operators /: range error (overflow)
-	EE_OVER_RANGE,
+	// {EE-0378} UNUSED
+	EE_UNUSED_0378,
 	
-	// {EE-0379} Operators /: divide by zero
-	EE_OVER_ZERO,
+	// {EE-0379} UNUSED
+	EE_UNUSED_0379,
 	
 	// {EE-0380} param: error in expression
 	EE_PARAM_BADEXP,
@@ -1214,8 +1214,8 @@ enum Exec_errors
 	// {EE-0395} Operators +: error in right operand
 	EE_PLUS_BADRIGHT,
 	
-	// {EE-0396} Operators +: range error (overflow)
-	EE_PLUS_RANGE,
+	// {EE-0396} UNUSED
+	EE_UNUSED_0396,
 	
 	// {EE-0397} pop: can't set destination
 	EE_POP_CANTSET,
@@ -1232,8 +1232,8 @@ enum Exec_errors
 	// {EE-0401} pow: error in right operand
 	EE_POW_BADRIGHT,
 	
-	// {EE-0402} pow: range error (overflow)
-	EE_POW_RANGE,
+	// {EE-0402} UNUSED
+	EE_UNUSED_0402,
 	
 	// {EE-0403} print: can't get 'from' or 'to' coordinates
 	EE_PRINT_CANTGETCOORD,
@@ -1673,8 +1673,8 @@ enum Exec_errors
 	// {EE-0548} sin: error in source expression
 	EE_SIN_BADSOURCE,
 	
-	// {EE-0549} sin: domain error
-	EE_SIN_DOMAIN,
+	// {EE-0549} UNUSED
+	EE_UNUSED_0549,
 	
 	// {EE-0550} sort: can't find object to sort
 	EE_SORT_BADTARGET,
@@ -1691,8 +1691,8 @@ enum Exec_errors
 	// {EE-0554} sqrt: error in source expression
 	EE_SQRT_BADSOURCE,
 	
-	// {EE-0555} sqrt: domain error
-	EE_SQRT_DOMAIN,
+	// {EE-0555} UNUSED
+	EE_UNUSED_0555,
 	
 	// {EE-0556} Stack: bad decoration
 	EE_STACK_BADDECORATION,
@@ -1793,8 +1793,8 @@ enum Exec_errors
 	// {EE-0588} textHeightSum: can't find object
 	EE_TAN_BADSOURCE,
 	
-	// {EE-0589} tan: error in source expression
-	EE_TAN_DOMAIN,
+	// {EE-0589} UNUSED
+	EE_UNUSED_0589,
 	
 	// {EE-0590} tan: domain error
 	EE_TEXT_HEIGHT_SUM_NOOBJECT,
@@ -1814,8 +1814,8 @@ enum Exec_errors
 	// {EE-0595} Operators *: error in right operand
 	EE_TIMES_BADRIGHT,
 	
-	// {EE-0596} Operators *: range error (overflow)
-	EE_TIMES_RANGE,
+	// {EE-0596} UNUSED
+	EE_UNUSED_0596,
 	
 	// {EE-0597} toLower: error in source expression
 	EE_TOLOWER_BADSOURCE,
@@ -1964,11 +1964,11 @@ enum Exec_errors
 	// {EE-0645} wrap: type mismatch
 	EE_WRAP_MISMATCH,
 	
-	// {EE-0646} wrap: overflow
-	EE_WRAP_RANGE,
+	// {EE-0646} UNUSED
+	EE_UNUSED_0646,
 	
-	// {EE-0647} wrap: division by zero
-	EE_WRAP_ZERO,
+	// {EE-0647} UNUSED
+	EE_UNUSED_0647,
 	
 	// {EE-0648} begins/ends with: illegal type for right operand
 	EE_BEGINSENDS_BADRIGHT,

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -164,6 +164,7 @@ extern bool MCS_changeprocesstype(bool to_foreground);
 
 extern bool MCS_isinteractiveconsole(int);
 extern bool MCS_isnan(double p_value);
+extern bool MCS_isfinite(double p_number);
 
 extern bool MCS_mcisendstring(MCStringRef p_command, MCStringRef& r_result, bool& r_error);
 

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -1822,11 +1822,12 @@ bool MCS_isinteractiveconsole(int p_fd)
 
 bool MCS_isnan(double p_number)
 {
-#ifdef _WIN32
-    return (_isnan(p_number) != 0);
-#else
-    return (isnan(p_number) != 0);
-#endif
+    return isnan(p_number);
+}
+
+bool MCS_isfinite(double p_number)
+{
+    return isfinite(p_number);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -2185,61 +2185,6 @@ void MCU_cleaninserted()
 		;
 }
 
-void MCU_dofunc(Functions func, uint4 nparams, real8 &n,
-                real8 tn, real8 oldn, MCSortnode *titems)
-{
-	real8 tp;
-	switch (func)
-	{
-    // JS-2013-06-19: [[ StatsFunctions ]] Support for 'arithmeticMean' (was average)
-    case F_ARI_MEAN:
-        n += tn;
-        break;
-	// JS-2013-06-19: [[ StatsFunctions ]] Support for 'averageDeviation'
-	case F_AVG_DEV:
-		tn = tn - oldn;
-		// IM-2014-02-28: [[ Bug 11778 ]] Make sure we're using the floating-point version of 'abs'
-		n += fabs(tn);
-		break;
-	// JS-2013-06-19: [[ StatsFunctions ]] Support for 'geometricMean'
-	case F_GEO_MEAN:
-		if (nparams == 0)
-			n = 1;
-		tp = 1 / oldn;
-		n *= pow(tn, tp);
-		break;
-	// JS-2013-06-19: [[ StatsFunctions ]] Support for 'harmonicMean'
-	case F_HAR_MEAN:
-		n += 1/tn;
-		break;
-	case F_MAX:
-		if (nparams++ == 0 || tn > n)
-			n = tn;
-		break;
-	case F_MIN:
-		if (nparams++ == 0 || tn < n)
-			n = tn;
-		break;
-	case F_SUM:
-		n += tn;
-		break;
-	case F_MEDIAN:
-        /* UNCHECKED */ MCNumberCreateWithReal(tn, titems[nparams].nvalue);
-		break;
-	// JS-2013-06-19: [[ StatsFunctions ]] Support for 'populationStdDev', 'populationVariance', 'sampleStdDev' (was stdDev), 'sampleVariance'
-	case F_POP_STD_DEV:
-	case F_POP_VARIANCE:
-	case F_SMP_STD_DEV:
-	case F_SMP_VARIANCE:
-		tn = tn - oldn;
-		n += tn * tn;
-		break;
-	case  F_UNDEFINED:
-	default:
-		break;
-	}
-}
-
 // MW-2013-06-25: [[ Bug 10983 ]] This function returns true if the given string
 //   could be a url. It checks for strings of the form:
 //     <letter> (<letter> | <digit> | '+' | '.' | '-')+ ':' <char>+

--- a/engine/src/util.h
+++ b/engine/src/util.h
@@ -187,8 +187,7 @@ extern Boolean MCU_freeinserted(MCObjectList *&l);
 extern void MCU_cleaninserted();
 //extern void MCU_get_color(MCExecPoint &ep, const char *name, MCColor &c);
 extern void MCU_geturl(MCExecContext& ctxt, MCStringRef p_target, MCValueRef &r_output);
-extern void MCU_dofunc(Functions func, uint4 nparams, real8 &n,
-	                       real8 tn, real8 oldn, MCSortnode *titems);
+
 // MW-2013-07-01: [[ Bug 10975 ]] This method returns true if the given string could be a url
 //   (as used by MCU_geturl, to determine whether to try and fetch via libUrl).
 extern bool MCU_couldbeurl(MCStringRef potential_url);

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -222,6 +222,12 @@ function TestBuildErrorMap pErrorFile, pErrorPrefix, pZerothError
          if tCode is empty then 
             throw "no error code found for" && tError
          end if
+         if tError begins with (pErrorPrefix & "_UNUSED_") then
+            if tError is not (pErrorPrefix & "_UNUSED_" & tCode) then
+               throw "unused error name" && tError && "does not match code" \
+                     && tCode && "change to" && pErrorPrefix & "_UNUSED_" & tCode
+            end if
+         end if
          if tErrorMap[tCode] is not empty then
             throw "duplicate error code" && tCode && "found for" && tError && \
                "change to" && the number of elements of tErrorMap + 1
@@ -244,19 +250,19 @@ private command __TestEnsureExecErrorMap
    if sExecErrorMap is not empty then
       exit __TestEnsureExecErrorMap
    end if
-   	
+
    put TestBuildErrorMap("executionerrors.h", "EE", "UNDEFINED") \
    	   into sExecErrorMap
 end __TestEnsureExecErrorMap
 
-private function __TestErrorMatches pError, pCode
+function TestErrorMatches pError, pCode
 	__TestEnsureExecErrorMap
-	
+
 	local tErrorNumber
 	put format("%04d", item 1 of line 1 of pError) into tErrorNumber
-	
+
 	return sExecErrorMap[tErrorNumber] is pCode
-end __TestErrorMatches
+end TestErrorMatches
 
 ----------------------------------------------------------------
 -- Unit test library functions
@@ -316,7 +322,7 @@ function _TestHandlerThrows pHandler, pTarget, pErrorCodes, pParam
    local tSuccess
    put true into tSuccess
    repeat for each item tErrorCode in pErrorCodes
-      put tSuccess and __TestErrorMatches(tError, tErrorCode) into tSuccess
+      put tSuccess and TestErrorMatches(tError, tErrorCode) into tSuccess
       delete the first line of tError
    end repeat
    return tSuccess
@@ -351,7 +357,7 @@ end ErrorDialog
 
 on TestAssertErrorDialog pDescription, pErrorCode
 	wait for messages
-	TestAssert pDescription, __TestErrorMatches(sError, pErrorCode)
+	TestAssert pDescription, TestErrorMatches(sError, pErrorCode)
 	put empty into sError
 end TestAssertErrorDialog
 

--- a/tests/lcs/core/math/arithmetic-commands.livecodescript
+++ b/tests/lcs/core/math/arithmetic-commands.livecodescript
@@ -19,11 +19,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 ----------
 
 private function MapError pError, pSrcErr, pDstErr
-   if item 1 of pError is pSrcErr then
+   if TestErrorMatches(pError, pSrcErr) then
       return "src"
    end if
 
-   if item 1 of pError is pDstErr then
+   if TestErrorMatches(pError, pDstErr) then
       return "dst"
    end if
 
@@ -32,8 +32,8 @@ end MapError
 
 ----------
 
-constant kAddSrcError = 10
-constant kAddDstError = 9
+constant kAddSrcError = "EE_ADD_BADSOURCE"
+constant kAddDstError = "EE_ADD_BADDEST"
 
 private function DoAdd pSrc, pDst
    try
@@ -53,8 +53,8 @@ end TestAdd
 
 ----------
 
-constant kSubtractSrcError = 579
-constant kSubtractDstError = 578
+constant kSubtractSrcError = "EE_SUBTRACT_BADSOURCE"
+constant kSubtractDstError = "EE_SUBTRACT_BADDEST"
 
 private function DoSubtract pSrc, pDst
    try
@@ -74,8 +74,8 @@ end TestSubtract
 
 ----------
 
-constant kMultiplySrcError = 334
-constant kMultiplyDstError = 333
+constant kMultiplySrcError = "EE_MULTIPLY_BADSOURCE"
+constant kMultiplyDstError = "EE_MULTIPLY_BADDEST"
 
 private function DoMultiply pSrc, pDst
    try
@@ -95,8 +95,8 @@ end TestMultiply
 
 ----------
 
-constant kDivideSrcError = 149
-constant kDivideDstError = 148
+constant kDivideSrcError = "EE_DIVIDE_BADSOURCE"
+constant kDivideDstError = "EE_DIVIDE_BADDEST"
 
 private function DoDivide pSrc, pDst
    try

--- a/tests/lcs/core/math/errors.livecodescript
+++ b/tests/lcs/core/math/errors.livecodescript
@@ -1,0 +1,346 @@
+script "CoreMathErrors"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+command DoSin pParam
+   get sin(pParam)
+end DoSin
+
+command DoCos pParam
+   get cos(pParam)
+end DoCos
+
+command DoTan pParam
+   get tan(pParam)
+end DoTan
+
+command DoAcos pParam
+   get acos(pParam)
+end DoAcos
+
+on TestAcosError
+   TestAssertThrow "acos throws on invalid domain", "DoAcos", \
+         the long id of me, "EE_MATH_DOMAIN", 2
+end TestAcosError
+
+command DoAsin pParam
+   get asin(pParam)
+end DoAsin
+
+on TestAsinError
+   TestAssertThrow "asin throws on invalid domain", "DoAsin", \
+         the long id of me, "EE_MATH_DOMAIN", 2
+end TestAsinError
+
+command DoAtan pParam
+   get atan(pParam)
+end DoAtan
+
+command DoExp pParam
+   get exp(pParam)
+end DoExp
+
+command DoExp1 pParam
+   get exp1(pParam)
+end DoExp1
+
+command DoExp2 pParam
+   get exp2(pParam)
+end DoExp2
+
+command DoExp10 pParam
+   get exp10(pParam)
+end DoExp10
+
+on TestExpErrors
+   local tParam
+   put GetVeryLargeInteger() into tParam
+   repeat for each item tItem in "exp,exp1,exp2,exp10"
+      TestAssertThrow tItem && "overflow throws", "Do" & tItem, \
+            the long id of me, "EE_MATH_RANGE", tParam
+   end repeat
+end TestExpErrors
+
+command DoLn pParam
+   get ln(pParam)
+end DoLn
+
+on TestLnError
+   TestAssertThrow "ln throws with negative input", "DoLn", \
+         the long id of me, "EE_MATH_DOMAIN", -1
+
+   TestAssertThrow "ln throws with -inf result", "DoLn", \
+         the long id of me, "EE_MATH_ZERO", 0
+end TestLnError
+
+command DoLn1 pParam
+   get ln1(pParam)
+end DoLn1
+
+on TestLn1Error
+   TestAssertThrow "ln1 throws with input < -1", "DoLn1", \
+         the long id of me, "EE_MATH_DOMAIN", -2
+
+   TestAssertThrow "ln1 throws with -inf result", "DoLn1", \
+         the long id of me, "EE_MATH_ZERO", -1
+end TestLn1Error
+
+command DoLog2 pParam
+   get log2(pParam)
+end DoLog2
+
+on TestLog2Error
+   TestAssertThrow "log2 throws with negative input", "DoLog2", \
+         the long id of me, "EE_MATH_DOMAIN", -1
+
+   TestAssertThrow "log2 throws with -inf result", "DoLog2", \
+         the long id of me, "EE_MATH_ZERO", 0
+end TestLog2Error
+
+command DoLog10 pParam
+   get log10(pParam)
+end DoLog10
+
+on TestLog10Error
+   TestAssertThrow "log10 throws with negative input", "DoLog10", \
+         the long id of me, "EE_MATH_DOMAIN", -1
+
+   TestAssertThrow "log10 throws with -inf result", "DoLog10", \
+         the long id of me, "EE_MATH_ZERO", 0
+end TestLog10Error
+
+command DoSqrt pParam
+   get sqrt(pParam)
+end DoSqrt
+
+on TestSqrtError
+   TestAssertThrow "sqrt throws with negative input", "DoSqrt", \
+         the long id of me, "EE_MATH_DOMAIN", -1
+end TestSqrtError
+
+command DoAtan2 pParam
+   get atan2(pParam["left"], pParam["right"])
+end DoAtan2
+
+command DoDiv pParam
+   get pParam["left"] div pParam["right"]
+end DoDiv
+
+on TestDivError
+   local tParam
+   put 10 into tParam["left"]
+   put 0 into tParam["right"]
+   TestAssertThrow "div throws with 0 denominator", "DoDiv", \
+         the long id of me, "EE_MATH_ZERO", tParam
+end TestDivError
+
+command DoMod pParam
+   get pParam["left"] mod pParam["right"]
+end DoMod
+
+on TestModError
+   local tParam
+   put 10 into tParam["left"]
+   put 0 into tParam["right"]
+   TestAssertThrow "mod 0 throws", "DoMod", \
+         the long id of me, "EE_MATH_ZERO", tParam
+end TestModError
+
+command DoWrap pParam
+   get pParam["left"] wrap pParam["right"]
+end DoWrap
+
+on TestWrapError
+   local tParam
+   put 10 into tParam["left"]
+   put 0 into tParam["right"]
+   TestAssertThrow "wrap 0 throws", "DoWrap", \
+         the long id of me, "EE_MATH_ZERO", tParam
+end TestWrapError
+
+// Returns an integer large enough to cause overflow when added to itself
+private function GetVeryLargeInteger pNegative
+   if pNegative then
+      return -(10^308)
+   end if
+   return 10^308
+end GetVeryLargeInteger
+
+command DoPlus pParam
+   get pParam["left"] + pParam["right"]
+end DoPlus
+
+on TestPlusError
+   local tParam
+   put GetVeryLargeInteger() into tParam["left"]
+   put GetVeryLargeInteger() into tParam["right"]
+   TestAssertThrow "plus overflow throws", "DoPlus", \
+         the long id of me, "EE_MATH_RANGE", tParam
+end TestPlusError
+
+command DoMultiply pParam
+   get pParam["left"] * pParam["right"]
+end DoMultiply
+
+on TestMultiplyError
+   local tParam
+   put GetVeryLargeInteger() into tParam["left"]
+   put 10 into tParam["right"]
+   TestAssertThrow "multiply overflow throws", "DoMultiply", \
+         the long id of me, "EE_MATH_RANGE", tParam
+end TestMultiplyError
+
+command DoMinus pParam
+   get pParam["left"] - pParam["right"]
+end DoMinus
+
+on TestMinusError
+   local tParam
+   put GetVeryLargeInteger(true) into tParam["left"]
+   put GetVeryLargeInteger() into tParam["right"]
+   TestAssertThrow "minus overflow throws", "DoMinus", \
+         the long id of me, "EE_MATH_RANGE", tParam
+end TestMinusError
+
+command DoOver pParam
+   get pParam["left"] / pParam["right"]
+end DoOver
+
+on TestOverError
+   local tParam
+   put 10 into tParam["left"]
+   put 0 into tParam["right"]
+   TestAssertThrow "/ throws with 0 denominator", "DoOver", \
+         the long id of me, "EE_MATH_ZERO", tParam
+end TestOverError
+
+command DoPow pParam
+   get pParam["left"] ^ pParam["right"]
+end DoPow
+
+on TestPowError
+   local tParam
+   put -1 into tParam["left"]
+   put 0.5 into tParam["right"]
+   TestAssertThrow "negative^(abs < 1) throws", "DoPow", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+
+   put -1 into tParam["left"]
+   put -0.5 into tParam["right"]
+   TestAssertThrow "negative^(-1 < x < 0) throws", "DoPow", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+
+   put 0 into tParam["left"]
+   put -2 into tParam["right"]
+   TestAssertThrow "zero^(-ve) throws", "DoPow", \
+         the long id of me, "EE_MATH_ZERO", tParam
+end TestPowError
+
+command DoAnnuity pParam
+   get annuity(pParam["left"], pParam["right"])
+end DoAnnuity
+
+on TestAnnuityError
+   // Divide by zero
+   local tParam
+   put -1 into tParam["left"]
+   put 2 into tParam["right"]
+   TestAssertThrow "annuity(-1, +ve) throws", "DoAnnuity", \
+         the long id of me, "EE_MATH_ZERO", tParam
+
+   // Sqrt -1
+   put -2 into tParam["left"]
+   put -0.5 into tParam["right"]
+   TestAssertThrow "annuity(-ve, -1 < x < 0) throws", "DoAnnuity", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+
+   put -2 into tParam["left"]
+   put 0.5 into tParam["right"]
+   TestAssertThrow "annuity(-ve, 0 < x < 1) throws", "DoAnnuity", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+end TestAnnuityError
+
+command DoCompound pParam
+   get compound(pParam["left"], pParam["right"])
+end DoCompound
+
+on TestCompoundError
+   // Divide by zero
+   local tParam
+   put -1 into tParam["left"]
+   put -1 into tParam["right"]
+   TestAssertThrow "compound(-1, -ve) throws", "DoCompound", \
+         the long id of me, "EE_MATH_ZERO", tParam
+
+   // Sqrt -1
+   put -2 into tParam["left"]
+   put 0.5 into tParam["right"]
+   TestAssertThrow "compound(-ve, abs < 1) throws", "DoCompound", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+end TestCompoundError
+
+on TestNaryOverflowErrors
+   local tParam
+   put GetVeryLargeInteger() into tParam["args"][1]
+   put GetVeryLargeInteger() into tParam["args"][2]
+   repeat for each item tItem in "sum,average,median,avgdev,stddev,pop_stddev,pop_variance,variance"
+      put tItem into tParam["which"]
+      TestAssertThrow tItem && "overflow throws", "DoNaryFunction", \
+            the long id of me, "EE_MATH_RANGE", tParam
+   end repeat
+end TestNaryOverflowErrors
+
+command DoGeoMean pParam
+   get geometricMean(pParam[1], pParam[2])
+end DoGeoMean
+
+on TestGeoMeanError
+   local tParam
+   put -1 into tParam[1]
+   put 1 into tParam[2]
+   TestAssertThrow "geometric mean with negative number throws domain error", "DoGeoMean", \
+         the long id of me, "EE_MATH_DOMAIN", tParam
+end TestGeoMeanError
+
+command DoNaryFunction pParams
+   switch pParams["which"]
+   case "sum"
+      get sum(pParams["args"])
+      break
+   case "average"
+      get avg(pParams["args"])
+      break
+   case "median"
+      get median(pParams["args"])
+      break
+   case "avgdev"
+      get averageDeviation(pParams["args"])
+      break
+   case "pop_stddev"
+      get populationStandardDeviation(pParams["args"])
+      break
+   case "pop_variance"
+      get populationVariance(pParams["args"])
+      break
+   case "stddev"
+      get sampleStandardDeviation(pParams["args"])
+      break
+   case "variance"
+      get sampleVariance(pParams["args"])
+      break
+   end switch
+end DoNaryFunction

--- a/tests/lcs/core/math/infinity.livecodescript
+++ b/tests/lcs/core/math/infinity.livecodescript
@@ -16,13 +16,8 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-command _TestInfinityDivOperator
-    get inf div 1 is inf
-end _TestInfinityDivOperator
-
 on TestInfinityDivOperator
-    TestAssertBrokenThrow "Infinity is unchanged by div operator", "_TestInfinityDivOperator", "Bug 14316", \
-        the long id of me, "EE_DIV_RANGE"
+    TestAssert "Infinity is unchanged by div operator", inf div 2 is inf
 end TestInfinityDivOperator
 
 on TestInfinitySubtractOperator
@@ -37,20 +32,10 @@ on TestInfinityAddOperator
    TestAssert "Infinity is unchanged by add operator", inf + 1 is inf
 end TestInfinityAddOperator
 
-command _TestInfinityMultiplyOperator
-    get inf * 2 is inf
-end _TestInfinityMultiplyOperator
-
 on TestInfinityMultiplyOperator
-    TestAssertBrokenThrow "Infinity is unchanged by multiply operator", "_TestInfinityMultiplyOperator", "Bug 14316", \
-        the long id of me, "EE_MULTIPLY_RANGE"
+    TestAssert "Infinity is unchanged by multiply operator", inf * 2 is inf
 end TestInfinityMultiplyOperator
 
-command _TestInfinityPowerOperator
-    get inf ^ 2 is inf
-end _TestInfinityPowerOperator
-
 on TestInfinityPowerOperator
-    TestAssertBrokenThrow "Infinity is unchanged by power operator", "_TestInfinityPowerOperator", "Bug 14316", \
-        the long id of me, "EE_POW_RANGE"
+    TestAssert "Infinity is unchanged by powwe operator", inf ^ 2 is inf
 end TestInfinityPowerOperator

--- a/tests/lcs/core/math/infinity.livecodescript
+++ b/tests/lcs/core/math/infinity.livecodescript
@@ -16,26 +16,170 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
-on TestInfinityDivOperator
-    TestAssert "Infinity is unchanged by div operator", inf div 2 is inf
-end TestInfinityDivOperator
+private command _TestBinaryOperator pLeft, pRight, pOperator, pExpected
+    local tResult, tExpr
+    switch pOperator
+    case "plus"
+        put pLeft + pRight into tResult
+        break
+    case "minus"
+        put pLeft - pRight into tResult
+        break
+    case "times"
+        put pLeft * pRight into tResult
+        break
+    case "over"
+        put pLeft / pRight into tResult
+        break
+    case "to the power of"
+        put pLeft ^ pRight into tResult
+        break
+    case "added to"
+        add pLeft to pRight
+        put pRight into tResult
+        break
+    case "subtracted from"
+        subtract pLeft from pRight
+        put pRight into tResult
+        break
+    case "multiplied by"
+        multiply pLeft by pRight
+        put pLeft into tResult
+        break
+    case "divided by"
+        divide pLeft by pRight
+        put pLeft into tResult
+        break
+    case "div"
+        put pLeft div pRight into tResult
+        break
+    case "mod"
+        put pLeft mod pRight into tResult
+        break
+    case "wrap"
+        put pLeft wrap pRight into tResult
+        break
+    default
+        put pOperator & "(" & pLeft & "," & pRight & ")" into tExpr
+        put value(tExpr) into tResult
+        break
+    end switch
+    if tExpr is empty then
+        TestAssert "Result of" && pLeft && pOperator && pRight && "is" && pExpected, \
+                tResult is pExpected
+    else
+        TestAssert "Result of" && tExpr && "is" && pExpected, \
+                tResult is pExpected
+    end if
+end _TestBinaryOperator
 
-on TestInfinitySubtractOperator
-    TestAssert "Infinity is unchanged by subtract operator", inf - 1 is inf
-end TestInfinitySubtractOperator
+on TestInfinityBinaryOperators
+    _TestBinaryOperator "inf", 1, "plus", "inf"
+    _TestBinaryOperator "-inf", 1, "plus", "-inf"
 
-on TestInfinityOverOperator
-   TestAssert "Infinity is unchanged by over operator", inf / 2 is inf
-end TestInfinityOverOperator
+    _TestBinaryOperator "inf", 1, "minus", "inf"
+    _TestBinaryOperator "-inf", 1, "minus", "-inf"
+    _TestBinaryOperator 1, "inf", "minus", "-inf"
+    _TestBinaryOperator 1, "-inf", "minus", "inf"
 
-on TestInfinityAddOperator
-   TestAssert "Infinity is unchanged by add operator", inf + 1 is inf
-end TestInfinityAddOperator
+    _TestBinaryOperator "inf", 2, "times", "inf"
+    _TestBinaryOperator "-inf", 2, "times", "-inf"
 
-on TestInfinityMultiplyOperator
-    TestAssert "Infinity is unchanged by multiply operator", inf * 2 is inf
-end TestInfinityMultiplyOperator
+    _TestBinaryOperator "inf", 2, "over", "inf"
+    _TestBinaryOperator "-inf", 2, "over", "-inf"
+    _TestBinaryOperator 2, "inf", "over", 0
+    _TestBinaryOperator 2, "-inf", "over", 0
 
-on TestInfinityPowerOperator
-    TestAssert "Infinity is unchanged by powwe operator", inf ^ 2 is inf
-end TestInfinityPowerOperator
+    _TestBinaryOperator "inf", 2, "to the power of", "inf"
+    _TestBinaryOperator "-inf", 2, "to the power of", "inf"
+    _TestBinaryOperator "-inf", 3, "to the power of", "-inf"
+    _TestBinaryOperator 2, "inf", "to the power of", "inf"
+    _TestBinaryOperator 2, "-inf", "to the power of", 0
+
+    _TestBinaryOperator "inf", 1, "added to", "inf"
+    _TestBinaryOperator "-inf", 1, "added to", "-inf"
+    _TestBinaryOperator 1, "inf", "added to", "inf"
+    _TestBinaryOperator 1, "-inf", "added to", "-inf"
+
+    _TestBinaryOperator 1, "inf", "subtracted from", "inf"
+    _TestBinaryOperator 1, "-inf", "subtracted from", "-inf"
+    _TestBinaryOperator "inf", 1, "subtracted from", "-inf"
+    _TestBinaryOperator "-inf", 1, "subtracted from", "inf"
+
+    _TestBinaryOperator "inf", 2, "multiplied by", "inf"
+    _TestBinaryOperator "-inf", 2, "multiplied by", "-inf"
+    _TestBinaryOperator 2, "inf", "multiplied by", "inf"
+    _TestBinaryOperator 2, "-inf", "multiplied by", "-inf"
+
+    _TestBinaryOperator "inf", 2, "divided by", "inf"
+    _TestBinaryOperator "-inf", 2, "divided by", "-inf"
+    _TestBinaryOperator 2, "inf", "divided by", 0
+    _TestBinaryOperator 2, "-inf", "divided by", 0
+
+    _TestBinaryOperator "inf", 2, "div", "inf"
+    _TestBinaryOperator "-inf", 2, "div", "-inf"
+    _TestBinaryOperator 2, "inf", "div", 0
+    _TestBinaryOperator 2, "-inf", "div", 0
+
+    _TestBinaryOperator 2, "inf", "mod", 2
+    _TestBinaryOperator 2, "-inf", "mod", 2
+
+    _TestBinaryOperator 2, "inf", "wrap", 2
+    _TestBinaryOperator 2, "-inf", "wrap", 2
+
+    _TestBinaryOperator 1, "inf", "atan2", 0
+    _TestBinaryOperator "inf", 1, "atan2", pi/2
+    _TestBinaryOperator "inf", "inf", "atan2", pi/4
+    _TestBinaryOperator 1, "-inf", "atan2", pi
+    _TestBinaryOperator "-inf", 1, "atan2", -pi/2
+    _TestBinaryOperator "-inf", "-inf", "atan2", -3*pi/4
+end TestInfinityBinaryOperators
+
+private command _TestUnaryOperator pOperator, pOperand, pExpected
+    local tResult, tExpr
+    put pOperator & "(" & pOperand & ")" into tExpr
+    put value(tExpr) into tResult
+    TestAssert tExpr && "is" && pExpected, \
+            tResult is pExpected
+end _TestUnaryOperator
+
+on TestInfinityUnaryOperators
+    _TestUnaryOperator "atan", "inf", pi/2
+    _TestUnaryOperator "atan", "-inf", -pi/2
+
+    _TestUnaryOperator "exp", "inf", "inf"
+    _TestUnaryOperator "exp", "-inf", 0
+    _TestUnaryOperator "exp1", "inf", "inf"
+    _TestUnaryOperator "exp1", "-inf", -1
+    _TestUnaryOperator "exp2", "inf", "inf"
+    _TestUnaryOperator "exp2", "-inf", 0
+    _TestUnaryOperator "exp10", "inf", "inf"
+    _TestUnaryOperator "exp10", "-inf", 0
+
+    _TestUnaryOperator "ln", "inf", "inf"
+    _TestUnaryOperator "ln1", "inf", "inf"
+    _TestUnaryOperator "log2", "inf", "inf"
+    _TestUnaryOperator "log10", "inf", "inf"
+
+    _TestUnaryOperator "sqrt", "inf", "inf"
+end TestInfinityUnaryOperators
+
+on TestInfinityNaryOperators
+    repeat for each item tItem in "sum,min,max,avg,median"
+        _TestUnaryOperator tItem, "inf", "inf"
+        if the platform is "win32" then
+            TestSkip tItem & "(-inf) is -inf", "Bug 22038"
+        else
+            _TestUnaryOperator tItem, "-inf", "-inf"
+        end if
+    end repeat
+
+    _TestBinaryOperator 2, "inf", "min", 2
+    _TestBinaryOperator 2, "-inf", "min", "-inf"
+
+    _TestBinaryOperator 2, "inf", "max", "inf"
+    _TestBinaryOperator 2, "-inf", "max", 2
+
+    TestAssert "Result of median(2,inf,inf) is inf", median(2,"inf","inf") is "inf"
+    TestAssert "Result of median(2,-inf,-inf) is -inf", median(2,"-inf","-inf") is "-inf"
+end TestInfinityNaryOperators

--- a/tests/lcs/core/math/math.livecodescript
+++ b/tests/lcs/core/math/math.livecodescript
@@ -97,12 +97,16 @@ repeat with i = 1 to 10
 end repeat
 
 end TestMathArrayPlusArray
-on TestMath3
 
+on TestAnnuity
+	TestAssert "test annuity formula", annuity(0.02, 25) is ( 1 - ( 1 + 0.02 ) ^ ( - 25 ) ) / 0.02
+	TestAssert "test annuity zero rate", annuity(0, 25) is 25
+end TestAnnuity
 
-TestAssert "test", annuity(0.02, 25) is ( 1 - ( 1 + 0.02 ) ^ ( - 25 ) ) / 0.02
+on TestCompound
+	TestAssert "test compound formula", compound(0.02, 25) is (1 + 0.02) ^ 25
+end TestCompound
 
-end TestMath3
 on TestMath4
 
 
@@ -131,21 +135,6 @@ TestAssert "test", atan2(-1,  0) is -pi / 2
 TestAssert "test", atan2(-1,  1) is -pi / 4
 
 end TestMath5
-on TestMath6
-
-
-TestAssert "test", average() is 0
-TestAssert "test", average(1.23) is 1.23
-TestAssert "test", average("1, 2, 3, 4, 5") is 3
-TestAssert "test", average(1, 2, 3, 4, 5) is 3
-
-local tArray
-repeat with i = 1 to 5
-	put i into tArray[i]
-end repeat
-TestAssert "test", average(tArray) is 3
-
-end TestMath6
 
 on TestMath7
 
@@ -730,21 +719,7 @@ repeat with i = 1 to 10 step 0.1
 end repeat
 
 end TestMath31
-on TestMathStdDev
 
-
-TestAssert "test", stddev() is 0
-TestAssert "test", stddev("1, 2, 3") is 1
-TestAssert "test", stddev(1,2,3) is 1
-TestAssert "test", stddev(0.5,1,1.5) is 0.5
-
-local tArray
-repeat with i = 1 to 5
-	put 6 - i into tArray[i]
-end repeat
-TestAssert "test", stddev(tArray) is stddev(1,2,3,4,5)
-
-end TestMathStdDev
 on TestMathNumberMinusNumber
 
 

--- a/tests/lcs/core/math/stats.livecodescript
+++ b/tests/lcs/core/math/stats.livecodescript
@@ -1,0 +1,211 @@
+script "CoreMathStats"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+private function ComputeAverage pMeanKind
+    local tTotal, tCount, tParams
+    put char 1 to -2 of item 2 to -1 of the params into tParams
+    put 0 into tTotal
+    put the number of items in tParams into tCount
+    if tCount is 0 then
+        return tTotal
+    end if
+    repeat for each item tItem in tParams
+        local tValue
+        // Strip quotes
+        put char 2 to -2 of tItem into tValue
+        switch pMeanKind
+        case "arithmetic"
+            add tValue to tTotal
+            break
+        case "harmonic"
+            add (1 / tValue) to tTotal
+            break
+        case "geometric"
+            if tTotal is 0 then
+                put 1 into tTotal
+            end if
+            multiply tTotal by (tValue ^ (1 / tCount))
+            break
+        end switch
+    end repeat
+
+    switch pMeanKind
+    case "arithmetic"
+        return tTotal / tCount
+    case "harmonic"
+        return tCount / tTotal
+    case "geometric"
+        return tTotal
+        break
+    end switch
+end ComputeAverage
+
+on TestAverage
+    TestAssert "test arithmetic mean no params", average() is ComputeAverage("arithmetic")
+    TestAssert "test arithmetic mean one param", average(1.23) is ComputeAverage("arithmetic", 1.23)
+    TestAssert "test arithmetic mean string param", average("1, 2, 3, 4, 5") is ComputeAverage("arithmetic", 1, 2, 3, 4, 5)
+    TestAssert "test arithmetic mean numeric params", average(1, 2, 3, 4, 5) is ComputeAverage("arithmetic", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test arithmetic mean array param", average(tArray) is ComputeAverage("arithmetic", 1, 2, 3, 4, 5)
+    TestDiagnostic average(tArray)
+end TestAverage
+
+on TestHarmonicMean
+    TestAssert "test harmonic mean no params", harmonicMean() is ComputeAverage("harmonic")
+    TestAssert "test harmonic mean one param", harmonicMean(1.23) is ComputeAverage("harmonic", 1.23)
+    TestAssert "test harmonic mean string param", harmonicMean("1, 2, 3, 4, 5") is ComputeAverage("harmonic", 1, 2, 3, 4, 5)
+    TestAssert "test harmonic mean numeric params", harmonicMean(1, 2, 3, 4, 5) is ComputeAverage("harmonic", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test arithmetic mean array param", harmonicMean(tArray) is ComputeAverage("harmonic", 1, 2, 3, 4, 5)
+end TestHarmonicMean
+
+on TestGeometricMean
+    TestAssert "test geometric mean no params", geometricMean() is ComputeAverage("geometric")
+    TestAssert "test geometric mean one param", geometricMean(1.23) is ComputeAverage("geometric", 1.23)
+    TestAssert "test geometric mean string param", geometricMean("1, 2, 3, 4, 5") is ComputeAverage("geometric", 1, 2, 3, 4, 5)
+    TestAssert "test geometric mean numeric params", geometricMean(1, 2, 3, 4, 5) is ComputeAverage("geometric", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test geometric mean array param", geometricMean(tArray) is ComputeAverage("geometric", 1, 2, 3, 4, 5)
+end TestGeometricMean
+
+private function ComputeStats pFunction
+    local tTotal, tCount, tParams, tMean
+    put char 1 to -2 of item 2 to -1 of the params into tParams
+    put 0 into tTotal
+    put the number of items in tParams into tCount
+    if tCount is 0 then
+        return tTotal
+    end if
+
+    if (pFunction is "sampleStandardDeviation" or pFunction is "sampleVariance") \
+            and tCount is 1 then
+        return 0
+    end if
+
+    local tParamArray
+    repeat with x = 1 to the number of items in tParams
+        // Strip quotes
+        put char 2 to -2 of item x of tParams into tParamArray[x]
+    end repeat
+    put average(tParamArray) into tMean
+
+    repeat for each element tValue in tParamArray
+        subtract tMean from tValue
+        switch pFunction
+        case "averageDeviation"
+            add abs(tValue) to tTotal
+            break
+        case "populationStandardDeviation"
+        case "populationVariance"
+        case "sampleStandardDeviation"
+        case "sampleVariance"
+            add tValue^2 to tTotal
+            break
+        end switch
+    end repeat
+
+    switch pFunction
+    case "averageDeviation"
+        return tTotal / tCount
+    case "populationStandardDeviation"
+        return sqrt(tTotal / tCount)
+    case "populationVariance"
+        return tTotal / tCount
+    case "sampleStandardDeviation"
+        return sqrt(tTotal / (tCount - 1))
+    case "sampleVariance"
+        return tTotal / (tCount - 1)
+    end switch
+end ComputeStats
+
+on TestAverageDeviation
+    TestAssert "test average deviation no params", averageDeviation() is ComputeStats("averageDeviation")
+    TestAssert "test average deviation one param", averageDeviation(1.23) is ComputeStats("averageDeviation", 1.23)
+    TestAssert "test average deviation string param", averageDeviation("1, 2, 3, 4, 5") is ComputeStats("averageDeviation", 1, 2, 3, 4, 5)
+    TestAssert "test average deviation numeric params", averageDeviation(1, 2, 3, 4, 5) is ComputeStats("averageDeviation", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test average deviation array param", averageDeviation(tArray) is ComputeStats("averageDeviation", 1, 2, 3, 4, 5)
+end TestAverageDeviation
+
+on TestPopulationStandardDeviation
+    TestAssert "test population standard deviation no params", populationStandardDeviation() is ComputeStats("populationStandardDeviation")
+    TestAssert "test population standard deviation one param", populationStandardDeviation(1.23) is ComputeStats("populationStandardDeviation", 1.23)
+    TestAssert "test population standard deviation string param", populationStandardDeviation("1, 2, 3, 4, 5") is ComputeStats("populationStandardDeviation", 1, 2, 3, 4, 5)
+    TestAssert "test population standard deviation numeric params", populationStandardDeviation(1, 2, 3, 4, 5) is ComputeStats("populationStandardDeviation", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test population standard deviation array param", populationStandardDeviation(tArray) is ComputeStats("populationStandardDeviation", 1, 2, 3, 4, 5)
+end TestPopulationStandardDeviation
+
+on TestPopulationVariance
+    TestAssert "test population variance no params", populationVariance() is ComputeStats("populationVariance")
+    TestAssert "test population variance one param", populationVariance(1.23) is ComputeStats("populationVariance", 1.23)
+    TestAssert "test population variance string param", populationVariance("1, 2, 3, 4, 5") is ComputeStats("populationVariance", 1, 2, 3, 4, 5)
+    TestAssert "test population variance numeric params", populationVariance(1, 2, 3, 4, 5) is ComputeStats("populationVariance", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test population variance array param", populationVariance(tArray) is ComputeStats("populationVariance", 1, 2, 3, 4, 5)
+end TestPopulationVariance
+
+on TestSampleStandardDeviation
+    TestAssert "test sample standard deviation no params", sampleStandardDeviation() is ComputeStats("sampleStandardDeviation")
+    TestAssert "test sample standard deviation one param", sampleStandardDeviation(1.23) is ComputeStats("sampleStandardDeviation", 1.23)
+    TestAssert "test sample standard deviation string param", sampleStandardDeviation("1, 2, 3, 4, 5") is ComputeStats("sampleStandardDeviation", 1, 2, 3, 4, 5)
+    TestAssert "test sample standard deviation numeric params", sampleStandardDeviation(1, 2, 3, 4, 5) is ComputeStats("sampleStandardDeviation", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test sample standard deviation array param", sampleStandardDeviation(tArray) is ComputeStats("sampleStandardDeviation", 1, 2, 3, 4, 5)
+end TestSampleStandardDeviation
+
+on TestSampleVariance
+    TestAssert "test sample variance no params", sampleVariance() is ComputeStats("sampleVariance")
+    TestAssert "test sample variance one param", sampleVariance(1.23) is ComputeStats("sampleVariance", 1.23)
+    TestAssert "test sample variance string param", sampleVariance("1, 2, 3, 4, 5") is ComputeStats("sampleVariance", 1, 2, 3, 4, 5)
+    TestAssert "test sample variance numeric params", sampleVariance(1, 2, 3, 4, 5) is ComputeStats("sampleVariance", 1, 2, 3, 4, 5)
+
+    local tArray
+    repeat with i = 1 to 5
+        put i into tArray[i]
+    end repeat
+    TestAssert "test sample variance array param", sampleVariance(tArray) is ComputeStats("sampleVariance", 1, 2, 3, 4, 5)
+end TestSampleVariance


### PR DESCRIPTION
Before merging, we need to check the siginfo struct upon handling the SIGFPE signal to set `errno` more specifically, as otherwise we are conflating eg divide by zero and out of range errors.