### PR TITLE
[[ Bug 21674 ]] Apply redirect to resource path on macOS

### DIFF
--- a/docs/notes/bugfix-21674.md
+++ b/docs/notes/bugfix-21674.md
@@ -1,0 +1,1 @@
+# Ensure extension resources are found in macOS standalones

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -888,7 +888,7 @@ static bool MCS_file_exists_at_path(MCStringRef p_path)
 //   the path is taken to be a directory and is always redirected if is within
 //   Contents/MacOS. If p_is_file is true, then the file is only redirected if
 //   the original doesn't exist, and the redirection does.
-static bool MCS_apply_redirect(MCStringRef p_path, bool p_is_file, MCStringRef& r_redirected)
+bool MCS_apply_redirect(MCStringRef p_path, bool p_is_file, MCStringRef& r_redirected)
 {
     // If the original file exists, do nothing.
     if (p_is_file && MCS_file_exists_at_path(p_path))

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -446,6 +446,16 @@ bool MCStandaloneCapsuleCallback(void *p_self, const uint8_t *p_digest, MCCapsul
             }
             else
                 t_resolved_path = *t_resources_path;
+            
+#ifdef _MACOSX
+            // As we are in a standalone we need to redirect the path on macOS to Resources/_MacOS
+            extern bool MCS_apply_redirect(MCStringRef p_path, bool p_is_file, MCStringRef& r_redirected);
+            MCAutoStringRef t_redirected_path;
+            if (MCS_apply_redirect(*t_resolved_path, false, &t_redirected_path))
+            {
+                t_resolved_path.Reset(*t_redirected_path);
+            }
+#endif
         }
         
         extern void MCEngineAddExtensionsFromModulesArray(MCAutoScriptModuleRefArray&, MCStringRef, MCStringRef&);


### PR DESCRIPTION
This patch ensures that `my resources folder` will return a path that has
had the redirect applied to it in macOS standalones where non-executable
paths are redirected from `Contents/MacOS/*` to `Contents/Resources/_MacOS/*`.