### PR TITLE
[Bugfix-15176] Remove inaccuracies from revDeleteFolder entry

### DIFF
--- a/docs/dictionary/command/revDeleteFolder.lcdoc
+++ b/docs/dictionary/command/revDeleteFolder.lcdoc
@@ -27,19 +27,14 @@ defaultFolder.
 
 The result:
 The <revDeleteFolder> <command> uses system services on each <platform>
-to perform the move. On <Mac OS> and <OS X|OS X systems>, it uses
-<AppleScript>; on <Windows> and <Unix> systems, it uses the <shell>
-<function>. Any errors encountered are <return|returned> in the <result>
-<function>. 
+to perform the move. Any errors encountered are <return|returned> in the 
+<result> <function>. 
 
 Description:
 Use the <revDeleteFolder> <function> to remove a <folder> from the disk.
 
 The <revDeleteFolder> <command> removes the entire <folder>, including
 all <file|files>, <subfolder|subfolders>, and their contents.
-
-On Mac OS and OS X systems, the <revDeleteFolder> <command> places the
-<folder> in the Trash.
 
 >*Warning:*  This <command> can be used to rename or move <file|files>
 > and <folder|folders> your stack did not create. Of course, a <stack>
@@ -61,8 +56,8 @@ On Mac OS and OS X systems, the <revDeleteFolder> <command> places the
 References: revCopyFolder (command), create folder (command),
 answer folder (command), delete file (command), revMoveFolder (command),
 function (control structure), folders (function), result (function),
-application (glossary), return (glossary), 
-standalone application (glossary), file (glossary), shell (glossary), 
+application (glossary), standalone application (glossary), 
+file (glossary), shell (glossary), 
 subfolder (glossary), platform (glossary), command (glossary), 
 Windows (glossary), main stack (glossary), OS X (glossary), 
 AppleScript (glossary), group (glossary), Unix (glossary), 

--- a/docs/notes/bugfix-15176.md
+++ b/docs/notes/bugfix-15176.md
@@ -1,0 +1,1 @@
+# Removed inaccurate information from the revDeleteFolder dictionary entry


### PR DESCRIPTION
Per bug 15176, revDeleteFolder is a permanent delete on Mac OS. Removed all information stating - or suggesting - otherwise.