### PR TITLE
Dictionary batch 39

### DIFF
--- a/docs/dictionary/command/topLevel.lcdoc
+++ b/docs/dictionary/command/topLevel.lcdoc
@@ -27,14 +27,14 @@ stack:
 Any stack reference.
 
 Description:
-Use the <topLevel> <command> to display a <stack> in an <editable
-window>. 
+Use the <topLevel> <command> to display a <stack> in an 
+<editable window>. 
 
 An editable window can be resized (if its resizable <property> is true),
 and its <control|controls> can be <selected>, moved, and changed. To
-edit a <stack> of a different style (a <palette>, <modeless>, or <modal
-dialog box|modal dialog>), use the <topLevel> <command> to display it in
-an <editable window>.
+edit a <stack> of a different style (a <palette>, <modeless>, or 
+<modal dialog box|modal dialog>), use the <topLevel> <command> to 
+display it in an <editable window>.
 
 The <topLevel> <command> closes the <stack> and reopens it as an
 <editable window>, so <closeStack> and <openStack>, <closeCard> and
@@ -50,11 +50,11 @@ does not close and reopen it.
 References: palette (command), lock messages (command), drawer (command),
 modeless (command), choose (command), property (glossary),
 current card (glossary), execute (glossary), message (glossary),
-editable window (glossary), command (glossary),
+editable window (glossary), command (glossary), control (glossary),
 modal dialog box (glossary), openCard (message), closeStack (message),
 closeCard (message), closeBackground (message), openStack (message),
-openBackground (message), stack (object), control (object),
-cantModify (property), selected (property)
+openBackground (message), stack (object), cantModify (property), 
+selected (property)
 
 Tags: windowing
 

--- a/docs/dictionary/function/tool.lcdoc
+++ b/docs/dictionary/function/tool.lcdoc
@@ -22,11 +22,11 @@ Example:
 if the tool is not "browse tool" then choose browse tool
 
 Returns (enum):
-The <tool> <function> <return|returns> one of the following <tool>
-names:browse, pointer, button, field, scrollbar, graphic, image, player,
-select, pencil, bucket, brush, eraser, spray can, rectangle, line, round
-rect, oval, polygon, curve, regular polygon, dropperfollowed by the word
-"tool" 
+The <tool> <function> <return|returns> one of the following 
+<tool> names: browse, pointer, button, field, scrollbar, graphic, image, 
+player, select, pencil, bucket, brush, eraser, spray can, rectangle, line, 
+round rect, oval, polygon, curve, regular polygon, or dropper, 
+followed by the word "tool" 
 
 
 Description:

--- a/docs/dictionary/function/topStack.lcdoc
+++ b/docs/dictionary/function/topStack.lcdoc
@@ -42,8 +42,8 @@ For example, an editable window has a mode of 1, and a
 <palette(command)> has a mode of 4. If several
 <palette(glossary)|palettes> and <editable window|editable windows> are
 open, the <topStack> is the frontmost editable <stack>, although
-<palette(glossary)|palettes> may be in front of it. If all the <editable
-window|editable windows> are then closed, the frontmost
+<palette(glossary)|palettes> may be in front of it. If all the 
+<editable window|editable windows> are then closed, the frontmost
 <palette(command)> becomes the <topStack>, since there is now no window
 with a lower <mode>.
 

--- a/docs/dictionary/keyword/to.lcdoc
+++ b/docs/dictionary/keyword/to.lcdoc
@@ -29,11 +29,11 @@ set the cIsRaining of me to true
 Description:
 Use the <to> <keyword> to complete a <command> that requires it.
 
-The <to> <keyword> is used with the <add>, <convert>, <copy>, <create
-alias>, <drag>, <exit to top>, <export>, <go>, <move>, <open socket>,
-<post>, print card, <rename>, <seek>, <send>, <send to program>, <write
-to file>, <write to process>, <write to socket>, and <write to driver>
-<command|commands>. 
+The <to> <keyword> is used with the <add>, <convert>, <copy>, 
+<create alias>, <drag>, <exit to top>, <export>, <go>, <move>, 
+<open socket>, <post>, print card, <rename>, <seek>, <send>, 
+<send to program>, <write to file>, <write to process>, 
+<write to socket>, and <write to driver> <command|commands>. 
 
 It is also used to designate the final color in visual effects, and with
 the set <command> to designate the new <property> setting.

--- a/docs/dictionary/property/tilt.lcdoc
+++ b/docs/dictionary/property/tilt.lcdoc
@@ -25,8 +25,8 @@ Value:
 The <tilt> is a number between -90 and 90.
 
 Description:
-Use the <tilt> <property> to find out where the user is in a <QuickTime
-VR> movie.
+Use the <tilt> <property> to find out where the user is in a 
+<QuickTime VR> movie.
 
 The user can move the view of a QuickTime VR movie using the
 navigational controls in the player; a handler can change the view by

--- a/docs/dictionary/property/toggleHilites.lcdoc
+++ b/docs/dictionary/property/toggleHilites.lcdoc
@@ -25,8 +25,8 @@ By default, the <toggleHilites> <property> of newly created
 <field(object)|fields> is set to false.
 
 Description:
-Use the <toggleHilites> <property> to control the <behavior> of <list
-field|list fields>.
+Use the <toggleHilites> <property> to control the <behavior> of 
+<list field|list fields>.
 
 If a field's <toggleHilites> <property> is set to true, clicking a
 <selected> line deselects the line. If the <toggleHilites> is false,

--- a/docs/dictionary/property/toggleHilites.lcdoc
+++ b/docs/dictionary/property/toggleHilites.lcdoc
@@ -36,16 +36,16 @@ If the field's <listBehavior> <property> is false, the setting of the
 <toggleHilites> <property> has no effect.
 
 >*Important:*  Setting the <toggleHilites> to true automatically sets
-> the <field|field's> <noncontiguousHilites> and <multipleLines>
+> the <field|field's> <noncontiguousHilites> and <multipleHilites>
 > <properties> to true. (However, setting the <toggleHilites> to false
 > does not set these <properties> back to false.) To set the
 > <toggleHilites> to true and the <noncontiguousHilites> or
-> <multipleLines> to false, be sure to set the <toggleHilites> first,
+> <multipleHilites> to false, be sure to set the <toggleHilites> first,
 > then set the other <properties> to false.
 
 References: property (glossary), behavior (glossary),
 list field (glossary), field (keyword), field (object),
-multipleLines (property), toggleHilites (property), properties (property),
+multipleHilites (property), toggleHilites (property), properties (property),
 listBehavior (property), selected (property),
 noncontiguousHilites (property), threeDHilite (property),
 hilitedLine (property)

--- a/docs/dictionary/property/toolTipDelay.lcdoc
+++ b/docs/dictionary/property/toolTipDelay.lcdoc
@@ -25,8 +25,8 @@ The <toolTipDelay> is a <non-negative> <integer>.
 By default, the <toolTipDelay> is 500 (half a second).
 
 Description:
-Use the <toolTipDelay> <property> to control the responsiveness of <tool
-tip|tool tips>.
+Use the <toolTipDelay> <property> to control the responsiveness of 
+<tool tip|tool tips>.
 
 A tool tip is a small box containing a line or two of text, which pops
 up on the screen when the mouse pointer hovers over a control. Use the

--- a/docs/dictionary/property/topLeft.lcdoc
+++ b/docs/dictionary/property/topLeft.lcdoc
@@ -39,11 +39,11 @@ Description:
 Use the <topLeft> <property> to change the placement of a <control> or
 window. 
 
-The <topLeft> of a <stack> is in <absolute (screen)
-coordinates(glossary)>. The first <item> (the <left>) of a card's
+The <topLeft> of a <stack> is in <absolute coordinates|absolute (screen) 
+coordinates>. The first <item> (the <left>) of a card's
 <topLeft> <property> is always zero; the second <item> (the <top>) is
-always zero. The <topLeft> of a <group> or <control> is in <relative
-(window) coordinates(glossary)>.
+always zero. The <topLeft> of a <group> or <control> is in 
+<relative coordinates|relative (window) coordinates>.
 
 In window coordinates, the point 0,0 is at the top left of the stack
 window. In screen coordinates, the point 0,0 is at the top left of the

--- a/docs/dictionary/property/topPattern.lcdoc
+++ b/docs/dictionary/property/topPattern.lcdoc
@@ -44,12 +44,12 @@ pattern used to draw the raised edge of the <object(glossary)>.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
-> <height> and <width> must be a power of 2. To be used on <Windows> and
-> <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
-> be used as a fully cross-platform pattern, both an image's dimensions
-> should be one of 8, 16, 32, 64, or 128.
+>*Cross-platform note:*  To be used as a pattern on 
+> <Mac OS|Mac OS systems>, an <image> must be 128x128 <pixels> or less, 
+> and both its <height> and <width> must be a power of 2. To be used on
+> <Windows> and <Unix|Unix systems>, <height> and <width> must be 
+> divisible by 8. To be used as a fully cross-platform pattern, both an 
+> image's dimensions should be one of 8, 16, 32, 64, or 128.
 
 The <topPattern> of <control(object)|controls> is drawn starting at the
 <control(object)|control's> upper right corner: if the
@@ -104,8 +104,8 @@ depending on the <object type>:
   bottom and right edges of the scroll area.
 
 
-* The <topPattern> of a <graphic>, <image>, <audio clip>, or <video
-  clip> has no effect.
+* The <topPattern> of a <graphic>, <image>, <audio clip>, or 
+  <video clip> has no effect.
 
 
 * The <topPattern> of a <player> or <EPS|EPS object> forms a border on
@@ -120,13 +120,13 @@ References: group (command), stacks (function), object (glossary),
 property (glossary), EPS (glossary), audio clip (glossary),
 Windows (glossary), object type (glossary), Mac OS (glossary),
 keyword (glossary), Unix (glossary), video clip (glossary),
-current stack (glossary), effective (keyword), field (keyword),
-image (keyword), button (keyword), card (keyword), scrollbar (keyword),
-player (keyword), graphic (keyword), control (keyword), button (object),
-field (object), stack (object), control (object), pixels (property),
-textStyle (property), owner (property), height (property),
-width (property), topColor (property), bottom (property),
-hiliteBorder (property), bottomPattern (property),
+current stack (glossary), control (glossary), effective (keyword), 
+field (keyword), image (keyword), button (keyword), card (keyword), 
+scrollbar (keyword), player (keyword), graphic (keyword), 
+control (keyword), button (object), field (object), stack (object), 
+pixels (property), textStyle (property), owner (property), 
+height (property), width (property), topColor (property), 
+bottom (property), hiliteBorder (property), bottomPattern (property),
 threeDHilite (property), threeD (property)
 
 Tags: ui

--- a/docs/dictionary/property/tracks.lcdoc
+++ b/docs/dictionary/property/tracks.lcdoc
@@ -21,11 +21,11 @@ put the tracks of player myPlayerName into myNode
 Value (enum):
 The <tracks> is a list of tracks, one per <line>. Each <line> consists
 of four <items>, separated by commas:
+ - the track ID (an integer)
+ - the track media type (for example, "audio", "video", or
+ "VR Panorama" )
 
-        - the track ID (an integer)
-        - the track media type (for example, "audio", "video", or
-          "VR Panorama" ) This property is read:only and cannot be set
-
+ This property is read-only and cannot be set
 
 Description:
 Use the <tracks> <property> to find out the contents of a <QuickTime>
@@ -41,7 +41,7 @@ This property was removed from the Windows platform in version 8.1.0,
 due to the change of player implementation from QuickTime to DirectShow.
 
 References: QuickTime (glossary), property (glossary), items (keyword),
-line (keyword), trackCount (property)
+line (keyword), duration (property), trackCount (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/traversalOn.lcdoc
+++ b/docs/dictionary/property/traversalOn.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the traversalOn of <object> to {true | false}
 
 Summary:
-Specifies whether a <control> can become the <active (focused)
-control(glossary)>. 
+Specifies whether a <control> can become the 
+<active control|active (focused) control>. 
 
 Associations: field, button, group
 


### PR DESCRIPTION
property/tilt.lcdoc - Fixed broken link.
keyword/to.lcdoc - Fixed broken links.
property/toggleHilites.lcdoc - Fixed broken link. Substituted multipleLines with multipleHilites in all instances.
function/tool.lcdoc - Fixed issue with return values appearing in the version it was introduced
property/toolTipDelay.lcdoc - Fixed broken link.
property/topLeft.lcdoc - Fixed broken link.
command/topLevel.lcdoc - Fixed broken links.
property/topPattern.lcdoc - Fixed broken links.
function/topStack.lcdoc - Fixed broken link.
property/tracks.lcdoc - Formatted item list for returns value. Can’t identify missing items.
property/traversalOn.lcdoc - Fixed broken link.