### PR TITLE
[Dictionary] revXMLPutIntoNode to RTFText

### DIFF
--- a/docs/dictionary/command/revXMLPutIntoNode.lcdoc
+++ b/docs/dictionary/command/revXMLPutIntoNode.lcdoc
@@ -25,8 +25,8 @@ revXMLPutIntoNode myCurrentNode,dataPaths["current"],field "Data", true
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 nodePath:
 The path to the node whose contents you want to set.
@@ -66,7 +66,8 @@ the <node|node's> start and end <tag|tags>.
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), revXMLAppend (command),
-result (function), uniDecode (function), XML tree (glossary),
+result (function), uniDecode (function), revXMLCreateTree (function), 
+revXMLCreateTreeFromFile (function), XML tree (glossary),
 Standalone Application Settings (glossary), tag (glossary),
 standalone application (glossary), Unicode (glossary), node (glossary),
 command (glossary), LiveCode custom library (glossary),

--- a/docs/dictionary/command/revXMLSetAttribute.lcdoc
+++ b/docs/dictionary/command/revXMLSetAttribute.lcdoc
@@ -55,8 +55,7 @@ If the attribute already exists, its value is set to the <newValue>.
 > <uniDecode> function to encode the text as UTF-8:
 
     revXMLSetAttribute myTree,the nodeName of me, \
-
-    uniDecode(the unicodeText of it,"UTF8")
+          uniDecode(the unicodeText of it,"UTF8")
 
 
 >*Important:*  The <revXMLSetAttribute> <command> is part of the 

--- a/docs/dictionary/command/revZipCloseArchive.lcdoc
+++ b/docs/dictionary/command/revZipCloseArchive.lcdoc
@@ -23,11 +23,9 @@ revZipCloseArchive the cArchive of me
 
 Parameters:
 archivePath:
-The absolute path to the zip archive to close. >*Note:* Any changes you
-make to an open zip archive will not be applied until you close the
-archive using this command. If revZipCloseArchive encounters an error,
-the result is set to an error code beginning with "ziperr", otherwise
-the result will be empty.
+The absolute path to the zip archive to close. 
+>*Note:* Any changes you make to an open zip archive will not be 
+>applied until you close the archive using this command. 
 
 The result:
 If <revZipCloseArchive> encounters an error, the result is set to an

--- a/docs/dictionary/command/revZipExtractItemToVariable.lcdoc
+++ b/docs/dictionary/command/revZipExtractItemToVariable.lcdoc
@@ -35,8 +35,8 @@ otherwise the result will be empty.
 Description:
 Use the <revZipExtractItemToVariable> command to load an item from a zip
 archive into memory as a variable in your LiveCode program. The archive
-must already have been opened by using the <revZipOpenArchive
-(command)>command. 
+must already have been opened by using the <revZipOpenArchive (command)> 
+command. 
 
 References: revZipOpenArchive (command),
 revZipExtractItemToFile (command), revZipEnumerateItems (function)

--- a/docs/dictionary/command/rotate.lcdoc
+++ b/docs/dictionary/command/rotate.lcdoc
@@ -62,9 +62,8 @@ the <angle> <property> affects only the screen display of the
 <image(keyword)>, not the actual picture data in it, so setting it
 repeatedly does not introduce distortion.
 
-    >*Note:*Rotating an image using good or best <resizeQuality> might
-    > cause the mask to be promoted to an alpha channel.
-
+>*Note:*Rotating an image using good or best <resizeQuality> might
+> cause the mask to be promoted to an alpha channel.
 
 >*Note:* As rotate is an image editing operation, the target image needs
 > to be on the currently visible card of an open stack to function.

--- a/docs/dictionary/function/revXMLRPC_GetHost.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetHost.lcdoc
@@ -28,8 +28,8 @@ The number returned by the <revXMLRPC_CreateRequest> when you created the
 executed an <XML-RPC> request.
 
 Returns (string):
-The <revXMLRPC_GetHost> <function> returns the <IP address> or <domain
-name> of the <host> that is the target of the <XML-RPC document>.
+The <revXMLRPC_GetHost> <function> returns the <IP address> or 
+<domain name> of the <host> that is the target of the <XML-RPC document>.
 
 Description:
 Use the <revXMLRPC_GetHost> <function> to retrieve the host that is the

--- a/docs/dictionary/function/revXMLRPC_GetPath.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetPath.lcdoc
@@ -29,8 +29,8 @@ executed an <XML-RPC> request.
 
 Returns (string):
 The <revXMLRPC_GetPath> <function> returns the <file path>, which allows
-the <host> to determine which resource is the target of the <XML-RPC
-document>.
+the <host> to determine which resource is the target of the 
+<XML-RPC document>.
 
 Description:
 Use the <revXMLRPC_GetPath> <function> to retrieve the path that is the

--- a/docs/dictionary/function/revXMLRPC_GetSocket.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetSocket.lcdoc
@@ -28,9 +28,9 @@ executed an <XML-RPC> request.
 
 Returns (string):
 The <revXMLRPC_GetSocket> <function> returns the socket connection that
-is established with the <host>. By default, <XML-RPC> uses the <post
-command> to execute an <XML-RPC> request, but this has the overhead of
-opening and closing a new socket every time. You can avoid this by
+is established with the <host>. By default, <XML-RPC> uses the 
+<post command> to execute an <XML-RPC> request, but this has the overhead 
+of opening and closing a new socket every time. You can avoid this by
 re-using an already opened <socket>.
 
 Description:

--- a/docs/dictionary/function/revXMLRootNode.lcdoc
+++ b/docs/dictionary/function/revXMLRootNode.lcdoc
@@ -25,8 +25,8 @@ put revXMLRootNode(thisTree) into myStartNode
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 Returns:
 The <revXMLRootNode> <function> returns a node path.
@@ -51,6 +51,7 @@ If the <revXMLRootNode> <function> encounters an error, it
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), function (control structure),
+revXMLCreateFile (function), revXMLCreateFileFromTree (function),
 revXMLNextSibling (function), revXMLPreviousSibling (function),
 revXMLParent (function), revXMLFirstChild (function),
 Standalone Application Settings (glossary), root node (glossary),

--- a/docs/dictionary/function/revXMLText.lcdoc
+++ b/docs/dictionary/function/revXMLText.lcdoc
@@ -46,8 +46,8 @@ Returns:
 The <revXMLText> function returns XML text.
 
 Description:
-Use the <revXMLText> <function> to turn an <XML tree> back into an <XML
-document>. 
+Use the <revXMLText> <function> to turn an <XML tree> back into an 
+<XML document>. 
 
 If the <revXMLText> <function> encounters an error, it <return|returns>
 an error message starting with "xmlerr".

--- a/docs/dictionary/function/revXMLTrees.lcdoc
+++ b/docs/dictionary/function/revXMLTrees.lcdoc
@@ -28,8 +28,8 @@ The <revXMLTrees> <function> returns a list of tree IDs, one per <line>.
 
 Description:
 Use the <revXMLTrees> <function> to find out which <XML tree|XML trees>
-have been created, or when you want to perform an action on all the <XML
-tree|XML trees> you're working with.
+have been created, or when you want to perform an action on all the 
+<XML tree|XML trees> you're working with.
 
 Each tree ID is the number returned by the <revXMLCreateTree> or
 <revXMLCreateTreeFromFile> <function> when you created the <XML tree>.

--- a/docs/dictionary/function/revXMLValidateDTD.lcdoc
+++ b/docs/dictionary/function/revXMLValidateDTD.lcdoc
@@ -32,8 +32,8 @@ DTDText:
 A Document Type Definition.
 
 Returns:
-The <revXMLValidateDTD> <function> <return|returns> empty if the <XML
-tree> validates against the DTD.
+The <revXMLValidateDTD> <function> <return|returns> empty if the 
+<XML tree> validates against the DTD.
 
 Description:
 Use the <revXMLValidateDTD> <function> to <validate> an <XML tree>

--- a/docs/dictionary/property/RTFText.lcdoc
+++ b/docs/dictionary/property/RTFText.lcdoc
@@ -52,12 +52,13 @@ Paragraphs with a non-empty listStyle are appropriately marked in
 and also with the new listtable tags.
 
 By using both sets of tags a reasonable degree of interoperability is
-> achieved with both TextEdit (and other Cocoa applications) on Mac, and
-> Word and WordPad on Windows.
+achieved with both TextEdit (and other Cocoa applications) on Mac, and
+Word and WordPad on Windows.
 >*Note:* Unfortunately, OpenOffice does not have particularly good rtf
 > import / export capabilities (it doesn't even round-trip correctly
 > through itself!) and thus copying / pasting of lists between LiveCode
 > and OpenOffice will not work reliably or correctly.
+
 >*Important:* Because the RTF standard does not include the box,
 > threeDbox, and link styles supported by LiveCode, the <RTFText>
 > property does not necessarily include all information necessary to
@@ -66,7 +67,7 @@ By using both sets of tags a reasonable degree of interoperability is
 > htmlTextproperty instead.
 
 For technical information about the RTF format, see the article at
-&lt;http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp&gt;. 
+[http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp]. 
 
 References: charToNum (function), format (glossary), RTF (glossary),
 field (keyword), HTMLText (property), foregroundColor (property),

--- a/docs/dictionary/property/right.lcdoc
+++ b/docs/dictionary/property/right.lcdoc
@@ -37,11 +37,12 @@ Description:
 Use the <right> <property> to change the horizontal placement of a
 <control> or window.
 
-The <right> of a <stack> is in <absolute (screen)
-coordinates(glossary)>. The <right> of a <card> is always the width of
-the <stack window>; setting the <right> of a <card> does not cause a
-<error|script error>, but it has no effect. The <right> of a <group> or
-<control> is in <relative (window) coordinates(glossary)>.
+The <right> of a <stack> is in 
+<absolute coordinates|absolute (screen) coordinates>. The <right> of a 
+<card> is always the width of the <stack window>; setting the <right> of 
+a <card> does not cause a <error|script error>, but it has no effect. 
+The <right> of a <group> or <control> is in 
+<relative coordinates|relative (window) coordinates>.
 
 Changing the <right> of an <object(glossary)> shifts it to the new
 position without resizing it. To change an <object|object's> width, set

--- a/docs/dictionary/property/roundRadius.lcdoc
+++ b/docs/dictionary/property/roundRadius.lcdoc
@@ -35,13 +35,13 @@ If the graphic's style <property> is not "roundRect", the setting of
 this <property> has no effect.
 
 The global setting of the <roundRadius> <property> <control|controls>
-the appearance of round rectangles drawn with the <roundRect> <paint
-tool>. Once a paint rounded rectangle is drawn, its appearance cannot be
-changed by changing the <global> <roundRadius> <property>.
+the appearance of round rectangles drawn with the <roundRect> 
+<paint tool>. Once a paint rounded rectangle is drawn, its appearance 
+cannot be changed by changing the <global> <roundRadius> <property>.
 
-References: global (command), property (glossary),
+References: global (command), control (glossary), property (glossary),
 non-negative (glossary), paint tool (glossary), roundRect (keyword),
-integer (keyword), graphic (keyword), control (object),
+integer (keyword), graphic (keyword),
 roundEnds (property), pixels (property)
 
 Tags: ui

--- a/docs/dictionary/property/rowDelimiter.lcdoc
+++ b/docs/dictionary/property/rowDelimiter.lcdoc
@@ -11,7 +11,8 @@ Specifies the <character|character(s)> used to separate rows in a
 string. 
 
 Introduced: 2.8.1
-Changed:7.0.0
+
+Changed: 7.0.0
 
 OS: mac, windows, linux, ios, android
 


### PR DESCRIPTION
command/revXMLPutIntoNode.lcdoc - Added references.
function/revXMLRootNode.lcdoc - Added references.
function/revXMLRPC_GetHost.lcdoc - Fixed broken link.
function/revXMLRPC_GetPath.lcdoc - Fixed broken link.
function/revXMLRPC_GetSocket.lcdoc - Fixed broken link.
command/revXMLSetAttribute.lcdoc - Formatted code example.
function/revXMLText.lcdoc - Fixed broken link.
function/revXMLTrees.lcdoc - Fixed broken link.
function/revXMLValidateDTD.lcdoc - Fixed broken link.
command/revZipCloseArchive.lcdoc - Formatting on note, removed duplicated information.
command/revZipExtractItemToVariable.lcdoc - Fixed broken link.
property/right.lcdoc - Fixed broken links.
command/rotate.lcdoc - Removed out of place indents from note.
property/roundRadius.lcdoc - Fixed broken link. Change type of reference to find an entry that exists.
property/RTFText.lcdoc - Better formatted section with notes. Made external link into an external link.