### PR TITLE
[21738] Ensure hide with visual effect scroll does actually scroll

### DIFF
--- a/docs/notes/bugfix-21738.md
+++ b/docs/notes/bugfix-21738.md
@@ -1,0 +1,1 @@
+# Ensure hide with visual effect scroll right/left/down/up does the correct effect

--- a/engine/src/stacke.cpp
+++ b/engine/src/stacke.cpp
@@ -758,21 +758,25 @@ Boolean scrolleffect_step(const MCRectangle &drect, MCStackSurface *p_target, MC
 	{
 		case VE_LEFT:
 			width = drect.width * t_position;
+            t_start_dst.origin.x -= width;
 			t_end_dst = MCGRectangleTranslate(t_end_src, t_end_src.size.width - width, 0.0);
 			break;
 			
 		case VE_RIGHT:
 			width = drect.width * t_position;
+            t_start_dst.origin.x += width;
 			t_end_dst = MCGRectangleTranslate(t_end_src, -t_end_src.size.width + width, 0.0);
 			break;
 			
 		case VE_UP:
 			height = drect.height * t_position;
+            t_start_dst.origin.y -= height;
 			t_end_dst = MCGRectangleTranslate(t_end_src, 0.0, t_end_src.size.height - height);
 			break;
 			
 		case VE_DOWN:
 			height = drect.height * t_position;
+            t_start_dst.origin.y += height;
 			t_end_dst = MCGRectangleTranslate(t_end_src, 0.0, -t_end_src.size.height + height);
 			break;
 			
@@ -783,7 +787,7 @@ Boolean scrolleffect_step(const MCRectangle &drect, MCStackSurface *p_target, MC
 	
 	t_end_dst.origin.x += drect.x;
 	t_end_dst.origin.y += drect.y;
-	
+    
 	p_target->Composite(t_start_dst, p_start, t_start_src, 1.0, kMCGBlendModeCopy);
 	p_target->Composite(t_end_dst, p_end, t_end_src, 1.0, kMCGBlendModeCopy);
 	


### PR DESCRIPTION
`t_start_dst` rect was not updated at all so this resulted in the `scroll` visual effect to look like the `wipe` visual effect when hiding objects.