### PR TITLE
[21168] Ensure path to MacOS app icon is always resolved

### DIFF
--- a/docs/notes/bugfix-21168.md
+++ b/docs/notes/bugfix-21168.md
@@ -1,0 +1,1 @@
+# Ensure path to MacOS app icon is always resolved

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -627,7 +627,7 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder, @xStandalonePa
    
    -- OK-2008-03-24 : Bug 6171. Restructured a little to ensure that the icon can be either relative or absolute.
    -- If the icon cannot be found at the exact location, assume its relative to the stack and put the stack path before it.
-   if there is no file sStandaloneSettingsA["OSX,iconFile"] and sStandaloneSettingsA["OSX,iconFile"] is not empty then
+   if not (sStandaloneSettingsA["OSX,iconFile"] begins with "/") and sStandaloneSettingsA["OSX,iconFile"] is not empty then
       put tStackPath & "/" before sStandaloneSettingsA["OSX,iconFile"]
    end if
    
@@ -704,7 +704,7 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder, @xStandalonePa
       
       -- Add a random uuid to use in the executable's uuid load command.
       put uuid() into tDeployInfo["uuid"]
-
+      
       revStandaloneDeployWithParams tTarget, tStackSourceFile, tDeployInfo
       
       -- Make sure we finish off the bundle contents

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -627,8 +627,12 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder, @xStandalonePa
    
    -- OK-2008-03-24 : Bug 6171. Restructured a little to ensure that the icon can be either relative or absolute.
    -- If the icon cannot be found at the exact location, assume its relative to the stack and put the stack path before it.
-   if not (sStandaloneSettingsA["OSX,iconFile"] begins with "/") and sStandaloneSettingsA["OSX,iconFile"] is not empty then
-      put tStackPath & "/" before sStandaloneSettingsA["OSX,iconFile"]
+   if sStandaloneSettingsA["OSX,iconFile"] is not empty then
+      if there is no file sStandaloneSettingsA["OSX,iconFile"] or \
+            (the folder is tStackPath and \
+            there is a file (the folder & "/" & sStandaloneSettingsA["OSX,iconFile"])) then
+         put tStackPath & "/" before sStandaloneSettingsA["OSX,iconFile"]
+      end if
    end if
    
    -- If the icon cannot be found (and we are building for OS X and its not empty) then add a warning.


### PR DESCRIPTION
Previously if `the defaultFolder` was set to the folder containing the stack, and the app icon was set to an icon in this folder, then the `sStandaloneSettingsA["OSX,iconFile"]` contained the relative path to the icon (e.g. `myIcon.icn`).

In this case the check `if there is no file sStandaloneSettingsA["OSX,iconFile"] ` returned false, thus the full path was never resolved, so `sStandaloneSettingsA["OSX,iconFile"]` was referencing an icon that could not be found.

This patch ensures that `sStandaloneSettingsA["OSX,iconFile"]` will always be able to resolve the full path to the icon file, regardless of the value of `the defaultFolder`