### PR TITLE
[Dictionary] save to serialControlString

### DIFF
--- a/docs/dictionary/command/save.lcdoc
+++ b/docs/dictionary/command/save.lcdoc
@@ -57,14 +57,14 @@ of that stack are also saved in the same <file>, and if you save a
 If the stack has not yet been saved and doesn't have a filename, you
 must use the `as` form.
 
-You cannot save to a standalone application's file; <standalone
-application|standalones> are read-only.
+You cannot save to a standalone application's file; 
+<standalone application|standalones> are read-only.
 
 The <save> command can save the <stack> in several different versions of
 the LiveCode stack file format.
 
 * If you use the `with newest format` form of the <save> command, the
-  <stack> is saved using the newest <stack version>
+  <stack> is saved using the newest <stack version>.
 * If you use the `with format` form of the <save> command, the
   <stackFormat> should be the particular <stack version> you want the
   stack to be saved as.

--- a/docs/dictionary/command/secure-socket.lcdoc
+++ b/docs/dictionary/command/secure-socket.lcdoc
@@ -78,9 +78,10 @@ it).
 
 References: open socket (command),
 Standalone Application Settings (glossary), command (glossary),
-LiveCode custom library (glossary), SSL & Encryption library (library),
-message (glossary), socketError (message),
-property (glossary), sslCertificates (property)
+LiveCode custom library (glossary), 
+standalone application (glossary), SSL & Encryption library (library), 
+message (glossary), socketError (message), property (glossary), 
+sslCertificates (property)
 
 Tags: file system
 

--- a/docs/dictionary/command/select.lcdoc
+++ b/docs/dictionary/command/select.lcdoc
@@ -9,9 +9,9 @@ Syntax: select empty
 Syntax: select <objectList>
 
 Summary:
-<select|Selects> part of the text of a <field>, or places the <insertion
-point> in a <field>, or removes the <insertion point>, or
-<select|Selects> one or more <object|objects>.
+<select|Selects> part of the text of a <field>, or places the 
+<insertion point> in a <field>, or removes the <insertion point>, 
+or <select|Selects> one or more <object|objects>.
 
 Introduced: 1.0
 

--- a/docs/dictionary/command/send-to-program.lcdoc
+++ b/docs/dictionary/command/send-to-program.lcdoc
@@ -61,8 +61,8 @@ is used.
 
 For more information about Apple events, see Apple Computer's technical
 documentation, Inside Macintosh: Interapplication Communication, located
-at <a
-href="http://developer.apple.com/techpubs/mac/IAC/IAC-2.html">http://developer.apple.com/techpubs/mac/IAC/IAC-2.html</a>. 
+at [Apple's developer site]
+(https://developer.apple.com/library/archive/documentation/mac/IAC/IAC-2.html). 
 
 References: request (command), reply (command),
 request appleEvent (command), function (control structure),

--- a/docs/dictionary/function/screenDepth.lcdoc
+++ b/docs/dictionary/function/screenDepth.lcdoc
@@ -22,9 +22,8 @@ Example:
 if the screenDepth &gt; 8 then show image "Photograph"
 
 Returns:
-The <screenDepth> <function> <return|returns> 0, 1, 2, 4, 8, 16, 24, or
-
-32. 
+The <screenDepth> <function> <return|returns> 0, 1, 2, 4, 8, 16, 24, 
+or 32. 
 
 
 Description:

--- a/docs/dictionary/function/selectedLoc.lcdoc
+++ b/docs/dictionary/function/selectedLoc.lcdoc
@@ -27,8 +27,8 @@ The <selectedLoc> <function> <return|returns> two positive
 <integer|integers> separated by a comma.
 
 Description:
-Use the <selectedLoc> <function> to determine the location in the <stack
-window> where the text <selection> appears.
+Use the <selectedLoc> <function> to determine the location in the 
+<stack window> where the text <selection> appears.
 
 When text is selected, a box around it is filled with the hiliteColor or
 <hilitePattern>. The first <item> of the <return value> is the

--- a/docs/dictionary/message/scrollbarPageDec.lcdoc
+++ b/docs/dictionary/message/scrollbarPageDec.lcdoc
@@ -27,8 +27,8 @@ The new position of the scrollbar thumb.
 
 Description:
 Handle the <scrollbarPageDec> <message> if you want to respond to the
-user clicking in the gray region above or to the left of the <scrollbar
-thumb>. 
+user clicking in the gray region above or to the left of the 
+<scrollbar thumb>. 
 
 Dragging the scrollbar thumb does not send a <scrollbarPageDec>
 <message>. 

--- a/docs/dictionary/message/scrollbarPageInc.lcdoc
+++ b/docs/dictionary/message/scrollbarPageInc.lcdoc
@@ -28,8 +28,8 @@ The new position of the scrollbar thumb.
 
 Description:
 Handle the <scrollbarPageInc> <message> if you want to respond to the
-user clicking in the gray region below or to the right of the <scrollbar
-thumb>. 
+user clicking in the gray region below or to the right of the 
+<scrollbar thumb>. 
 
 Dragging the scrollbar thumb does not send a <scrollbarPageInc>
 <message>. 

--- a/docs/dictionary/message/searchKey.lcdoc
+++ b/docs/dictionary/message/searchKey.lcdoc
@@ -23,8 +23,8 @@ Description:
 Handle the <searchKey> message to perform an action when the search
 button is pressed.
 
-The <searchKey> message is sent to the current card of the <default
-stack> when the hardware search button is pressed.
+The <searchKey> message is sent to the current card of the 
+<default stack> when the hardware search button is pressed.
 
 References: backKey (message), menuKey (message),
 default stack (property)

--- a/docs/dictionary/property/screenMouseLoc.lcdoc
+++ b/docs/dictionary/property/screenMouseLoc.lcdoc
@@ -21,16 +21,16 @@ set the screenMouseLoc to the topLeft of this stack
 
 Value:
 The <screenMouseLoc> consists of two <integer|integers>, separated by a
-comma. It reports the position of the <mouse pointer> in <absolute
-coordinates>--that is, relative to the top left of the main screen. (The
-<mouseLoc> <function> is similar, but its coordinates are relative to
-the <defaultStack> window rather than the screen.) If you set this
-property, the mouse pointer is moved to the specified location on the
-screen. 
+comma. It reports the position of the <mouse pointer> in 
+<absolute coordinates>--that is, relative to the top left of the main 
+screen. (The <mouseLoc> <function> is similar, but its coordinates are 
+relative to the <defaultStack> window rather than the screen.) If you set 
+this property, the mouse pointer is moved to the specified location on 
+the screen. 
 
 Description:
-Use the <screenMouseLoc> <property> to find out where the <mouse
-pointer> is, or to change the location of the <mouse pointer>.
+Use the <screenMouseLoc> <property> to find out where the 
+<mouse pointer> is, or to change the location of the <mouse pointer>.
 
 >*Important:*  Taking over the position of the <mouse pointer> can
 > disorient and confuse users, and <user interface|user-interface>

--- a/docs/dictionary/property/secureMode.lcdoc
+++ b/docs/dictionary/property/secureMode.lcdoc
@@ -23,8 +23,8 @@ By default, the <secureMode> <property> is set to false.
 
 Description:
 Use the <secureMode> <property> to lock down <file> access in situations
-where security is required: for example, for a kiosk application or <web
-server>. 
+where security is required: for example, for a kiosk application or 
+<web server>. 
 
 If the <secureMode> <property> is set to true, the <application> cannot
 use the <get>, <put>, <open file>, <read from file>, or <write to file>

--- a/docs/dictionary/property/serialControlString.lcdoc
+++ b/docs/dictionary/property/serialControlString.lcdoc
@@ -51,9 +51,9 @@ the desired settings. Then open the serial <port> using the <open file>
 
 On Mac OS systems, the <serialControlString> <property> can be used to
 set the printer or modem <port|ports>. On <Windows|Windows systems>, the
-<serialControlString> can be used to set the COM <port|ports>. On <OS
-X|OS X systems>, the <serialControlString> can be used to set a serial
-<peripheral device|device> returned by the <driverNames> function.
+<serialControlString> can be used to set the COM <port|ports>. On 
+<OS X|OS X systems>, the <serialControlString> can be used to set a 
+serial <peripheral device|device> returned by the <driverNames> function.
 
 The format of the <serialControlString> is compatible with the extended
 MS-DOS "mode" command.
@@ -61,8 +61,8 @@ MS-DOS "mode" command.
 References: close file (command), open driver (command),
 open file (command), driverNames (function), property (glossary),
 OS X (glossary), sign (glossary), Windows (glossary), port (glossary),
-command (glossary), peripheral device (glossary), modem: (keyword),
-COMn: (keyword)
+command (glossary), 
+peripheral device (glossary), modem: (keyword), COMn: (keyword)
 
 Tags: networking
 


### PR DESCRIPTION
command/save.lcdoc  - Fixed broken link.
function/screenDepth.lcdoc - Removed excess newlines in the middle of returns text.
property/screenMouseLoc.lcdoc - Fixed broken links.
message/scrollbarPageDec.lcdoc - Fixed broken link.
message/scrollbarPageInc.lcdoc - Fixed broken link.
message/searchKey.lcdoc - Fixed broken link.
command/secure-socket.lcdoc - Added reference to fix broken link.
property/secureMode.lcdoc - Fixed broken link.
command/select.lcdoc - Fixed broken link.
function/selectedLoc.lcdoc - Fixed broken link.
command/send-to-program.lcdoc - Replaced external link as the old one can’t be found anymore. Format is in line with the change to request (command).
property/serialControlString.lcdoc - Fixed broken link. Rearranged references as it seems like being first on a line is a problem for those with colons in their name.