### PR TITLE
[Bugfix-13506] Remove outdated information from create entry

### DIFF
--- a/docs/dictionary/command/create.lcdoc
+++ b/docs/dictionary/command/create.lcdoc
@@ -66,13 +66,6 @@ If you use the invisible form, the object is created with its visible
 property set to false, so it cannot be seen. Use this form to create a 
 hidden object, change its appearance or position, then make it visible.
 
-When the new control is created, the Pointer tool is automatically 
-chosen. If you use the create command in a handler, you can use the 
-following statement after the create command to resume using the Browse 
-tool:
-
-    send "choose browse tool" to me in 1 tick
-
 >*Tip:*  To create a control in a specific stack, first set the 
 <defaultStack> to the stack where you want to create the new control:
 

--- a/docs/dictionary/command/create.lcdoc
+++ b/docs/dictionary/command/create.lcdoc
@@ -69,26 +69,9 @@ hidden object, change its appearance or position, then make it visible.
 When the new control is created, the Pointer tool is automatically 
 chosen. If you use the create command in a handler, you can use the 
 following statement after the create command to resume using the Browse 
-tool:	send "choose browse tool" to me in 1 tick
+tool:
 
->*Note:*  In the development environment, after an object is created, 
-LiveCode automatically resets the corresponding template to its default 
-values. This means that if you change an object template and then
-create several objects of that type, only the first object will reflect
-your settings. To prevent LiveCode from automatically setting the
-template back to its defaults, set the <lockMessages> property to true
-before creating the objects:
-
-    set the borderWidth of the templateButton to 8
-    lock messages
-    repeat for 5 times
-    create button
-    end repeat
-    unlock messages
-
-
-LiveCode resets the template only when in the development environment, 
-not in standalone applications.
+    send "choose browse tool" to me in 1 tick
 
 >*Tip:*  To create a control in a specific stack, first set the 
 <defaultStack> to the stack where you want to create the new control:

--- a/docs/notes/bugfix-13506.md
+++ b/docs/notes/bugfix-13506.md
@@ -1,0 +1,1 @@
+# Removed outdated information from 'create' documentation.


### PR DESCRIPTION
Removed a paragraph regarding the template object reseting after using the create command as it does not appear to be true.

Note: It was commented on (privately) that the template object *does* reset after the next event dispatch point and example code was given but that wasn't reproduced in LC 9.0.2.