### PR TITLE
[21807] Ensure you can set the android recorder props more than once

### DIFF
--- a/docs/notes/bugfix-21807.md
+++ b/docs/notes/bugfix-21807.md
@@ -1,0 +1,1 @@
+# Ensure you can set the android recorder properties more than once

--- a/extensions/libraries/androidaudiorecorder/androidaudiorecorder.lcb
+++ b/extensions/libraries/androidaudiorecorder/androidaudiorecorder.lcb
@@ -42,6 +42,8 @@ __safe foreign handler _JNI_MediaRecorderStop(in pRecorder as JObject) returns n
 	binds to "java:android.media.MediaRecorder>stop()V"
 __safe foreign handler _JNI_MediaRecorderReset(in pRecorder as JObject) returns nothing \
 	binds to "java:android.media.MediaRecorder>reset()V"
+__safe foreign handler _JNI_MediaRecorderRelease(in pRecorder as JObject) returns nothing \
+binds to "java:android.media.MediaRecorder>release()V"
 __safe foreign handler _JNI_MediaRecorderGetMaxAmplitude(in pRecorder as JObject) returns JInt \
     binds to "java:android.media.MediaRecorder>getMaxAmplitude()I"
 
@@ -187,7 +189,8 @@ public handler androidRecorderStopRecording()
 	end if
 	
 	_JNI_MediaRecorderStop(mRecorder)
-	_JNI_MediaRecorderReset(mRecorder)
+	_JNI_MediaRecorderRelease(mRecorder)
+    put nothing into mRecorder
 end handler
 
 /**


### PR DESCRIPTION
It seems that MediaRecorder::reset() does not actually reset the properties of the MediaRecorder instance. So if you e.g. try to `androidRecorderSetRecordInput "Mic"`, you'll get an error:

`MediaRecorder: audio source has already been set`

This patch uses `MediaRecorder::release()` instead of `MediaRecorder::reset()` when `androidRecorderStopRecording()` is called.

In that way a new instance of MediaRecorder will be created every time `androidRecorderStartRecording()` is called, and it will be destroyed every time `androidRecorderStopRecording()` is called.