### PR TITLE
[Dictionary] set to show

### DIFF
--- a/docs/dictionary/command/set.lcdoc
+++ b/docs/dictionary/command/set.lcdoc
@@ -34,8 +34,8 @@ value (string):
 
 
 Description:
-Use the <set> <command> to change the setting of a <property> or <custom
-property>. 
+Use the <set> <command> to change the setting of a <property> or 
+<custom property>. 
 
 If you specify a property that doesn't exist, LiveCode creates a custom
 property with that name for the <object(glossary)>.

--- a/docs/dictionary/command/show.lcdoc
+++ b/docs/dictionary/command/show.lcdoc
@@ -63,7 +63,8 @@ bit builds of LiveCode.
 References: hide (command), answer effect (command),
 show groups (command), show cards (command), show taskbar (command),
 visual effect (command), object (glossary), command (glossary), 
-property (glossary), black (keyword), showPict (property), 
+property (glossary), QuickTime (glossary), black (keyword), 
+dontUserQT (property), dontUseQTEffects(property), showPict (property), 
 toolTip (property), imageSource (property), showInvisibles (property), 
 visible (property)
 

--- a/docs/dictionary/function/setRegistry.lcdoc
+++ b/docs/dictionary/function/setRegistry.lcdoc
@@ -84,9 +84,9 @@ Changes:
 The type parameter was added in version 2.0. In previous versions, the
 type information could not be set.
 
-References: function (control structure), deleteRegistry (function),
-MCISendString (function), file (glossary), error message (glossary),
-binaryEncode (glossary), return (glossary), Windows (glossary),
+References: function (control structure), binaryEncode (function),
+deleteRegistry (function), MCISendString (function), file (glossary), 
+error message (glossary), return (glossary), Windows (glossary),
 binary file (glossary), registry (glossary), binary (glossary),
 command (glossary), behavior (glossary), default (keyword),
 string (keyword)

--- a/docs/dictionary/function/setResource.lcdoc
+++ b/docs/dictionary/function/setResource.lcdoc
@@ -38,9 +38,15 @@ resName (string):
 
 flagsList:
 A list that can contain one or more flag characters. The possible
-resource flags are as follows: S System heap U Purgeable L Locked P
-Protected R Preload C Compressed resourceThe flags may be listed in any
-order. If a character is included, its corresponding resource flag is
+resource flags are as follows: 
+- S System heap 
+- U Purgeable 
+- L Locked 
+- P Protected 
+- R Preload 
+- C Compressed resource
+
+The flags may be listed in any order. If a character is included, its corresponding resource flag is
 set to true. If the character is not included in the flagsList, its
 corresponding resource flag is set to false. If the flagsList is empty,
 all the flags are set to false.
@@ -60,9 +66,9 @@ Use the <setResource> <function> to create a <resource> or change its
 data. 
 
 If the <destinationFile> does not exist, the <setResource> <function>
-creates the <file>. If the <destinationFile> exists but has no <resource
-fork>, the <setResource> function creates the <resource fork> and copies
-the <resource> to it.
+creates the <file>. If the <destinationFile> exists but has no 
+<resource fork>, the <setResource> function creates the <resource fork> 
+and copies the <resource> to it.
 
 If the specified resource already exists, the <setResource> <function>
 replaces the data in the <resource> with the <data>. Otherwise, the
@@ -92,4 +98,3 @@ deleteResource (function), resource fork (glossary), resource (glossary),
 Mac OS (glossary), return (glossary), resfile (keyword), file (keyword)
 
 Tags: file system
-

--- a/docs/dictionary/function/sha1Digest.lcdoc
+++ b/docs/dictionary/function/sha1Digest.lcdoc
@@ -26,15 +26,15 @@ Parameters:
 message(data): A <binary data> string.
 
 Returns:
-Returns the message digest of the <message> as a 20 <byte> <binary
-data> string.
+Returns the message digest of the <message> as a 20 <byte> 
+<binary data> string.
 
 Description:
 Compute a message digest of <message> using the SHA-1 cryptographic
 hash function.
 
 > *Warning:* Serious flaws have been found in the SHA-1 hash algorithm
-> that make in unsuitable to use for security-critical purposes.
+> that make it unsuitable to use for security-critical purposes.
 > Unless you need backwards compatibility with existing systems, use
 > one of the other algorithms available with the <messageDigest> <function>
 

--- a/docs/dictionary/function/shortFilePath.lcdoc
+++ b/docs/dictionary/function/shortFilePath.lcdoc
@@ -7,8 +7,8 @@ Syntax: the shortFilePath of <filePath>
 Syntax: shortFilePath(<filePath>)
 
 Summary:
-<return|Returns> the 8.3-format equivalent of a <Windows> long <file
-path>. 
+<return|Returns> the 8.3-format equivalent of a <Windows> long 
+<file path>. 
 
 Introduced: 1.1
 

--- a/docs/dictionary/keyword/seventh.lcdoc
+++ b/docs/dictionary/keyword/seventh.lcdoc
@@ -20,8 +20,8 @@ Example:
 put "Hello!" into seventh line of field "Greetings"
 
 Description:
-Use the <seventh> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <seventh> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <seventh> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 7. It can also be used to designate the

--- a/docs/dictionary/property/columnDelimiter.lcdoc
+++ b/docs/dictionary/property/columnDelimiter.lcdoc
@@ -45,4 +45,4 @@ only for the current handler and setting it in one handler does not
 affect its value in other handlers called.
 
 References: combine (command), split (command), split (command), 
-character (keyword)
+tab (constant), character (keyword)

--- a/docs/dictionary/property/shadow.lcdoc
+++ b/docs/dictionary/property/shadow.lcdoc
@@ -26,14 +26,14 @@ By default, the <shadow> of a newly created <stack> is set to true. The
 <shadow> of a newly created <control> is false by <default>, but may be
 true if it is created by the <development environment>. (For example,
 choosing Object menu &gt; New Control &gt; Shadow Button creates a
-button whose <shadow> is true.).
+button whose <shadow> is true.)
 
 Description:
 Use the <shadow> <property> to draw a drop shadow.   
 
 While the <shadow> <property> can be set for any <control(keyword)>, it
 affects the appearance of only <field|fields> and <button|buttons>.
-Other <control(object)|controls> do not display a drop shadow,
+Other <control(glossary)|controls> do not display a drop shadow,
 regardless of the setting of their <shadow> <property>.
 
 The <shadow> of a <stack window> is drawn by the operating system. On
@@ -54,16 +54,14 @@ shadow with the <shadowOffset> <property>. (The <shadowOffset> has no
 effect on <stack window|stack windows>.)
 
 Changes:
-The ability to specify the <shadow> of a <stack> was added in version 2.
-
-1. 
+The ability to specify the <shadow> of a <stack> was added in version 2.1. 
 
 
 References: object (glossary), property (glossary), Unix (glossary),
 Windows (glossary), Mac OS (glossary), stack window (glossary),
 development environment (glossary), default (keyword), button (keyword),
 field (keyword), control (keyword), button (object), field (object),
-stack (object), control (object), pixels (property),
+stack (object), pixels (property),
 shadowOffset (property)
 
 Tags: ui

--- a/docs/dictionary/property/shadowColor.lcdoc
+++ b/docs/dictionary/property/shadowColor.lcdoc
@@ -74,8 +74,8 @@ depending on the <object type>:
   the <scrollbar>.
 
 
-* The <shadowColor> of a <graphic>, <player>, <audio clip>, <video
-  clip>, or <EPS|EPS object> has no effect.
+* The <shadowColor> of a <graphic>, <player>, <audio clip>, 
+  <video clip>, or <EPS|EPS object> has no effect.
 
 
 * The <shadowColor> of an <image(keyword)> is the seventh color in the


### PR DESCRIPTION
property/columnDelimiter.lcdoc - Added missing reference.
command/set.lcdoc - Fixed broken link.
function/setRegistry.lcdoc - Changed type of reference to appropriate one.
function/setResource.lcdoc - Fixed broken links and some formatting. 
(Note: External documentation URL is outdated. Not replaced because I couldn’t find that information on Apple's website.)
keyword/seventh.lcdoc - Fixed broken link.
function/sha1Digest.lcdoc - Fixed broken link.
property/shadow.lcdoc - Removed reference with no entry to go to.
property/shadowColor.lcdoc - Fixed broken link.
function/shortFilePath.lcdoc - Fixed broken link.
command/show.lcdoc - Added missing references.
