### PR TITLE
[Dictionary] statRound to subsidiary-window

### DIFF
--- a/docs/dictionary/function/statRound.lcdoc
+++ b/docs/dictionary/function/statRound.lcdoc
@@ -50,12 +50,12 @@ with <statRound> is not skewed upward, the way it is with the <round>
 <function>. Therefore, you should use <statRound> when statistical
 accuracy is required.
 
-A positive <precision> indicates a place to the right of the <decimal
-point>, and a <negative> <precision> indicates a place to the left. For
-example, 1 rounds off to the nearest tenth, 2 rounds off to the nearest
-hundredth, -1 rounds off by ten, and so on. If you don't specify a
-<precision>, zero is used, meaning that the <number> is rounded off to a
-whole number.
+A positive <precision> indicates a place to the right of the 
+<decimal point>, and a <negative> <precision> indicates a place to the 
+left. For example, 1 rounds off to the nearest tenth, 2 rounds off to the 
+nearest hundredth, -1 rounds off by ten, and so on. If you don't specify 
+a <precision>, zero is used, meaning that the <number> is rounded off to 
+a whole number.
 
 >*Note:* The <statRound> <function> is equivalent to
 > <HyperCard|HyperTalk's> "round" <function>.

--- a/docs/dictionary/keyword/stderr.lcdoc
+++ b/docs/dictionary/keyword/stderr.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: stderr
 
 Summary:
-Used with the <write to file> <command> to designate the <standard
-error> location.
+Used with the <write to file> <command> to designate the 
+<standard error> location.
 
 Introduced: 1.0
 
@@ -18,8 +18,8 @@ Example:
 write field 3 to stderr
 
 Description:
-Use the <stderr> <keyword> to write error messages to the <standard
-error> location, usually the screen or console window.
+Use the <stderr> <keyword> to write error messages to the 
+<standard error> location, usually the screen or console window.
 
 On Unix systems, error messages from a program are normally displayed on
 the console, but can be redirected to go to another device, process, or

--- a/docs/dictionary/keyword/stdin.lcdoc
+++ b/docs/dictionary/keyword/stdin.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: stdin
 
 Summary:
-Used with the <read from file> <command> to designate the <standard
-input>. 
+Used with the <read from file> <command> to designate the 
+<standard input>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/keyword/stdout.lcdoc
+++ b/docs/dictionary/keyword/stdout.lcdoc
@@ -5,8 +5,8 @@ Type: keyword
 Syntax: stdout
 
 Summary:
-Used with the <write to file> <command> to designate the <standard
-output>. 
+Used with the <write to file> <command> to designate the 
+<standard output>. 
 
 Introduced: 1.0
 
@@ -18,8 +18,8 @@ Example:
 write field 3 to stdout
 
 Description:
-Use the <stdout> <keyword> to write data to the <standard output,
-(glossary)>usually the screen or console window.
+Use the <stdout> <keyword> to write data to the 
+<standard output (glossary)>, usually the screen or console window.
 
 On Unix systems, output from a program is normally written to the
 screen, but can be redirected to go to another device, process, or file.
@@ -42,7 +42,7 @@ Support for using <stdout> on <OS X|OS X systems> was added in version
 2.0. 
 
 References: write to process (command), write to file (command),
-standard output (glossary), keyword (glossary),  (glossary),
+standard output (glossary), keyword (glossary),
 command (glossary), OS X (glossary), stdin (keyword), stderr (keyword)
 
 Tags: file system

--- a/docs/dictionary/property/strokeGradient.lcdoc
+++ b/docs/dictionary/property/strokeGradient.lcdoc
@@ -33,65 +33,47 @@ gradient card of the property inspector which has full control over each
 parameter. The stroke gradient will be observed in the border lines of
 the shape. The allowed keys are as follows:
 
-strokeGradient["type"]
+* strokeGradient["type"] - The type of gradient. It can take the 
+following values: 
+  * "linear" 
+  * "radial"
+  * "conical"
+  * "spiral"
+  * "diamond"
+  * "xy"
+  * "sqrtxy"
 
-    The type of gradient, can take the values, "linear", "radial",
-    "conical", "spiral", "diamond", "xy", "sqrtxy"
+* strokeGradient["ramp"] - A return delimited list of gradient 
+stops that define the layout of the of the gradient. A gradient stop 
+is a comma delimited list of numbers that specify the following values: 
+  * position - a number between 0 and 1
+  * red, green, blue - numbers between 0 and 255
+  * alpha - number between 0 (transparent) and 255 (opaque), 
+if omitted it is assumed to be 255.
 
+* strokeGradient["from"] - A coordinate specifying the starting 
+point of the gradient
 
-strokeGradient["ramp"]
+* strokeGradient["to"] - A coordinate specifying the end point 
+of the gradient
 
-    A return delimited list of gradient  stops (see below) that define
-    the layout of the of the gradient.
+* strokeGradient["via"] - A coordinate specifying the intermediate 
+point of the gradient (affects scaling and shearing of the gradient)
 
+* strokeGradient["quality"] - The quality can be set to normal or good 
+(higher detail but slower). This property is normal by default.
 
-strokeGradient["from"]
+* strokeGradient["repeat"] - A number between 1 and 255 that specifies 
+the number of times the gradient ramp is repeated between the start and 
+end points. This property is 1 by default.
 
-    A coordinate specifying the starting point of the gradient
+* strokeGradient["mirror"] - A boolean value specifying whether 
+alternating repetitions of the ramp are reversed. This property is false 
+by default.
 
-
-strokeGradient["to"]
-
-    A coordinate specifying the end point of the gradient
-
-
-strokeGradient["via"]
-
-    A coordinate specifying the intermediate point of the gradient
-    (affects scaling and shearing of the gradient)
-
-
-strokeGradient["quality"]        
-
-    The quality can be set to normal or good (higher detail but slower).
-    This property is normal by default.
-
-
-strokeGradient["repeat"]
-
-    A number between 1 and 255 that specifies the number of times the
-    gradient ramp is repeated between the start and end points. This
-    property is 1 by default.
-
-
-strokeGradient["mirror"]      
-
-    A boolean value specifying whether alternating repetitions of the
-    ramp are reversed. This property is false by default.
-
-
-strokeGradient["wrap"]
-
-    A boolean value specifying whether the ramp is repeated to fill the
-    entire graphic a object.    This property is false by default.
-
-
-A gradient stop is a comma is a comma delimited list of numbers that
-specify the following values: position - number between 0 and 1
-
-    red, green, blue - numbers between 0 and 255
-    alpha - number between 0 (transparent) and 255 (opaque), if omitted
-    it is assumed \ to be 255.
+*strokeGradient["wrap"] - A boolean value specifying whether the ramp is 
+repeated to fill the entire graphic a object. This property is false by 
+default.
 
 
 References: opaque (property), antialiased (property)

--- a/docs/dictionary/property/style.lcdoc
+++ b/docs/dictionary/property/style.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the style of <object> to <styleName>
 
 Summary:
-Specifies the general appearance and behavior of an <object(object)>.
+Specifies the general appearance and behavior of an <object(glossary)>.
 
 Associations: button
 
@@ -94,8 +94,8 @@ following:
 
 
 References: modeless (command), pulldown (command), object (glossary),
-property (glossary), behavior (glossary), opaque (glossary),
-regular polygon (glossary), checkbox (glossary), Motif (glossary),
+property (glossary), behavior (glossary), regular polygon (glossary), 
+checkbox (glossary), Motif (glossary),
 appearance (glossary), background (glossary), standard (keyword),
 opaque (keyword), popup (keyword), shadow (keyword), scrollbar (object),
 graphic (object), field (object), stack (object), roundEnds (property),

--- a/docs/dictionary/property/styledText.lcdoc
+++ b/docs/dictionary/property/styledText.lcdoc
@@ -107,21 +107,21 @@ Centered Hello World
 Left-aligned Hello unicodeString
 
 This would transpire as the following array:
-1 =
-style = { textAlign = center }
-runs =
-1 = { text = Centered  }
-2 =
-style = { textStyle = bold }
-text = Hello
-3 = { text =  World }
-2 =
-runs =
-1 = { text = Left-aligned  }
-2 =
-style = { textColor = 255,0,0 }
-text = Hello
-3 = { unicodeText = unicodeString }
+    1 =
+      style = { textAlign = center }
+      runs =
+        1 = { text = Centered  }
+        2 =
+          style = { textStyle = bold }
+          text = Hello
+        3 = { text =  World }
+    2 =
+      runs =
+        1 = { text = Left-aligned  }
+        2 =
+          style = { textColor = 255,0,0 }
+          text = Hello
+        3 = { unicodeText = unicodeString }
 
 [ For brevity, single element arrays are represented using { ... }
 notation ]

--- a/docs/glossary/s/subsidiary-window.lcdoc
+++ b/docs/glossary/s/subsidiary-window.lcdoc
@@ -9,8 +9,8 @@ A window that is part of another window or associated with it in some
 way. 
 
 Subsidiary window types include <drawer|drawers> (which slide out from
-one edge of a parent window) and <sheet|sheets> (which are <dialog
-box|dialog boxes> associated with a parent window).
+one edge of a parent window) and <sheet|sheets> (which are 
+<dialog box|dialog boxes> associated with a parent window).
 
 References: sheet (glossary), drawer (glossary), dialog box (glossary)
 


### PR DESCRIPTION
function/statRound.lcdoc - Fixed broken link.
keyword/stderr.lcdoc - Fixed broken links.
keyword/stdin.lcdoc - Fixed broken link.
keyword/stdout.lcdoc - Fixed broken link. Removed phantom glossary reference.
property/strokeGradient.lcdoc - Reformatted list of key values. Moved explanation of gradient stops to the end of the only key description to mention them.
property/style.lcdoc - Fixed broken link. Removed dead reference.
property/styledText.lcdoc - Reformatted output array.
glossary/s/subsidiary-window.lcdoc - Fixed broken link.