### PR TITLE
[Dictionary] revXMLAttribute to revXMLPreviousSibling

### DIFF
--- a/docs/dictionary/function/revXMLAttribute.lcdoc
+++ b/docs/dictionary/function/revXMLAttribute.lcdoc
@@ -40,7 +40,7 @@ Returns:
 The <revXMLAttribute> <function> returns a <string>.
 
 Description:
-Use the <revXMLAttribute> <function> to get an attribute's value.un
+Use the <revXMLAttribute> <function> to get an attribute's value.
 
 If the <revXMLAttribute> <function> encounters an error, it
 <return|returns> an error message starting with "xmlerr".

--- a/docs/dictionary/function/revXMLAttribute.lcdoc
+++ b/docs/dictionary/function/revXMLAttribute.lcdoc
@@ -27,7 +27,7 @@ put revXMLAttribute(currTree,currNode,the short name of field x) \
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
 function when you created the XML tree.
 
 node:
@@ -54,7 +54,8 @@ If the <revXMLAttribute> <function> encounters an error, it
 > checkbox is checked.
 
 References: function (control structure), revXMLAttributes (function),
-revXMLNodeContents (function), LiveCode custom library (glossary),
+revXMLNodeContents (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), LiveCode custom library (glossary),
 node (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), return (glossary),
 attribute (glossary), XML tree (glossary), string (keyword),

--- a/docs/dictionary/function/revXMLAttribute.lcdoc
+++ b/docs/dictionary/function/revXMLAttribute.lcdoc
@@ -28,7 +28,7 @@ put revXMLAttribute(currTree,currNode,the short name of field x) \
 Parameters:
 treeID:
 The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
-function when you created the XML tree.
+function when you created the <XML tree>.
 
 node:
 The path to the node whose attribute value you want to get.

--- a/docs/dictionary/function/revXMLAttributeValues.lcdoc
+++ b/docs/dictionary/function/revXMLAttributeValues.lcdoc
@@ -27,7 +27,7 @@ get revXMLAttributeValues(thisTree,thisNode,field "Type",comma,2)
 Parameters:
 treeID:
 The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
-function when you created the XML tree.
+function when you created the <XML tree>.
 
 startNode:
 The path to the node where you want to start.

--- a/docs/dictionary/function/revXMLAttributeValues.lcdoc
+++ b/docs/dictionary/function/revXMLAttributeValues.lcdoc
@@ -26,7 +26,7 @@ get revXMLAttributeValues(thisTree,thisNode,field "Type",comma,2)
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
 function when you created the XML tree.
 
 startNode:
@@ -69,6 +69,7 @@ If the <revXMLAttributeValues> <function> encounters an error, it
 > checkbox is checked.
 
 References: function (control structure), revXMLAttributes (function),
+revXMLCreateTree (function), revXMLCreateTreeFromFile (function),
 revXMLMatchingNode (function), value (glossary),
 Standalone Application Settings (glossary),
 standalone application (glossary), XML tree (glossary), return (glossary),

--- a/docs/dictionary/function/revXMLChildContents.lcdoc
+++ b/docs/dictionary/function/revXMLChildContents.lcdoc
@@ -29,8 +29,8 @@ put revXMLChildContents(tTreeId, "root", tab, return, "full", -1) into tChildPat
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 startNode:
 The path to the node where you want to start.
@@ -42,12 +42,13 @@ nodeDelim (string):
 A string that separates each child node from the rest.
 
 includePathDetails:
-The includePathDetails can take the following values:   - "false" : just
-the name of each node is returned (default) - "true" : includes which
-child number each node is in brackets after its name - "full" : the full
-path of each node is returned including child numbers in brackets where
-required - "relative" : a path relative to startNode is included with
-child numbers in brackets where required
+The includePathDetails can take the following values:  
+- "false" : just the name of each node is returned (default)
+- "true" : includes which child number each node is in brackets after its name
+- "full" : the full path of each node is returned including child numbers in brackets 
+where required
+- "relative" : a path relative to startNode is included with child numbers in brackets 
+where required
 
 depth:
 The depth specifies how many generations of the XML tree to show. If you
@@ -85,7 +86,8 @@ string "Text" when called with "root" as the <startNode> and 1 as the
 > checkbox is checked.
 
 References: revXMLAppend (command), function (control structure),
-revXMLAttributes (function), revXMLNumberOfChildren (function),
+revXMLAttributes (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), revXMLNumberOfChildren (function),
 LiveCode custom library (glossary),
 Standalone Application Settings (glossary), tag (glossary),
 standalone application (glossary), return (glossary), XML tree (glossary),

--- a/docs/dictionary/function/revXMLChildNames.lcdoc
+++ b/docs/dictionary/function/revXMLChildNames.lcdoc
@@ -26,8 +26,8 @@ get revXMLChildNames(currTree,line 2 of theNodes,return,"Grass",true)
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 startNode:
 The path to the node whose child nodes you want to list.

--- a/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
+++ b/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
@@ -7,10 +7,12 @@ Syntax: revXMLDataFromXPathQuery(pDocID, pXPathExpression [, charDelimiter [, li
 Summary:
 pDocID is the xml document id returned from one of the revXMLCreate
 functions. The charDelimiter and lineDelimiter both default to cr. If
-neither is specified then the items will be returned one per line: J. K.
-Rowling Harry Potter
-Cory Doctorow
-Little Brother
+neither is specified then the items will be returned one per line.
+For example: 
+
+J. K. Rowling Harry Potter
+
+Cory Doctorow Little Brother
 
 Introduced: 6.5
 
@@ -26,46 +28,39 @@ The revXMLDataFromXPathQuery function returns the data set resulting
 from evaluating the xpath expression against the specified xml tree. For
 instance, given xml data of
 
-&lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
-&lt;bookstore&gt;
-&lt;book category="COOKING"&gt;
-
-    &lt;title lang="en"&gt;Everyday Italian&lt;/title&gt;
-    &lt;author&gt;Giada De Laurentiis&lt;/author&gt;
-    &lt;year&gt;2005&lt;/year&gt;
-    &lt;price&gt;30.00&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="CHILDREN"&gt;
-
-    &lt;title lang="en"&gt;Harry Potter&lt;/title&gt;
-    &lt;author&gt;J K. Rowling&lt;/author&gt;
-    &lt;year&gt;2005&lt;/year&gt;
-    &lt;price&gt;29.99&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="WEB"&gt;
-
-    &lt;title lang="en"&gt;XQuery Kick Start&lt;/title&gt;
-    &lt;author&gt;James McGovern&lt;/author&gt;
-    &lt;author&gt;Per Bothner&lt;/author&gt;
-    &lt;author&gt;Kurt Cagle&lt;/author&gt;
-    &lt;author&gt;James Linn&lt;/author&gt;
-    &lt;author&gt;Vaidyanathan Nagarajan&lt;/author&gt;
-    &lt;year&gt;2003&lt;/year&gt;
-    &lt;price&gt;49.99&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="WEB"&gt;
-
-    &lt;title lang="en"&gt;Learning XML&lt;/title&gt;
-    &lt;author&gt;Erik T. Ray&lt;/author&gt;
-    &lt;year&gt;2003&lt;/year&gt;
-    &lt;price&gt;39,95&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;/bookstore&gt;
-
+    &lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
+        &lt;bookstore&gt;
+            &lt;book category="COOKING"&gt;
+                &lt;title lang="en"&gt;Everyday Italian&lt;/title&gt;
+                &lt;author&gt;Giada De Laurentiis&lt;/author&gt;
+                &lt;year&gt;2005&lt;/year&gt;
+                &lt;price&gt;30.00&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="CHILDREN"&gt;
+                &lt;title lang="en"&gt;Harry Potter&lt;/title&gt;
+                &lt;author&gt;J K. Rowling&lt;/author&gt;
+                &lt;year&gt;2005&lt;/year&gt;
+                &lt;price&gt;29.99&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="WEB"&gt;
+                &lt;title lang="en"&gt;XQuery Kick Start&lt;/title&gt;
+                &lt;author&gt;James McGovern&lt;/author&gt;
+                &lt;author&gt;Per Bothner&lt;/author&gt;
+                &lt;author&gt;Kurt Cagle&lt;/author&gt;
+                &lt;author&gt;James Linn&lt;/author&gt;
+                &lt;author&gt;Vaidyanathan Nagarajan&lt;/author&gt;
+                &lt;year&gt;2003&lt;/year&gt;
+                &lt;price&gt;49.99&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="WEB"&gt;
+                &lt;title lang="en"&gt;Learning XML&lt;/title&gt;
+                &lt;author&gt;Erik T. Ray&lt;/author&gt;
+                &lt;year&gt;2003&lt;/year&gt;
+                &lt;price&gt;39,95&lt;/price&gt;
+            &lt;/book&gt;
+        &lt;/bookstore&gt;
+    &lt;/xml&gt;
+    
 then
 
 put "/bookstore/book/[price&lt;30]/title" into pXPathExpression

--- a/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
+++ b/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
@@ -10,9 +10,13 @@ functions. The charDelimiter and lineDelimiter both default to cr. If
 neither is specified then the items will be returned one per line.
 For example: 
 
-J. K. Rowling Harry Potter
+J. K. Rowling
 
-Cory Doctorow Little Brother
+Harry Potter
+
+Cory Doctorow
+
+Little Brother
 
 Introduced: 6.5
 

--- a/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
+++ b/docs/dictionary/function/revXMLDataFromXPathQuery.lcdoc
@@ -63,8 +63,8 @@ instance, given xml data of
     
 then
 
-put "/bookstore/book/[price&lt;30]/title" into pXPathExpression
-put revXMLDataFromXPathQuery(pDocID, pXPathExpression)
+    put "/bookstore/book/[price&lt;30]/title" into pXPathExpression
+    put revXMLDataFromXPathQuery(pDocID, pXPathExpression)
 
 gives you "Harry Potter"
 

--- a/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
+++ b/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
@@ -6,9 +6,14 @@ Syntax: revXMLEvaluateXPath(pDocID, pXPathExpression [, charDelimiter ] )
 
 Summary:
 The charDelimiter defaults to cr. If not specified then the items will
-be returned one per line: J. K. Rowling
+be returned one per line. For example: 
+
+J. K. Rowling
+
 Harry Potter
+
 Cory Doctorow
+
 Little Brother
 
 Introduced: 6.5
@@ -26,55 +31,50 @@ The revXMLEvaluateXPath function returns the data set resulting from
 evaluating the xpath expression against the specified xml tree. For
 instance, given xml data of
 
-&lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
-&lt;bookstore&gt;
-&lt;book category="COOKING"&gt;
-
-    &lt;title lang="en"&gt;Everyday Italian&lt;/title&gt;
-    &lt;author&gt;Giada De Laurentiis&lt;/author&gt;
-    &lt;year&gt;2005&lt;/year&gt;
-    &lt;price&gt;30.00&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="CHILDREN"&gt;
-
-    &lt;title lang="en"&gt;Harry Potter&lt;/title&gt;
-    &lt;author&gt;J K. Rowling&lt;/author&gt;
-    &lt;year&gt;2005&lt;/year&gt;
-    &lt;price&gt;29.99&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="WEB"&gt;
-
-    &lt;title lang="en"&gt;XQuery Kick Start&lt;/title&gt;
-    &lt;author&gt;James McGovern&lt;/author&gt;
-    &lt;author&gt;Per Bothner&lt;/author&gt;
-    &lt;author&gt;Kurt Cagle&lt;/author&gt;
-    &lt;author&gt;James Linn&lt;/author&gt;
-    &lt;author&gt;Vaidyanathan Nagarajan&lt;/author&gt;
-    &lt;year&gt;2003&lt;/year&gt;
-    &lt;price&gt;49.99&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;book category="WEB"&gt;
-
-    &lt;title lang="en"&gt;Learning XML&lt;/title&gt;
-    &lt;author&gt;Erik T. Ray&lt;/author&gt;
-    &lt;year&gt;2003&lt;/year&gt;
-    &lt;price&gt;39,95&lt;/price&gt;
-
-&lt;/book&gt;
-&lt;/bookstore&gt;
-
+    &lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
+        &lt;bookstore&gt;
+            &lt;book category="COOKING"&gt;
+                &lt;title lang="en"&gt;Everyday Italian&lt;/title&gt;
+                &lt;author&gt;Giada De Laurentiis&lt;/author&gt;
+                &lt;year&gt;2005&lt;/year&gt;
+                &lt;price&gt;30.00&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="CHILDREN"&gt;
+                &lt;title lang="en"&gt;Harry Potter&lt;/title&gt;
+                &lt;author&gt;J K. Rowling&lt;/author&gt;
+                &lt;year&gt;2005&lt;/year&gt;
+                &lt;price&gt;29.99&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="WEB"&gt;
+                &lt;title lang="en"&gt;XQuery Kick Start&lt;/title&gt;
+                &lt;author&gt;James McGovern&lt;/author&gt;
+                &lt;author&gt;Per Bothner&lt;/author&gt;
+                &lt;author&gt;Kurt Cagle&lt;/author&gt;
+                &lt;author&gt;James Linn&lt;/author&gt;
+                &lt;author&gt;Vaidyanathan Nagarajan&lt;/author&gt;
+                &lt;year&gt;2003&lt;/year&gt;
+                &lt;price&gt;49.99&lt;/price&gt;
+            &lt;/book&gt;
+            &lt;book category="WEB"&gt;
+                &lt;title lang="en"&gt;Learning XML&lt;/title&gt;
+                &lt;author&gt;Erik T. Ray&lt;/author&gt;
+                &lt;year&gt;2003&lt;/year&gt;
+                &lt;price&gt;39,95&lt;/price&gt;
+            &lt;/book&gt;
+        &lt;/bookstore&gt;
+    &lt;/xml&gt;
+    
 then
 
-put "/bookstore/book/[price&lt;40]/" into pXPathExpression
-put revXMLEvaluateXPath(pDocID, pXPathExpression)
+    put "/bookstore/book/[price&lt;40]/" into pXPathExpression
+    put revXMLEvaluateXPath(pDocID, pXPathExpression)
 
 gives you 
 
 bookstore/book[1]
+
 bookstore/book[2]
+
 bookstore/book[4]
 
 References: revXMLCreateTreeFromFile (function),

--- a/docs/dictionary/function/revXMLFirstChild.lcdoc
+++ b/docs/dictionary/function/revXMLFirstChild.lcdoc
@@ -36,8 +36,8 @@ The <revXMLFirstChild> <function> returns a <string> consisting of the
 path to the first child node.
 
 Description:
-Use the <revXMLFirstChild> <function> to begin scanning the <child
-node|child nodes> of a <parent node>.
+Use the <revXMLFirstChild> <function> to begin scanning the 
+<child node|child nodes> of a <parent node>.
 
 If the <revXMLFirstChild> <function> encounters an error, it
 <return|returns> an error message starting with "xmlerr".

--- a/docs/dictionary/function/revXMLNextSibling.lcdoc
+++ b/docs/dictionary/function/revXMLNextSibling.lcdoc
@@ -26,8 +26,8 @@ put revXMLNextSibling(the currTree of me,thisNode) into nextNode
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 siblingNode:
 The path to the node where you want to start.
@@ -62,7 +62,8 @@ If the <revXMLNextSibling> <function> encounters an error, it
 > checkbox is checked.
 
 References: function (control structure), revXMLRootNode (function),
-revXMLFirstChild (function), LiveCode custom library (glossary),
+revXMLFirstChild (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), LiveCode custom library (glossary),
 sibling node (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), return (glossary),
 child node (glossary), XML library (library), nodes (property)

--- a/docs/dictionary/function/revXMLNextSibling.lcdoc
+++ b/docs/dictionary/function/revXMLNextSibling.lcdoc
@@ -5,8 +5,8 @@ Type: function
 Syntax: revXMLNextSibling(<treeID>, <siblingNode>, [incText] )
 
 Summary:
-<return|Returns> the path to a <child node|child node's> next <sibling
-node>. 
+<return|Returns> the path to a <child node|child node's> next 
+<sibling node>. 
 
 Associations: xml library
 

--- a/docs/dictionary/function/revXMLNodeContents.lcdoc
+++ b/docs/dictionary/function/revXMLNodeContents.lcdoc
@@ -5,8 +5,8 @@ Type: function
 Syntax: revXMLNodeContents(<treeID>, <node>)
 
 Summary:
-<return|Returns> the text contained in the specified <node> in an <XML
-tree>. 
+<return|Returns> the text contained in the specified <node> in an 
+<XML tree>. 
 
 Associations: xml library
 
@@ -26,8 +26,8 @@ put revXMLNodeContents(thisDoc,mySection) into field "Current Section"
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 node:
 The path to the node whose contents you want to get.
@@ -60,8 +60,9 @@ string "Text" when called with "root" as the <node>.
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), revXMLAppend (command),
-function (control structure), revXMLAttribute (function), node (glossary),
-Standalone Application Settings (glossary),
+function (control structure), revXMLAttribute (function), 
+revXMLCreateTree (function), revXMLCreateTreeFromFile (function), 
+node (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), XML tree (glossary), return (glossary),
 LiveCode custom library (glossary), string (keyword),
 XML library (library)

--- a/docs/dictionary/function/revXMLParent.lcdoc
+++ b/docs/dictionary/function/revXMLParent.lcdoc
@@ -54,7 +54,7 @@ If the <revXMLParent> <function> encounters an error, it
 
 References: function (control structure), revXMLRootNode (function),
 revXMLFirstChild (function), revXMLCreateTree (function),
-revXMLCreateFromTree (function), LiveCode custom library (glossary),
+revXMLCreateTreeFromFile (function), LiveCode custom library (glossary),
 node (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), return (glossary), XML tree (glossary),
 parent node (glossary), XML library (library)

--- a/docs/dictionary/function/revXMLParent.lcdoc
+++ b/docs/dictionary/function/revXMLParent.lcdoc
@@ -5,8 +5,8 @@ Type: function
 Syntax: revXMLParent(<treeID>, <childNode>)
 
 Summary:
-<return|Returns> the path to the <parent node> of a <node> in an <XML
-tree>. 
+<return|Returns> the path to the <parent node> of a <node> in an 
+<XML tree>. 
 
 Associations: xml library
 
@@ -26,8 +26,8 @@ put revXMLParent(thisTree,thisNode) into field "Parent"
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 childNode:
 The path to the node where you want to start.
@@ -53,7 +53,8 @@ If the <revXMLParent> <function> encounters an error, it
 > checkbox is checked.
 
 References: function (control structure), revXMLRootNode (function),
-revXMLFirstChild (function), LiveCode custom library (glossary),
+revXMLFirstChild (function), revXMLCreateTree (function),
+revXMLCreateFromTree (function), LiveCode custom library (glossary),
 node (glossary), Standalone Application Settings (glossary),
 standalone application (glossary), return (glossary), XML tree (glossary),
 parent node (glossary), XML library (library)

--- a/docs/dictionary/function/revXMLPreviousSibling.lcdoc
+++ b/docs/dictionary/function/revXMLPreviousSibling.lcdoc
@@ -25,8 +25,8 @@ put revXMLPreviousSibling(myDoc,thisNode) into thisNode
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 siblingNode:
 The path to the node where you want to start.
@@ -61,7 +61,8 @@ If the <revXMLPreviousSibling> <function> encounters an error, it
 > checkbox is checked.
 
 References: function (control structure), revXMLRootNode (function),
-revXMLFirstChild (function), LiveCode custom library (glossary),
+revXMLFirstChild (function), revXMLCreateTree (function),
+revXMLCreateTreeFromFile (function), LiveCode custom library (glossary),
 Standalone Application Settings (glossary), return (glossary),
 standalone application (glossary), XML library (library),
 nodes (property)


### PR DESCRIPTION
function/revXMLAttribute.lcdoc - Removed extraneous text. Added references and created links for related text.
function/revXMLAttributeValues.lcdoc - Added references and created links for related text.
function/revXMLChildContents.lcdoc - Formatted unordered list. Added references and created links from related text.
function/revXMLChildNames.lcdoc - Added references and created links from related text.
function/revXMLDataFromXPathQuery.lcdoc - Formatted various pieces of text.
function/revXMLEvaluateXPath.lcdoc - Formatted various piece of text.
function/revXMLFirstChild.lcdoc - Fixed broken link.
function/revXMLNextSibling.lcdoc - Fixed broken link. Added references and created links for related text.
function/revXMLNodeContents.lcdoc - Fixed broken link. Added references and created links for related text.
function/revXMLParent.lcdoc - Fixed broken link. Added references and created link for related text.
function/revXMLPreviousSibling.lcdoc - Added references and created links for related text.
