### PR TITLE
[Dictionary] revSetSpeechPitch to revXMLAddNote

### DIFF
--- a/docs/dictionary/command/revSetSpeechPitch.lcdoc
+++ b/docs/dictionary/command/revSetSpeechPitch.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: revSetSpeechPitch <pitchLevel>
 
 Summary:
-Sets the pitch (whether the voice is high or low) to be used with <text
-to speech>.
+Sets the pitch (whether the voice is high or low) to be used with 
+<text to speech>.
 
 Associations: speech library
 
@@ -42,13 +42,12 @@ for a treble voice and a lower <pitchLevel> for a bass voice.
 The <pitchLevel> is logarithmically related to the voice frequency: the
 range 30 to 127 corresponds approximately to the range from 50Hz to
 12,000Hz. If you need to convert from Hertz (cycles per second) to the
-<pitchLevel> numbers used with this <command>, use the following <custom
-function>: 
+<pitchLevel> numbers used with this <command>, use the following 
+<custom function>: 
 
     function pitchFromHertz theHertzFrequency
-    get (ln(theHertzFrequency) - ln(261.625))/ln(1.05946309434)
-    return round(60 + it)
-
+        get (ln(theHertzFrequency) - ln(261.625))/ln(1.05946309434)
+        return round(60 + it)
     end pitchFromHertz
 
 

--- a/docs/dictionary/command/revSetSpeechSpeed.lcdoc
+++ b/docs/dictionary/command/revSetSpeechSpeed.lcdoc
@@ -31,8 +31,8 @@ If text to speech is not available on the current system, the
 message. 
 
 Description:
-Use the <revSetSpeechSpeed> <command> to speed up or slow down <text to
-speech|speech>. 
+Use the <revSetSpeechSpeed> <command> to speed up or slow down 
+<text to speech|speech>. 
 
 The greater the <wordsPerMinute>, the faster the speech. (A normal
 speech rate for English is approximately 150 words per minute.)

--- a/docs/dictionary/command/revSetSpeechVoice.lcdoc
+++ b/docs/dictionary/command/revSetSpeechVoice.lcdoc
@@ -34,8 +34,8 @@ If text to speech is not available on the current system, the
 message. 
 
 Description:
-Use the <revSetSpeechVoice> <command> to change the way <text to
-speech|speech> sounds.
+Use the <revSetSpeechVoice> <command> to change the way 
+<text to speech|speech> sounds.
 
 To get a list of voices installed on the current system, use the
 <revSpeechVoices> <function>.

--- a/docs/dictionary/command/revSetStackFileProfile.lcdoc
+++ b/docs/dictionary/command/revSetStackFileProfile.lcdoc
@@ -28,9 +28,7 @@ The profileName specifies which profile to use.
 
 stackName:
 The short name of an open stack. If you don't specify a stack, the stack
-file that the topStack belongs to is changed. >*Note:* Although the
-revSetStackFileProfile command changes a stack file, you specify a stack
-name, not a file name.
+file that the topStack belongs to is changed. 
 
 Description:
 Use the <revSetStackFileProfile> <command> to change <property> settings
@@ -47,12 +45,12 @@ to the settings you specified. This helps you quickly switch the
 appearance and behavior of the <object(glossary)> without needing to set
 its <properties> individually.
 
-The <revSetStackFileProfile> <command> changes the current <property
-profile|profile> of the specified <stack>, all the <stacks> in the same
-<stack file>, and all the <object|objects> in all these <stacks>. If an
-<object(glossary)> does not have a <property profile|profile> with the
-specified <profileName>, the <object|object's> <properties> are not
-changed. 
+The <revSetStackFileProfile> <command> changes the current 
+<property profile|profile> of the specified <stack>, all the <stacks> in 
+the same <stack file>, and all the <object|objects> in all these 
+<stacks>. If an <object(glossary)> does not have a 
+<property profile|profile> with the specified <profileName>, the 
+<object|object's> <properties> are not changed. 
 
 >*Important:*  The <revSetStackFileProfile> <command> is part of the
 > <Profile library>. To ensure that the <command> works in a 

--- a/docs/dictionary/command/revSetVideoGrabSettings.lcdoc
+++ b/docs/dictionary/command/revSetVideoGrabSettings.lcdoc
@@ -56,7 +56,8 @@ References: revVideoGrabSettings (command), function (control structure),
 video capture (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), QuickTime (glossary),
 command (glossary), LiveCode custom library (glossary),
-Video library (library)
+Video library (library), dontUseQT (property), 
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
+++ b/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
@@ -48,7 +48,7 @@ You must use the <revInitializeVideoGrabber> <command> to open the
 The rectangle specified by the <left>, <top>, <right>, and <bottom> is
 the rectangle of the <video grabber|video grabber window>: the top,
 left, bottom, and right edges of the <video grabber>, in 
-<absolute coordinates(glossary)>.
+<absolute coordinates(glossary)|absolute (screen) coordinates>.
 
 >*Important:*  The <revSetVideoGrabberRect> <command> is part of the 
 > <Video library>. To ensure that the <command> works in a 

--- a/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
+++ b/docs/dictionary/command/revSetVideoGrabberRect.lcdoc
@@ -47,8 +47,8 @@ You must use the <revInitializeVideoGrabber> <command> to open the
 
 The rectangle specified by the <left>, <top>, <right>, and <bottom> is
 the rectangle of the <video grabber|video grabber window>: the top,
-left, bottom, and right edges of the <video grabber>, in <absolute
-(screen) coordinates(glossary)>.
+left, bottom, and right edges of the <video grabber>, in 
+<absolute coordinates(glossary)>.
 
 >*Important:*  The <revSetVideoGrabberRect> <command> is part of the 
 > <Video library>. To ensure that the <command> works in a 

--- a/docs/dictionary/command/revUpdateGeometry.lcdoc
+++ b/docs/dictionary/command/revUpdateGeometry.lcdoc
@@ -35,8 +35,6 @@ resized. Use it only if both the following conditions are true:
 1. Your stack uses the Geometry pane of the property inspector to
    automate object positioning and sizing when the stack window is
    resized, and
-
-
 2. Either a handler in your stack locks messages and then moves or
    resizes the stack window, or a resizeStack <handler> in your <stack>
    does not pass the <resizeStack> <message> at the end of the

--- a/docs/dictionary/command/revVideoGrabDialog.lcdoc
+++ b/docs/dictionary/command/revVideoGrabDialog.lcdoc
@@ -40,8 +40,8 @@ Description:
 Use the <revVideoGrabDialog> <command> to specify settings for use with
 the <video grabber>.
 
-You must use the revInitializeVideoGrabber <command> to open the <video
-grabber> before you can use the <revVideoGrabDialog> <command>.
+You must use the revInitializeVideoGrabber <command> to open the 
+<video grabber> before you can use the <revVideoGrabDialog> <command>.
 
 Use the <settingsType> <parameter> to specify which <dialog box> you
 want to show.
@@ -73,7 +73,8 @@ video capture (glossary), VFW (glossary),
 Standalone Application Settings (glossary), QuickTime (glossary),
 statement (glossary), standalone application (glossary),
 parameter (glossary), video grabber (glossary), dialog box (glossary),
-LiveCode custom library (glossary), Video library (library)
+LiveCode custom library (glossary), Video library (library),
+dontUseQT (property), dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revVideoGrabIdle.lcdoc
+++ b/docs/dictionary/command/revVideoGrabIdle.lcdoc
@@ -54,7 +54,8 @@ video capture (glossary), VFW (glossary),
 Standalone Application Settings (glossary), QuickTime (glossary),
 video grabber (glossary), standalone application (glossary),
 command (glossary), LiveCode custom library (glossary),
-Video library (library), idle (message)
+Video library (library), idle (message), dontUseQT (property),
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revVideoGrabSettings.lcdoc
+++ b/docs/dictionary/command/revVideoGrabSettings.lcdoc
@@ -59,7 +59,8 @@ variable (glossary), video capture (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), video grabber (glossary),
 command (glossary), LiveCode custom library (glossary),
-Video library (library)
+Video library (library), dontUseQT (property), 
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/command/revXMLAddDTD.lcdoc
+++ b/docs/dictionary/command/revXMLAddDTD.lcdoc
@@ -25,8 +25,8 @@ revXMLAddDTD theCurrTree,the templateDTD of me
 
 Parameters:
 treeID:
-The numbe returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or 
+<revXMLCreateTreeFromFile> function when you created the XML tree.
 
 DTDText (string):
 A string that makes up a valid Document Type Definition.
@@ -47,7 +47,9 @@ Use the <revXMLAddDTD> <command> to specify the format of an <XML tree>.
 > checkbox is checked.
 
 References: revXMLAppend (command), revXMLValidateDTD (function),
-result (function), Standalone Application Settings (glossary),
+result (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), 
+Standalone Application Settings (glossary), 
 standalone application (glossary), DTD (glossary), XML tree (glossary),
 command (glossary), LiveCode custom library (glossary),
 XML library (library)

--- a/docs/dictionary/command/revXMLAddNode.lcdoc
+++ b/docs/dictionary/command/revXMLAddNode.lcdoc
@@ -25,8 +25,8 @@ revXMLAddNode myTree,theNode,the short name of me,field "Contents"
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or 
+<revXMLCreateTreeFromFile> function when you created the XML tree.
 
 parentNode:
 The node whose child the node being created will be.
@@ -58,7 +58,8 @@ Use the <revXMLAddNode> <command> to add a <node> to an <XML tree>.
 > checkbox is checked.
 
 References: revXMLMoveNode (command), revXMLDeleteNode (command),
-revXMLAppend (command), result (function), node (glossary),
+revXMLAppend (command), result (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), node (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), XML tree (glossary),
 command (glossary), child node (glossary),

--- a/docs/dictionary/function/revUnixFromMacPath.lcdoc
+++ b/docs/dictionary/function/revUnixFromMacPath.lcdoc
@@ -5,8 +5,8 @@ Type: function
 Syntax: revUnixFromMacPath(<macPathname> [, <convertOSX>])
 
 Summary:
-Converts a <Mac OS>-style <file path|pathname> to a <Unix> -style <file
-path|pathname>. 
+Converts a <Mac OS>-style <file path|pathname> to a <Unix>-style 
+<file path|pathname>. 
 
 Introduced: 1.0
 
@@ -32,17 +32,17 @@ convertOSX:
 
 
 Returns:
-The <revUnixFromMacPath> <function> returns a <string> with the <file
-path> in the format expected by the <Mac OS>. The <convertOSX> is true
-or false. If you don't specify the <convertOSX>, if <OS X> is running,
-LiveCode assumes the <macPathname> is an <OS X>-style path to a <Mac
-OS>-style path; otherwise, it assumes the <macPathname> is a <Mac
-OS>-style path.
+The <revUnixFromMacPath> <function> returns a <string> with the 
+<file path> in the format expected by the <Mac OS>. The <convertOSX> 
+is true or false. If you don't specify the <convertOSX>, if <OS X> is 
+running, LiveCode assumes the <macPathname> is an <OS X>-style path to 
+a <Mac OS>-style path; otherwise, it assumes the <macPathname> is a 
+<Mac OS>-style path.
 
 Description:
 Use the <revUnixFromMacPath> <function> to convert a <Mac OS>-style file
-path to the LiveCode <file path> format (for example, to convert a <file
-path|pathname> returned by an XFCN).
+path to the LiveCode <file path> format (for example, to convert a 
+<file path|pathname> returned by an XFCN).
 
 The <revUnixFromMacPath> <function> converts colons (:) to slashes (/),
 the folder-level <delimiter> for <Unix> <file path|pathnames>. It also
@@ -61,8 +61,8 @@ The OS X path convention is used by LiveCode, but the old Mac OS-style
 path convention is used by certain applications (such as AppleScript),
 even on OS X systems. If the <convertOSX> is true (or if you don't
 specify the <convertOSX> and the application is running under <OS X>),
-the <revUnixFromMacPath> <function> assumes that <absolute file
-path|absolute paths> are using the <OS X> convention. If the
+the <revUnixFromMacPath> <function> assumes that 
+<absolute file path|absolute paths> are using the <OS X> convention. If the
 <convertOSX> is false, the <revUnixFromMacPath> <function> assumes that
 absolute paths use the <Mac OS> convention.
 
@@ -72,12 +72,12 @@ it to another program or external. If you are using only LiveCode
 commands and functions, you do not need to convert the pathname, since
 LiveCode does it for you.
 
->*Note:* When included in a <standalone application>, the <Common
-> library> is implemented as a hidden <group> and made available when
-> the <group> receives its first <openBackground> message. During the
-> first part of the <application|application's> startup process, before
-> this <message> is sent, the <revUnixFromMacPath> <function> is not yet
-> available. This may affect attempts to use this <function> in
+>*Note:* When included in a <standalone application>, the 
+> <Common library> is implemented as a hidden <group> and made available 
+> when the <group> receives its first <openBackground> message. During 
+> the first part of the <application|application's> startup process, 
+> before this <message> is sent, the <revUnixFromMacPath> <function> is 
+> not yet available. This may affect attempts to use this <function> in
 > <startup>, <preOpenStack>, <openStack>, or <preOpenCard>
 > <handler|handlers> in the <main stack>. Once the <application> has
 > finished starting up, the <library> is available and the


### PR DESCRIPTION
command/revSetSpeechPitch.lcdoc - Fixed broken links. Formatted code example.
command/revSetSpeechSpeed.lcdoc - Fixed broken link.
command/revSetSpeechVoice.lcdoc - Fixed broken link.
command/revSetStackFileProfile.lcdoc - Fixed broken link. Removed redundant note.
command/revSetVideoGrabberRect.lcdoc - Fixed broken link.
command/revSetVideoGrabSettings.lcdoc - Added absent references.
function/revUnixFromMacPath.lcdoc - Fixed broken link.
command/revUpdateGeometry.lcdoc - Moved ordered list items closer together because they were both marked as 1.
command/revVideoGrabDialog.lcdoc - Fixed broken link. Added absent references.
command/revVideoGrabIdle.lcdoc - Added absent references.
command/revVideoGrabSettings.lcdoc - Added absent references.
command/revXMLAddDTD.lcdoc - Corrected spelling. Added references to functions important to this command.
command/revXMLAddNote.lcdoc - Added references to functions important to this command.
