### PR TITLE
[Bugfix-21718] Mention calling mobileSensorAvailable before mobileCurrentLocation

### DIFF
--- a/docs/dictionary/function/mobileCurrentLocation.lcdoc
+++ b/docs/dictionary/function/mobileCurrentLocation.lcdoc
@@ -57,8 +57,11 @@ the device. If location tracking has not been enabled this function
 returns empty. Otherwise it returns an array.
 
 >*Note*: Before using the <mobileCurrentLocation> function, the 
-<mobileSensorAvailable> function should first be called. Doing this 
-will request the necessary permissions for using location sensors.
+<mobileSensorAvailable> function should first be called with the line:
+
+    mobileSensorAvailable("location")
+    
+> Doing this will request the necessary permissions for using location sensors.
 
 References: mobileStopTrackingSensor (command),
 mobileStartTrackingSensor (command), mobileSensorAvailable (function),

--- a/docs/dictionary/function/mobileCurrentLocation.lcdoc
+++ b/docs/dictionary/function/mobileCurrentLocation.lcdoc
@@ -56,7 +56,12 @@ Use the <mobileCurrentLocation> function to find the current location of
 the device. If location tracking has not been enabled this function
 returns empty. Otherwise it returns an array.
 
+>*Note*: Before using the <mobileCurrentLocation> function, the 
+<mobileSensorAvailable> function should first be called. Doing this 
+will request the necessary permissions for using location sensors.
+
 References: mobileStopTrackingSensor (command),
-mobileStartTrackingSensor (command), mobileSensorReading (function),
+mobileStartTrackingSensor (command), mobileSensorAvailable (function),
+mobileSensorReading (function),
 trackingError (message), locationChanged (message)
 

--- a/docs/notes/bugfix-21718.md
+++ b/docs/notes/bugfix-21718.md
@@ -1,0 +1,1 @@
+# Added note about calling mobileSensorAvailable to the mobileCurrentLocation entry


### PR DESCRIPTION
Added note to mobileCurrentLocation's dictionary entry that to use it, mobileSensorAvailable should be called first.