### PR TITLE
[Bugfix 21382] Remove HTML entities from menu (keyword)

### DIFF
--- a/docs/dictionary/keyword/menu.lcdoc
+++ b/docs/dictionary/keyword/menu.lcdoc
@@ -45,7 +45,7 @@ The syntax for menu item strings is:
     [&lt;flags&gt;] &lt;label&gt; ['/' &lt;accelerator&gt; ['|' &lt;tag&gt;]]
 
 
-Where `&lt;flags&gt;` may include:
+Where &lt;flags&gt; may include:
 
 * `!c`, `!n`, `!r`: the menu item has respectively, a check, no check,
   or a selected radio button
@@ -55,15 +55,15 @@ Where `&lt;flags&gt;` may include:
   menu item; use this to create submenus
 
 
-The `&lt;accelerator&gt;` can be specified as one of:
+The &lt;accelerator&gt; can be specified as one of:
 
-* `&lt;char&gt;`: Command key + specified char
-* `&lt;keyname&gt;`: Named key without modifiers
-* `&lt;modifiers&gt; &lt;char&gt;`: Specified modifiers + character
-* `&lt;modifiers&gt; &lt;keyname&gt;`: Specified modifiers + named key
+* &lt;char&gt;: Command key + specified char
+* &lt;keyname&gt;: Named key without modifiers
+* &lt;modifiers&gt; &lt;char&gt;: Specified modifiers + character
+* &lt;modifiers&gt; &lt;keyname&gt;: Specified modifiers + named key
 
 
-In the `&lt;accelerator&gt;`, `&lt;modifiers&gt;` is either:
+In the &lt;accelerator&gt;, &lt;modifiers&gt; is either:
 
 * a space separated list of: 'command' or 'cmd', 'control' or 'ctrl',
   'option' or 'opt', 'alt', 'shift'; in this case the keyname/char

--- a/docs/notes/bugfix-21382.md
+++ b/docs/notes/bugfix-21382.md
@@ -1,0 +1,1 @@
+# Removed unwanted HTML entries from the menu dictionary entry

--- a/docs/notes/bugfix-21382.md
+++ b/docs/notes/bugfix-21382.md
@@ -1,1 +1,1 @@
-# Removed unwanted HTML entries from the menu dictionary entry
+# Removed unwanted HTML entities from the menu dictionary entry


### PR DESCRIPTION
Removed the backticks from parts where both they and angle brackets enclosed text as this entry continues to display incorrectly. The commit history for this file suggests there isn't much in the way of an alternative that hasn't already been tried.