### PR TITLE
[Bugfix 21741] Add notes about evaluating scientific notation

### DIFF
--- a/docs/dictionary/operator/equals.lcdoc
+++ b/docs/dictionary/operator/equals.lcdoc
@@ -36,6 +36,12 @@ Use the <=> (equality) <operator> to find out whether two <numeric>
 <expression|expressions> yield the same number or whether two
 <string|strings> are equivalent.
 
+>*Note:* A string in the form "xEy", where x is a number and y is an
+>integer will be treated as a number in <scientific notation>. This 
+>means that such a string is evaluated as x * 10^y. For example:
+
+    put "5e2" = "500" -- returns true
+
 When comparing strings, the <=> <operator> compares the two
 <value|values> <character> by <character>. If the <caseSensitive>
 <property> is true, the comparison between two <string|strings> treats
@@ -75,7 +81,8 @@ Previously, comparing two arrays would have converted both arrays into
 the empty string, and always returned true.
 
 References: property (glossary), operator (glossary),
-case-sensitive (glossary), value (glossary), string (glossary),
+case-sensitive (glossary), scientific notation (glossary),
+value (glossary), string (glossary),
 expression (glossary), character (keyword), numeric (keyword),
 &lt;&gt; (operator), contains (operator), caseSensitive (property)
 

--- a/docs/dictionary/operator/equals.lcdoc
+++ b/docs/dictionary/operator/equals.lcdoc
@@ -40,7 +40,7 @@ Use the <=> (equality) <operator> to find out whether two <numeric>
 >integer will be treated as a number in <scientific notation>. This 
 >means that such a string is evaluated as x * 10^y. For example:
 
-    put "5e2" = "500" -- returns true
+    put "3e2" = "300" -- returns true
 
 When comparing strings, the <=> <operator> compares the two
 <value|values> <character> by <character>. If the <caseSensitive>

--- a/docs/glossary/s/scientific-notation.lcdoc
+++ b/docs/glossary/s/scientific-notation.lcdoc
@@ -10,7 +10,7 @@ a <value> between one and ten, multiplied by the appropriate power of
 ten. 
 
 >*Note:* Whenever a string takes the form xEy in LiveCode, where x is a 
-> number and y is in an <integer>, it is interpreted as a number in 
+> number and y is an <integer>, it is interpreted as a number in 
 > scientific notation. This means that such a string is evaluated as 
 > x*10^y. For example:
 

--- a/docs/glossary/s/scientific-notation.lcdoc
+++ b/docs/glossary/s/scientific-notation.lcdoc
@@ -9,7 +9,14 @@ A way of <format|formatting> numbers where the number is represented as
 a <value> between one and ten, multiplied by the appropriate power of
 ten. 
 
-References: format (glossary), value (glossary)
+>*Note:* Whenever a string takes the form xEy in LiveCode, where x is a 
+> number and y is in an <integer>, it is interpreted as a number in 
+> scientific notation. This means that such a string is evaluated as 
+> x*10^y. For example:
+
+    
+
+References: format (glossary), integer (glossary), value (glossary)
 
 Tags: math
 

--- a/docs/glossary/s/scientific-notation.lcdoc
+++ b/docs/glossary/s/scientific-notation.lcdoc
@@ -14,7 +14,7 @@ ten.
 > scientific notation. This means that such a string is evaluated as 
 > x*10^y. For example:
 
-    
+    put 1e2 is 100 -- returns true    
 
 References: format (glossary), integer (glossary), value (glossary)
 


### PR DESCRIPTION
Added notes to the = and scientific notation entries mentioning that strings in the form xEy may be treated as numbers.