### PR TITLE
[Dictionary] trueWordOffset to unicodeTooltip.lcdoc

### DIFF
--- a/docs/dictionary/command/undo.lcdoc
+++ b/docs/dictionary/command/undo.lcdoc
@@ -20,11 +20,11 @@ Description:
 The undo command undoes the last action performed by the user. Undoable
 actions include:
 
-	* Using the paint tools
-	* Deleting controls by selecting them with the Pointer tool and
-      pressing Delete
-	* Moving controls with the Pointer tool
-	* Editing actions (such as typing, cutting, and pasting) in a field
+ * Using the paint tools
+ * Deleting controls by selecting them with the Pointer tool and
+pressing Delete
+ * Moving controls with the Pointer tool
+ * Editing actions (such as typing, cutting, and pasting) in a field
 
 
 The undo command cannot be used to undo actions performed by a script.

--- a/docs/dictionary/command/ungroup.lcdoc
+++ b/docs/dictionary/command/ungroup.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: ungroup
 
 Summary:
-Makes a <group(glossary)|group's> <object|objects> into <card
-control|card objects>, deleting the <group(command)>.
+Makes a <group(glossary)|group's> <object|objects> into 
+<card control|card objects>, deleting the <group(command)>.
 
 Associations: group
 

--- a/docs/dictionary/function/truewordOffset.lcdoc
+++ b/docs/dictionary/function/truewordOffset.lcdoc
@@ -18,7 +18,7 @@ Example:
 truewordOffset("Chile",tListOfCountries) -- returns 48
 
 Example:
-truewordOffset("d'Ãªtre","Ce n'est pas tant d'Ãªtre riche qui fait le bonheur, c'est de le devenir.") -- returns 5
+truewordOffset("d'être","Ce n'est pas tant d'être riche qui fait le bonheur, c'est de le devenir.") -- returns 5
 
 Parameters:
 stringToFind (string):

--- a/docs/dictionary/keyword/uInt1.lcdoc
+++ b/docs/dictionary/keyword/uInt1.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt1
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 1-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 1-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,9 +23,9 @@ read from file myFile for 3 uInt1
 Description:
 Use the <uInt1> <keyword> to read data from a <binary file>.
 
-If you specify <uInt1> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
+If you specify <uInt1> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is returned 
+as a series of numbers separated by commas, one for each unsigned <integer>
 read. 
 
 References: read from socket (command), read from process (command),

--- a/docs/dictionary/keyword/uInt2.lcdoc
+++ b/docs/dictionary/keyword/uInt2.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt2
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 2-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 2-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,10 +23,10 @@ read from file "/etc/datoids" for 1 uInt2
 Description:
 Use the <uInt2> <keyword> to read data from a <binary file>.
 
-If you specify <uInt2> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
-read. 
+If you specify <uInt2> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+unsigned <integer> read. 
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/keyword/uInt4.lcdoc
+++ b/docs/dictionary/keyword/uInt4.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt4
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 4-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 4-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,10 +23,10 @@ read from file it for 17 uInt4
 Description:
 Use the <uInt4> <keyword> to read data from a <binary file>.
 
-If you specify <uInt4> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
-read. 
+If you specify <uInt4> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+unsigned <integer> read. 
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/message/undoKey.lcdoc
+++ b/docs/dictionary/message/undoKey.lcdoc
@@ -30,8 +30,8 @@ unless "Suspend LiveCode UI" is turned on in the Development <menu>.
 This means that the <undoKey> <message> is not received by a <stack> if
 it's running in the <development environment>.
 
-The <undoKey> <message> is sent when the user presses Command-Z (on <Mac
-OS|Mac OS systems>), Control-Z (on <Windows|Windows systems>),
+The <undoKey> <message> is sent when the user presses Command-Z (on 
+<Mac OS|Mac OS systems>), Control-Z (on <Windows|Windows systems>),
 Alt-Backspace (on <Unix|Unix systems>), or the keyboard <Undo> key.
 
 The message is sent to the active (focused) control, or to the current

--- a/docs/dictionary/property/twelveHourTime.lcdoc
+++ b/docs/dictionary/property/twelveHourTime.lcdoc
@@ -33,7 +33,7 @@ of the <convert> command when a time specifier is used.
 If the <twelveHourTime> is true, the time function <return|returns> a
 value including AM or PM. If the <twelveHourTime> is false, AM or PM is
 not included; instead, the hour is not reset to 1 after noon. For
-example, the time 2:35 PM <a/>in 12-hour time is equivalent to 14:35 in
+example, the time 2:35 PM in 12-hour time is equivalent to 14:35 in
 24-hour time.
 
 References: convert (command), function (control structure),

--- a/docs/dictionary/property/umask.lcdoc
+++ b/docs/dictionary/property/umask.lcdoc
@@ -22,8 +22,7 @@ set the umask to 0077
 
 Description:
 Use the <umask> command to set the access permissions for
-
-    <files> and <folders> created by LiveCode.
+<files> and <folders> created by LiveCode.
 
 
 The umask is a positive integer, or empty.
@@ -31,18 +30,20 @@ The umask is a positive integer, or empty.
 By default, the umask is set to the user's Unix "umask" setting.
 
 The <umask> blocks specific permissions from being granted for newly
-created <files> and <folders>. It affects <files> created with the <open
-file> <command>, <folders> created with the <create folder> <command>,
-and <files> and <folders> created on the local system with the <URL>
-<keyword>. 
+created <files> and <folders>. It affects <files> created with the 
+<open file> <command>, <folders> created with the <create folder> 
+<command>, and <files> and <folders> created on the local system with 
+the <URL> <keyword>. 
 
 The <umask> is most easily represented in <octal>.  Each digit of the
 <octal> representation of the <umask> specifies a set of permissions:
-<ul> <li> Read permission (4) lets a user read or copy the file or
-folder.</li> <li> Write permission (2) lets a user change the contents
-of the file or folder.</li> <li> Execute permission (1) lets a user run
+ - Read permission (4) lets a user read or copy the file or
+folder.
+ - Write permission (2) lets a user change the contents
+of the file or folder.
+ - Execute permission (1) lets a user run
 the file (if it is a program file), or work with files in the
-folder.</li> </ul>
+folder.
 
 Each digit is the sum of the permission values that are to be blocked.
 For example, to specify that read and execute permission should both be

--- a/docs/dictionary/property/unicodeFormattedText.lcdoc
+++ b/docs/dictionary/property/unicodeFormattedText.lcdoc
@@ -21,8 +21,8 @@ aided unicode text manipulation is no longer required. This property
 should not be used in new code; simply get the formattedText as normal.
 The following are now equivalent:
 
-get the unicodeFormattedText of field 1
-get textEncode(the formattedText of field 1, "UTF16")
+    get the unicodeFormattedText of field 1
+    get textEncode(the formattedText of field 1, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodeLabel.lcdoc
+++ b/docs/dictionary/property/unicodeLabel.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeLabel of button 1 to tText
-set the label of button 1 to textDecode(tText, "UTF16")
+    set the unicodeLabel of button 1 to tText
+    set the label of button 1 to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodePlainText.lcdoc
+++ b/docs/dictionary/property/unicodePlainText.lcdoc
@@ -20,8 +20,8 @@ aided unicode text manipulation is no longer required. This property
 should not be used in new code; simply get the plainText as normal. The
 following are now equivalent:
 
-get the unicodePlainText of field 1
-get textEncode(the plainText of field 1, "UTF16")
+    get the unicodePlainText of field 1
+    get textEncode(the plainText of field 1, "UTF16")
 
 OS: mac, windows, linux
 

--- a/docs/dictionary/property/unicodeTitle.lcdoc
+++ b/docs/dictionary/property/unicodeTitle.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeTitle of this stack to tText
-set the title of this stack to textDecode(tText, "UTF16")
+    set the unicodeTitle of this stack to tText
+    set the title of this stack to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodeTooltip.lcdoc
+++ b/docs/dictionary/property/unicodeTooltip.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeTooltip of button 1 to tText
-set the tooltip of button 1 to textDecode(tText, "UTF16")
+    set the unicodeTooltip of button 1 to tText
+    set the tooltip of button 1 to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 


### PR DESCRIPTION
function/truewordOffset.lcdoc - Fixed apparent encoding error in code example.
property/twelveHourTime.lcdoc - Removed html element
keyword/uInt1.lcdoc - Fixed broken links
keyword/uInt2.lcdoc - Fixed broken links
keyword/uInt4.lcdoc - Fixed broken links
property/umask.lcdoc - Formatted description to not have a part show up (incompletely) as a code example. Replaced unordered list html with equivalent markdown.
command/undo.lcdoc - Formatted list of undoable actions to not show up as a code example
message/undoKey.lcdoc - Fixed broken link.
command/ungroup.lcdoc - Fixed broken link.
property/unicodeFormattedText.lcdoc - Formatted equivalent code examples to show up as code examples.
property/unicodeLabel.lcdoc - Formatted equivalent code examples to show up as code examples.
property/unicodePlainText.lcdoc - Formatted equivalent code examples to show up as code examples.
property/unicodeTitle.lcdoc  - Formatted equivalent code examples to show up as code examples.
property/unicodeTooltip.lcdoc - Formatted equivalent code examples to show up as code examples.