### PR TITLE
[Bugfix 21770] Fix reference errors in URL entry

### DIFF
--- a/docs/dictionary/keyword/URL.lcdoc
+++ b/docs/dictionary/keyword/URL.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: URL
 
 Summary:
-Designates a <container> consisting of an Internet <resource> or <local
-file> in the form of a <URL(glossary)>.
+Designates a <container> consisting of an Internet <resource> or 
+<local file> in the form of a <URL(glossary)>.
 
 Introduced: 1.0
 
@@ -46,8 +46,8 @@ on textRead
 end textRead
 
 Description:
-Use the <URL(keyword)> <keyword> to access the contents of a <local
-file> or a <file(glossary)> accessible on the Web.
+Use the <URL(keyword)> <keyword> to access the contents of a 
+<local file> or a <file(glossary)> accessible on the Web.
 
 A <URL(keyword)> is a method of designating a <file(glossary)> or other
 <resource>. You can use a <URL(keyword)> like any other <container>. You
@@ -75,17 +75,15 @@ schemes>, see [RFC 1630](https://tools.ietf.org/html/rfc1630).
 >*Important:*  The <http>, <ftp> and <https> <keyword|keywords> are
 > part 
 > of the <Internet library> on desktop <platform|platforms>. To ensure 
-> that the <keyword|keywords> work in a desktop <standalone
-> application>, 
-> you must include this <LiveCode custom library|custom library> when 
-> you create your <standalone application|standalone>. In the
-> Inclusions 
+> that the <keyword|keywords> work in a desktop 
+> <standalone application>,  you must include this 
+> <LiveCode custom library|custom library> when you create your 
+> <standalone application|standalone>. In the Inclusions 
 > pane of the <Standalone Application Settings> window, make sure the 
 > "Internet" script library is selected.
 
 >*Cross-platform note:* On iOS and Android, you can use the <http>,
-> <ftp> 
-> and <https> <keyword|keywords> without the need for the 
+> <ftp> and <https> <keyword|keywords> without the need for the 
 > <Internet library>. When specifying <URL(glossary)|URLs> for iOS and 
 > Android, you must use the appropriate form that conforms to 
 > [RFC 1630](https://tools.ietf.org/html/rfc1630). 
@@ -110,7 +108,8 @@ References: launch url (command), libURLSetAuthCallback (command),
 libURLSetExpect100 (command), load (command), urlEncode (function),
 binary file (glossary), command (glossary), container (glossary),
 expression (glossary), file (glossary), FTP (glossary),
-keyword (glossary), library (glossary), local file (glossary),
+keyword (glossary), LiveCode custom library (glossary),
+local file (glossary),
 platform (glossary), resource (glossary), resource fork (glossary),
 server (glossary), text file (glossary), Unicode (glossary),
 URL (glossary), URL scheme (glossary), web server (glossary),

--- a/docs/notes/bugfix-21770.md
+++ b/docs/notes/bugfix-21770.md
@@ -1,0 +1,1 @@
+# Fixed various errors in the dictionary entry for the URL keyword


### PR DESCRIPTION
Fixed broken links, replaced unused reference with missing reference.