### PR TITLE
[[Dictionary]] Unlock error dialogs typo

### DIFF
--- a/docs/dictionary/command/unlock-error-dialogs.lcdoc
+++ b/docs/dictionary/command/unlock-error-dialogs.lcdoc
@@ -18,7 +18,7 @@ Example:
 unlock error dialogs
 
 Example:
-if the platform is not "Windows" then unlock error dialogs
+if the platform is not "Win32" then unlock error dialogs
 
 Description:
 Use the <unlock error dialogs> <command> to allow LiveCode to display


### PR DESCRIPTION
Correct typo in code example for `unlock error dialogs` dictionary entry.
("Windows" is not a valid result of `the platform`, the correct value is
"Win32")