### PR TITLE
[21765] Fix problem when 'adb devices' finds no serial number

### DIFF
--- a/docs/notes/bugfix-21765.md
+++ b/docs/notes/bugfix-21765.md
@@ -1,0 +1,1 @@
+# Ensure Android standalones can be installed in devices with no serial number returned by `adb devices`

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -150,6 +150,9 @@ on androidDevicesChanged
    
    put empty into sAvailableDevices
    repeat for each line tDevice in tDevices
+      if tDevice contains "no serial number" then
+         put quote&quote into word 1 to -2 of tDevice
+      end if
       put word 2 of tDevice into sAvailableDevices[word 1 of tDevice]
    end repeat
    


### PR DESCRIPTION
In some cases (hopefully rare) the `adb devices` command does not output the serial number of the connected Android device. Instead, it outputs:

`(no serial number)  device`

This happens with e.g. the tablet Fusion5_F704B. 

The S/B expects something like the following:

`FA74V0T02098	device`

So in these cases the S/B is confused and the android standalone cannot be installed.

This patch fixes the problem by replacing `(no serial number)` with `""` in the device list, as the shell command that installs the .apk to the device ('adb install ...') can work with an empty device identifier as well.