### PR TITLE
[Dictionary] switch to thumbSize

### DIFF
--- a/docs/dictionary/control_st/switch.lcdoc
+++ b/docs/dictionary/control_st/switch.lcdoc
@@ -95,9 +95,9 @@ at the end of each <statementList>. This ensures that only one
 
 This also means that you can attach more than one <caseValue> or
 <caseCondition> to the same <statementList>, simply by placing one
-<case> line above the next. The following example beeps if the <current
-card> is either the last or first <card>, and goes to the next <card>
-otherwise: 
+<case> line above the next. The following example beeps if the 
+<current card> is either the last or first <card>, and goes to the 
+next <card> otherwise: 
 
     switch (the number of this card)
     case 1
@@ -121,7 +121,8 @@ more slowly the <switch> <control structure|structure>
 > <command> and appears in the <commandNames>.
 
 References: switch (control structure), if (control structure),
-break (control structure), value (function), commandNames (function),
+break (control structure), repeat (control structure), 
+try (control structure), value (function), commandNames (function),
 current card (glossary), value (glossary), execute (glossary),
 statement (glossary), keyword (glossary), expression (glossary),
 control structure (glossary), evaluate (glossary), command (glossary),

--- a/docs/dictionary/control_st/throw.lcdoc
+++ b/docs/dictionary/control_st/throw.lcdoc
@@ -24,7 +24,7 @@ end if
 Parameters:
 errorString (string):
 The string that is returned to the calling try control structure. The
-errorString becomes the parameter of the catch lin in the try control
+errorString becomes the parameter of the catch line in the try control
 structure. 
 
 Description:
@@ -35,9 +35,10 @@ within a <try> <control structure>.
 inside a <handler>.
 
 If LiveCode generates the error (for example, an execution error from a
-built-in command), it returns a positive number to the <try> <control
-structure>. To avoid confusion, therefore, a <throw> <control structure>
-should return a <negative> number, or a non-numeric <string>.
+built-in command), it returns a positive number to the <try> 
+<control structure>. To avoid confusion, therefore, a <throw> 
+<control structure> should return a <negative> number, or a 
+non-numeric <string>.
 
 If a <throw> <control structure> is <execute|executed> in a <handler>
 that was not <call|called> from within a <try> <control structure>, an

--- a/docs/dictionary/function/tan.lcdoc
+++ b/docs/dictionary/function/tan.lcdoc
@@ -40,8 +40,8 @@ infinite (undefined). The <tan> <function> instead <return|returns> a
 very large number for such angles, due to internal number handling.
 
 The <tan> <function> requires its input to be in <radian|radians>. To
-provide an angle in <degree|degrees>, use the following <custom
-function>:
+provide an angle in <degree|degrees>, use the following 
+<custom function>:
 
     function tanInDegrees angleInDegrees
         return tan(angleInDegrees * pi / 180)

--- a/docs/dictionary/keyword/system.lcdoc
+++ b/docs/dictionary/keyword/system.lcdoc
@@ -22,8 +22,8 @@ Use the <system> <keyword> to correctly format dates and times that will
 be viewed by the user (for example, dates and times that are displayed
 in a <field>).
 
-The <system> <format> is set by the Date & Time control panel (on <Mac
-OS|Mac OS systems>), the Date control panel (on <Windows|Windows
+The <system> <format> is set by the Date & Time control panel (on 
+<Mac OS|Mac OS systems>), the Date control panel (on <Windows|Windows
 systems>), or the LANG environment variable (on <Unix|Unix systems>).
 
 You can use the <system> keyword in combination with the <long>,

--- a/docs/dictionary/keyword/templateButton.lcdoc
+++ b/docs/dictionary/keyword/templateButton.lcdoc
@@ -35,9 +35,8 @@ You can use the <set> <command> to set the <properties> of the
 <default>. This example creates a <radio button>:
 
     on makeRadio
-    set the style of the templateButton to "radioButton"
-    create button "Red" -- "Red" is a radio button
-
+        set the style of the templateButton to "radioButton"
+        create button "Red" -- "Red" is a radio button
     end makeRadio
 
 

--- a/docs/dictionary/keyword/templateVideoClip.lcdoc
+++ b/docs/dictionary/keyword/templateVideoClip.lcdoc
@@ -35,9 +35,10 @@ the <properties> of the <templateVideoClip> does not affect existing
 The properties of the <templateVideoClip> can be returned to the default
 settings using the <reset> command.
 
-You can refer to the <templateVideoClip> using any of the following
-forms: templateVideoClip
+You can refer to the <templateVideoClip> using any of the 
+following forms: 
 
+    templateVideoClip
     the templateVideoClip
     templateVideoClip()
 

--- a/docs/dictionary/keyword/tenth.lcdoc
+++ b/docs/dictionary/keyword/tenth.lcdoc
@@ -20,8 +20,8 @@ Example:
 multiply the tenth word of tCurrentAmounts by ten
 
 Description:
-Use the <tenth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <tenth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <tenth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 10. It can also be used to designate the

--- a/docs/dictionary/keyword/the.lcdoc
+++ b/docs/dictionary/keyword/the.lcdoc
@@ -31,7 +31,6 @@ The <the> <keyword> is mandatory before the names of built-in
     get the time -- must use "the" if () are not used
     get time()   -- cannot use "the" if () are used
 
-
 The <the> <keyword> is optional before the names of <properties>, but it
 is good style to include it.
 

--- a/docs/dictionary/keyword/third.lcdoc
+++ b/docs/dictionary/keyword/third.lcdoc
@@ -20,8 +20,8 @@ Example:
 repeat until third line of tKeysPressed is "Control"
 
 Description:
-Use the <third> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <third> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <third> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 3. It can also be used to designate the

--- a/docs/dictionary/keyword/this.lcdoc
+++ b/docs/dictionary/keyword/this.lcdoc
@@ -7,8 +7,8 @@ Type: keyword
 Syntax: this
 
 Summary:
-Indicates the <current stack>, or the <current card> of the <current
-stack>. 
+Indicates the <current stack>, or the <current card> of the 
+<current stack>. 
 
 Introduced: 1.0
 
@@ -27,8 +27,8 @@ Example:
 send preOpenStack to this stack
 
 Description:
-Use the <this> <keyword> to indicate the <current card> or <current
-stack> in an <expression>.
+Use the <this> <keyword> to indicate the <current card> or 
+<current stack> in an <expression>.
 
 When used in a sort <command>, the <this> <keyword> indicates each
 <card(keyword)> to be sorted. You can use the <this> <keyword> to sort

--- a/docs/dictionary/property/systemColorSelector.lcdoc
+++ b/docs/dictionary/property/systemColorSelector.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: systemColorSelector
 
 Summary:
-The <systemColorSelector> <property> is not implemented and is <reserved
-word|reserved>.
+The <systemColorSelector> <property> is not implemented and is 
+<reserved word|reserved>.
 
 Introduced: 1.1
 

--- a/docs/dictionary/property/systemFileSelector.lcdoc
+++ b/docs/dictionary/property/systemFileSelector.lcdoc
@@ -7,8 +7,8 @@ Syntax: set the systemFileSelector to {true | false}
 Summary:
 Specifies whether the <ask file>, <answer file>, and <answer folder>
 <command|commands> use the standard <file dialog box|file dialog boxes>
-built in to the current operating system, or a built-in <file dialog
-box>. 
+built in to the current operating system, or a built-in 
+<file dialog box>. 
 
 Introduced: 1.0
 

--- a/docs/dictionary/property/text.lcdoc
+++ b/docs/dictionary/property/text.lcdoc
@@ -7,8 +7,8 @@ Type: property
 Syntax: set the text of {<button> | <field> | <image>} to <string>
 
 Summary:
-Specifies the text contained by a <button> or <field> or the <binary
-file|binary data> in an <image>.
+Specifies the text contained by a <button> or <field> or the 
+<binary file|binary data> in an <image>.
 
 Associations: field, button, image
 

--- a/docs/dictionary/property/textStyle.lcdoc
+++ b/docs/dictionary/property/textStyle.lcdoc
@@ -35,14 +35,13 @@ set the textStyle["bold"] of field "name" to true
 Value:
 The <textStyle> of an <object(glossary)> or <chunk> is either "plain",
 empty, "mixed", or one or more of the following, separated by commas:
-
-        - bold
-        - italic
-        - underline
-        - strikeout
-        - <box> 
-        - threeDbox
-        - link (or group)
+ - bold
+ - italic
+ - underline
+ - strikeout
+ - <box> 
+ - threeDbox
+ - link (or group)
 
 
 Description:
@@ -67,12 +66,12 @@ The "link" style can be used only for chunks of a field, not for
 objects. Setting the <textStyle> of a <chunk> to "link" turns it into a
 <grouped text|text group>.
 
-the <textStyle> [&lt;style&gt;]
+    the <textStyle> [&lt;style&gt;]
 
 Here, style can be one of bold, condensed, expanded, italic, oblique,
-box, threedbox, underline, strikeout, link. For example
+box, threedbox, underline, strikeout, link. For example:
 
-set the <textStyle> ["bold"] of field 1 to true
+    set the <textStyle> ["bold"] of field 1 to true
 
 Changes:
 The "link" style was introduced in version 1.1. In previous versions,

--- a/docs/dictionary/property/themeClass.lcdoc
+++ b/docs/dictionary/property/themeClass.lcdoc
@@ -29,8 +29,8 @@ a text entry box.
 
 If no <themeClass> is specified, the engine will auto-detect the
 appropriate type based on the properties of the object. To retrieve this
-auto-detected type when the property is empty use <the effective
-themeClass>. 
+auto-detected type when the property is empty use the <effective>
+<themeClass>. 
 
 Unlike many other appearance-related properties, the <themeClass>
 property is not inherited.

--- a/docs/dictionary/property/thumbSize.lcdoc
+++ b/docs/dictionary/property/thumbSize.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the thumbSize of <scrollbar> to <number>
 
 Summary:
-Specifies how large a <scrollbar|scrollbar's> draggable <scrollbar
-thumb|thumb> is.
+Specifies how large a <scrollbar|scrollbar's> draggable 
+<scrollbar thumb|thumb> is.
 
 Associations: scrollbar
 

--- a/docs/glossary/t/tabbed-button.lcdoc
+++ b/docs/glossary/t/tabbed-button.lcdoc
@@ -8,8 +8,8 @@ Type: glossary
 Description:
 A <button> type that lets you select a section of a <dialog box> or
 window. A tabbed button looks like a stack of file folders, with several
-tabs across the top. Clicking a tab displays its section in the <dialog
-box>. 
+tabs across the top. Clicking a tab displays its section in the 
+<dialog box>. 
 
 References: button (glossary), dialog box (glossary)
 


### PR DESCRIPTION
control_st/switch.lcdoc - Added missing references. Fixed broken link.
keyword/system.lcdoc - Fixed broken link.
property/systemColorSelector.lcdoc - Fixed broken link.
property/systemFileSelector.lcdoc - Fixed broken link.
glossary/tabbed-button.lcdoc - Fixed broken link.
function/tan.lcdoc - Fixed broken link.
keyword/templateButton.lcdoc - Formatted code example.
keyword/templateVideoClip.lcdoc - Formatted list of forms in line with those from other entries.
keyword/tenth.lcdoc - Fixed broken link.
property/text.lcdoc - Fixed broken link.
property/textStyle.lcdoc - Formatted list to not display as code and to have one item in the list display correctly. Formatted code example to display as code.
property/themeClass - Fixed broken links.
keyword/third.lcdoc - Fixed broken link.
keyword/this.lcdoc - Fixed broken links.
control_st/throw.lcdoc - Fixed broken links.
property/thumbSize.lcdoc - Fixed broken link.
