### PR TITLE
Add Known Issue note to moveStack and resizeStack entries

### DIFF
--- a/docs/dictionary/message/moveStack.lcdoc
+++ b/docs/dictionary/message/moveStack.lcdoc
@@ -34,9 +34,12 @@ Description:
 Handle the <moveStack> <message> if you want to respond to movement of
 the <stack window>.
 
-The <moveStack> <message> is sent only if the user moved the <stack
-window>. This <message> is not sent when a <handler> moves the window by
-changing its <location>, <rectangle>, or other <properties>.
+The <moveStack> <message> is sent only if the user moved the 
+<stack window>. This <message> is not sent when a <handler> moves the 
+window by changing its <location>, <rectangle>, or other <properties>.
+
+>*Known issue:* Currently errors in <moveStack> and <resizeStack> are
+> ignored, as this was causing a hang in the IDE.
 
 References: grab (command), handler (glossary), current card (glossary),
 message (glossary), stack window (glossary), rectangle (glossary),

--- a/docs/dictionary/message/resizeStack.lcdoc
+++ b/docs/dictionary/message/resizeStack.lcdoc
@@ -63,8 +63,10 @@ true.)
 > scroll is not included in the <pNewHeight> and <pOldHeight>. This means 
 > that the <parameter|parameters> of the <resizeStack> 
 > <message(keyword)> are always equal to the stack's <height> before
-> and 
-> after resizing, regardless of the <vScroll> setting.
+> and  after resizing, regardless of the <vScroll> setting.
+
+>*Known issue:* Currently errors in <moveStack> and <resizeStack> are
+> ignored, as this was causing a hang in the IDE.
 
 References: revChangeWindowSize (command), lock screen (command),
 object (glossary), property (glossary), current card (glossary),


### PR DESCRIPTION
Added a note to the moveStack and resizeStack dictionary entries on how, at present, errors are ignored for those handlers.