### PR TITLE
[12876] Ensure the IDE can be launched when the installer finishes on Linux

### DIFF
--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -248,11 +248,6 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    packageCompilerConfigureVariable tPackager, "ProductTitle", tProductName && getReadableVersion(pVersion)
    packageCompilerConfigureVariable tPackager, "ProductTag", tProductTag & "_" & getTaggedVersion(pVersion)
 
-   -- For Linux only, case-fold the product name to lowercase and
-   -- remove all spaces - we can just use the product tag
-   if pPlatform is "Linux" or pPlatform is "Linux-x86_64" or pPlatform is "Linux-armv6hf" then
-      put tProductTag into tProductName
-   end if
    packageCompilerConfigureVariable tPackager, "ProductName", tProductName
    
    -- The edition tags.

--- a/docs/notes/bugfix-12876.md
+++ b/docs/notes/bugfix-12876.md
@@ -1,0 +1,1 @@
+# Ensure the IDE can be launched when the installer finishes


### PR DESCRIPTION
This patch removes the block of code which used the productTag (e.g. "livecodecommunity.x86_64") instead of the productName (e.g. "LiveCode Community.x86_64") on Linux.

This block was there for backwards compatibility reasons, and was incorrect anyway, as it was checking `if pPlatform is "Linux"`, which should have been `if pPlatform is "Linux-x86"` for the 32bit case (note pPlatform is not `the platform`)

This resulted in the executable name in the 32bit case being "LiveCode <Edition>.x86", and the installer was indeed trying to launch "LiveCode <Edition>.x86".

In the 64bit case, the executable name was "livecode<edition>.x86_64" whereas the installer tried to launch "LiveCode <Edition>.x86_64".

So this patch ensures that in any case the executable name will match the name that the installer tries to launch.