### PR TITLE
[Bugfix 12410] Mention trailing slash removal for defaultFolder

### DIFF
--- a/docs/dictionary/property/defaultFolder.lcdoc
+++ b/docs/dictionary/property/defaultFolder.lcdoc
@@ -67,11 +67,17 @@ create the <absolute file path|full path>.
 
 You cannot delete the current <defaultFolder>.
 
->*Important:*  The <folderPath> is specified using <Unix> conventions,
+>*Important:*  The folderPath is specified using <Unix> conventions,
 > even on <Mac OS> and <Windows> systems. The names of <folder|folders>
 > are separated with a "/" character, 
 > and <absolute file path|absolute paths> (starting with a disk or 
 > partition name) must begin with a "/" character. 
+
+>*Note:* When setting the <defaultFolder>, any trailing slash will be
+> removed. For example:
+
+    set the defaultFolder to /Users/John/
+    put the defaultFolder -- returns /Users/John
 
 References: absolute file path (glossary), command (glossary), 
 create alias (command), current folder (glossary), effective (keyword), 

--- a/docs/notes/bugfix-12410.md
+++ b/docs/notes/bugfix-12410.md
@@ -1,0 +1,1 @@
+# Added documentation note about the removal of trailing slashes when setting the defaultFolder


### PR DESCRIPTION
Added a note mentioning that if a trailing slash is supplied when setting the defaultFolder, it is removed. Included with an example.