### PR TITLE
[21378] Ensure adding/deleting/moving items does not change the existing itemNames

### DIFF
--- a/extensions/widgets/navbar/navbar.lcb
+++ b/extensions/widgets/navbar/navbar.lcb
@@ -1504,9 +1504,14 @@ private handler navDataDifferent(in pLeft as List, in pRight as List) returns Bo
             return true
         end if
 
-        if pLeft[tIndex]["icon_name"] is not pRIght[tIndex]["icon_name"] then
+        if pLeft[tIndex]["icon_name"] is not pRight[tIndex]["icon_name"] then
             return true
         end if
+
+        if pLeft[tIndex]["name"] is not pRight[tIndex]["name"] then
+            return true
+        end if
+
 
         if pLeft[tIndex]["hilited_icon_name"] is not pRight[tIndex]["hilited_icon_name"] then
             if not (pLeft[tIndex]["hilited_icon_name"] is "" and pRight[tIndex]["hilited_icon_name"] is pRight[tIndex]["icon_name"]) and not (pLeft[tIndex]["hilited_icon_name"] is pLeft[tIndex]["icon_name"] and pRight[tIndex]["hilited_icon_name"] is "") then

--- a/extensions/widgets/navbar/notes/21378.md
+++ b/extensions/widgets/navbar/notes/21378.md
@@ -1,0 +1,1 @@
+# [21378] Ensure adding/deleting/moving items does not change the existing itemNames


### PR DESCRIPTION
`navDataDifferent()` incorrectly returned `false` when changing the name of an item.

Thus `mNavData` was not updated properly, so all the changes in the name(s) were lost and replaced by `new item` when you added/deleted/repositioned an item.

This patch ensures `navDataDifferent()` returns `true` if the name of an item has changed.