### PR TITLE
[21728] Ensure one can set the image filename to a relative path

### DIFF
--- a/docs/notes/bugfix-21728.md
+++ b/docs/notes/bugfix-21728.md
@@ -1,0 +1,1 @@
+# Ensure one can set the filename of an image to a relative path

--- a/engine/src/ifile.cpp
+++ b/engine/src/ifile.cpp
@@ -438,7 +438,7 @@ bool MCImageGetRepForFileWithStackContext(MCStringRef p_filename, MCStack *p_sta
 		// else try to resolve from stack file location
 		MCAutoStringRef t_path;
 		t_success = p_stack->resolve_relative_path(p_filename, &t_path);
-		if (t_success)
+		if (t_success && MCS_exists(*t_path, True))
 			t_success = MCImageRepGetDensityMapped(*t_path, t_rep);
 		
 		// else try to resolve from current folder


### PR DESCRIPTION
`resolve_relative_path` (from _stack_ location) returned `true`, but there was no actual file in the resolved path location, so the call to `MCImageRepGetDensityMapped` failed, and the code that tries to resolve the image path from the _default folder_ location was never executed.