### PR TITLE
[Dictionary] showFocusBorder to startFrame

### DIFF
--- a/docs/dictionary/command/sort.lcdoc
+++ b/docs/dictionary/command/sort.lcdoc
@@ -67,8 +67,8 @@ do two successive sorts to create subcategories within the major sort
 categories. For example, to sort the cards of a stack by ZIP code and
 sort within each ZIP code by last names, use these two statements:
 
-sort cards by field "Last Name"
-sort cards numeric by field "ZIP code"
+    sort cards by field "Last Name"
+    sort cards numeric by field "ZIP code"
 
 The 'text' and 'international' forms are affected by the caseSensitive
 and formSensitive properties.

--- a/docs/dictionary/command/start-editing.lcdoc
+++ b/docs/dictionary/command/start-editing.lcdoc
@@ -43,9 +43,9 @@ group-editing mode, using the fonts and colors of the <stack> the
 <stop editing> <command>, the <group(glossary)|group's> correct
 appearance is restored.
 
->*Note:* The <start editing> <command> temporarily modifies the <object
-> hierarchy>, displaying only the <object|objects> that belong to the
-> <group(command)> being edited. <inheritance|Inherited> font and color
+>*Note:* The <start editing> <command> temporarily modifies the 
+> <object hierarchy>, displaying only the <object|objects> that belong to 
+> the <group(command)> being edited. <inheritance|Inherited> font and color
 > <properties> may not appear correctly while the <group(command)> is
 > being edited, but will be restored whhen you exit group-editing mode.
 > Also, if the <start editing> <command> is included in a <handler>,

--- a/docs/dictionary/command/start-session.lcdoc
+++ b/docs/dictionary/command/start-session.lcdoc
@@ -36,9 +36,9 @@ that identifier.
 The location where the <$_SESSION(keyword)> array is stored on the
 server is configured using the <sessionSavePath> <property>.
 
-A session is stored until it expires or is deleted using the <delete
-session command>. The maximum age of a session is configured using the
-<sessionLifetime> <property>.
+A session is stored until it expires or is deleted using the 
+<delete session command>. The maximum age of a session is configured 
+using the <sessionLifetime> <property>.
 
 >*Note:* You do not need to alter any of the session properties in order
 > to start and use sessions. They provide a way for advanced users to

--- a/docs/dictionary/function/sin.lcdoc
+++ b/docs/dictionary/function/sin.lcdoc
@@ -39,12 +39,11 @@ The <sin> <function> repeats every 2*pi <radian|radians>:
 for any value of x.
 
 The <sin> <function> requires its input to be in <radian|radians>. To
-provide an angle in <degree|degrees>, use the following <custom
-function>:
+provide an angle in <degree|degrees>, use the following 
+<custom function>:
 
     function sinInDegrees angleInDegrees
-    return sin(angleInDegrees * pi / 180)
-
+        return sin(angleInDegrees * pi / 180)
     end sinInDegrees
 
 

--- a/docs/dictionary/keyword/sixth.lcdoc
+++ b/docs/dictionary/keyword/sixth.lcdoc
@@ -20,8 +20,8 @@ Example:
 subtract sixth line of me from first line of me
 
 Description:
-Use the <sixth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <sixth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <sixth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 6. It can also be used to designate the

--- a/docs/dictionary/property/showFocusBorder.lcdoc
+++ b/docs/dictionary/property/showFocusBorder.lcdoc
@@ -53,8 +53,8 @@ The focusBorder of <card|cards> and <stacks> has no effect.
 References: modeless (command), focus (command), modal (command),
 stacks (function), object (glossary), property (glossary), EPS (glossary),
 insertion point (glossary), dialog box (glossary), Unix (glossary),
-active control (glossary), field (keyword), card (object), image (object),
-field (object), control (object), focusPattern (property),
+active control (glossary), control (glossary), field (keyword), 
+card (object), image (object), field (object), focusPattern (property),
 properties (property)
 
 Tags: ui

--- a/docs/dictionary/property/size.lcdoc
+++ b/docs/dictionary/property/size.lcdoc
@@ -26,8 +26,8 @@ Description:
 Use the <size> <property> to judge how much memory an <object(glossary)>
 takes when displayed.
 
-The <size> of an <image>, <EPS|EPS object>, <audio clip>, or <video
-clip> is is the number of <byte|bytes> of disk space that the
+The <size> of an <image>, <EPS|EPS object>, <audio clip>, or 
+<video clip> is is the number of <byte|bytes> of disk space that the
 <object(glossary)> takes up.
 
 The <size> <property> of a <stack> is always 10000. For <stacks>, this

--- a/docs/dictionary/property/socketTimeoutInterval.lcdoc
+++ b/docs/dictionary/property/socketTimeoutInterval.lcdoc
@@ -30,10 +30,10 @@ yet, the <socketTimeout> <message> is sent to the <object(glossary)>
 whose <script> contains the <read from socket> or <write to socket>
 <command>. 
 
-LiveCode checks the <socketTimeoutInterval> every time a <read from
-socket> or <write to socket> <command> is <execute|executed>, so you can
-specify different intervals for different <command|commands> by changing
-the <socketTimeoutInterval> before issuing the <command>.
+LiveCode checks the <socketTimeoutInterval> every time a 
+<read from socket> or <write to socket> <command> is <execute|executed>, 
+so you can specify different intervals for different <command|commands> 
+by changing the <socketTimeoutInterval> before issuing the <command>.
 
 As long as the action is still pending, the <socketTimeout> <message> is
 sent every time the <socketTimeoutInterval> elapses. For example, if the

--- a/docs/dictionary/property/spray.lcdoc
+++ b/docs/dictionary/property/spray.lcdoc
@@ -22,8 +22,8 @@ A <brushID> is a built-in brush number between 1 and 36. (These brushes
 correspond to LiveCode's built-in patterns 101 to 136.)
 
 An <imageID> is the ID of an <image> to use for painting with the spray
-can. LiveCode looks for the specified <image> first in the <current
-stack>, then in other open <stacks>.
+can. LiveCode looks for the specified <image> first in the 
+<current stack>, then in other open <stacks>.
 
 By default, the <spray> is set to 34 (a round splatter pattern).
 

--- a/docs/dictionary/property/sslCertificates.lcdoc
+++ b/docs/dictionary/property/sslCertificates.lcdoc
@@ -80,6 +80,6 @@ verified against. Support has now been added to locate and load the root
 certificates installed (and kept up to date) as part of the OS.
 
 References: encrypt (command), Standalone Application Settings (glossary),
-property (glossary), LiveCode custom library (glossary),
-SSL & Encryption library (library)
+standalone application (glossary), property (glossary), 
+LiveCode custom library (glossary), SSL & Encryption library (library)
 

--- a/docs/dictionary/property/stackFileVersion.lcdoc
+++ b/docs/dictionary/property/stackFileVersion.lcdoc
@@ -28,8 +28,8 @@ the <stack version> directly, as an optional parameter of the <save>
 Use the <stackFileVersion> to obtain or change the default stack file
 format version LiveCode uses when saving stacks.
 
-Setting the <stackFileVersion> to something less than the newest <stack
-version> could result in data being lost when stacks are saved. For
+Setting the <stackFileVersion> to something less than the newest 
+<stack version> could result in data being lost when stacks are saved. For
 example, setting the <stackFileVersion> to 7.0 will cause any widgets in
 the stack to be lost, along with their scripts and properties.
 
@@ -53,5 +53,5 @@ Changes:
 Deprecated from version 8.0.0.
 
 
-References: save (command), stack version (glossary),
+References: save (command), command (glossary), stack version (glossary),
 minStackFileVersion (property)

--- a/docs/dictionary/property/startFrame.lcdoc
+++ b/docs/dictionary/property/startFrame.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: startFrame
 
 Summary:
-The <startFrame> <property> is not implemented and is <reserved
-word|reserved>.
+The <startFrame> <property> is not implemented and is 
+<reserved word|reserved>.
 
 Introduced: 1.0
 

--- a/docs/glossary/s/SQL.lcdoc
+++ b/docs/glossary/s/SQL.lcdoc
@@ -6,11 +6,11 @@ Type: glossary
 
 Description:
 Structured Query Language. A standard language for specifying,
-retrieving, and updating data in a <database>. You use the <Database
-library> to communicate with <database|databases> using SQL.
+retrieving, and updating data in a <database>. You use the 
+<Database library> to communicate with <database|databases> using SQL.
 
-    >*Note:*>*Important:*   This documentation pronounces SQL as
-    > "sequel". Your pronunciation may vary.
+>*Important:* This documentation pronounces SQL as "sequel". Your 
+> pronunciation may vary.
 
 
 References: database (glossary), Database library (library)

--- a/docs/glossary/s/stack-version.lcdoc
+++ b/docs/glossary/s/stack-version.lcdoc
@@ -63,7 +63,7 @@ lost or altered:
 References: save (command), version (function), stack file (glossary),
 stack (glossary), Unicode (glossary), field (glossary), button (glossary),
 script (glossary), custom property (glossary), card (glossary),
-widget (glossary), blendLevel (property), ink (property),
+widget (object), blendLevel (property), ink (property), 
 textFont (property), textStyle (property), textSize (property),
 unicodeToolTip (property), antialiased (property), opaque (property),
 minStackFileVersion (property)

--- a/docs/glossary/s/standard-output.lcdoc
+++ b/docs/glossary/s/standard-output.lcdoc
@@ -9,8 +9,8 @@ The place where the output, or result, of a program is directed.
 
 Usually, the standard output is the <command line|command-line> window
 by default. On <Unix|Unix systems>, the standard output can be
-redirected to a <file>, a printer, or another port or device. On <OS
-X|OS X systems>, the standard output is the Console window.
+redirected to a <file>, a printer, or another port or device. On 
+<OS X|OS X systems>, the standard output is the Console window.
 
 References: file (glossary), Unix (glossary), OS X (glossary),
 command line (glossary)


### PR DESCRIPTION
property/showFocusBorder.lcdoc - Changed type of a reference as it didn’t go anywhere as is.
function/sin.lcdoc - Formatted code example.
keyword/sixth.lcdoc - Fixed broken link.
property/size.lcdoc - Fixed broken link.
property/socketTimeoutInterval.lcdoc - Fixed broken link.
command/sort.lcdoc - Formatted code example.
property/spray.lcdoc - Fixed broken link.
glossary/s/SQL.lcdoc - Fixed broken link. Reformatted ‘Important’ note.
property/sslCertificates.lcdoc - Added missing reference.
glossary/s/stack-version.lcdoc - Changed type of a reference.
property/stackFileVersion.lcdoc - Fixed broken link. Added missing reference.
glossary/s/standard-output.lcdoc - Fixed broken link.
command/start-editing.lcdoc - Fixed broken link.
command/start-session.lcdoc - Fixed broken link.
property/startFrame.lcdoc - Fixed broken link.
