### PR TITLE
[Dictionary] unload extension to yExtent

### DIFF
--- a/docs/dictionary/command/unload-extension.lcdoc
+++ b/docs/dictionary/command/unload-extension.lcdoc
@@ -27,11 +27,11 @@ extensionIdentifier:
 The identifier of the extension to unload.
 
 Description:
-Use the <unload extension> <command> to unload a <LiveCode Builder
-extension>. The extension is removed from memory. If the extension is a
-library, its public handlers will no longer be in the message path. If
-it is a widget, it will no longer be available as a control to add to a
-stack. 
+Use the <unload extension> <command> to unload a 
+<LiveCode Builder extension>. The extension is removed from memory. If 
+the extension is a library, its public handlers will no longer be in the 
+message path. If it is a widget, it will no longer be available as a 
+control to add to a stack. 
 
 If a module with the given identifier has already been loaded into
 memory, the result will be set to "module already loaded".

--- a/docs/dictionary/command/write-to-driver.lcdoc
+++ b/docs/dictionary/command/write-to-driver.lcdoc
@@ -41,10 +41,10 @@ References: write to file (command), open driver (command),
 close driver (command), read from driver (command),
 write to process (command), write to socket (command),
 function (control structure), driverNames (function), result (function),
-command (glossary), peripheral device (glossary), real8 (keyword),
-int1 (keyword), int4 (keyword), real4 (keyword), 
-int2 (keyword), LPT1: (keyword), printer: (keyword), modem: (keyword), 
-COMn: (keyword)
+command (glossary), peripheral device (glossary), COMn: (keyword), 
+real8 (keyword), int1 (keyword), int4 (keyword), real4 (keyword), 
+int2 (keyword), LPT1: (keyword), printer: (keyword), modem: (keyword) 
+
 
 Tags: networking
 

--- a/docs/dictionary/command/write-to-driver.lcdoc
+++ b/docs/dictionary/command/write-to-driver.lcdoc
@@ -42,8 +42,9 @@ close driver (command), read from driver (command),
 write to process (command), write to socket (command),
 function (control structure), driverNames (function), result (function),
 command (glossary), peripheral device (glossary), real8 (keyword),
-int1 (keyword), int4 (keyword), real4 (keyword), int2 (keyword),
-LPT1: (keyword), printer: (keyword), modem: (keyword), COMn: (keyword)
+int1 (keyword), int4 (keyword), real4 (keyword), 
+int2 (keyword), LPT1: (keyword), printer: (keyword), modem: (keyword), 
+COMn: (keyword)
 
 Tags: networking
 

--- a/docs/dictionary/command/write-to-process.lcdoc
+++ b/docs/dictionary/command/write-to-process.lcdoc
@@ -30,8 +30,8 @@ been opened previously with the open process command; otherwise, an
 error message is returned in the result.
 
 The result:
-The process to write to must be opened first with the <open process
-command>, and the mode the <process> was opened in must be write or
+The process to write to must be opened first with the <open process>
+<command>, and the mode the <process> was opened in must be write or
 update. If the process is not running or is read-only, the <result>
 function is set to "Process is not open for write.". If there is an
 error writing to the process, the <result> function <return|returns> the
@@ -41,7 +41,6 @@ Description:
 Use the <write to process> <command> to send input to another program.
 
 References: open process (command), read from process (command),
-write to driver (command), open process command (command),
-result (function), command (glossary), process (glossary),
-return (glossary), stdout (keyword)
+write to driver (command), result (function), command (glossary), 
+process (glossary), return (glossary), stdout (keyword)
 

--- a/docs/dictionary/function/URLDecode.lcdoc
+++ b/docs/dictionary/function/URLDecode.lcdoc
@@ -38,8 +38,8 @@ another system.
 When the <URLDecode> function encounters a percent sign (%), it treats
 the next two characters as <hexadecimal> digits. (If one of the
 <characters> is not a <hexadecimal> digit, it's treated as a zero.) The
-number is converted to its <character> equivalent, using the <character
-set> currently in use.
+number is converted to its <character> equivalent, using the 
+<character set> currently in use.
 
 References: post (command), function (control structure),
 decompress (function), macToISO (function), arrayDecode (function),

--- a/docs/dictionary/function/variableNames.lcdoc
+++ b/docs/dictionary/function/variableNames.lcdoc
@@ -7,8 +7,8 @@ Syntax: the variableNames
 Syntax: variableNames()
 
 Summary:
-<return|Returns> a list of all <parameter|parameters>, <local
-variable|local variables>, and <global> <variable|variables>.
+<return|Returns> a list of all <parameter|parameters>, 
+<local variable|local variables>, and <global> <variable|variables>.
 
 Introduced: 1.0
 
@@ -26,13 +26,12 @@ Returns:
 The <variableNames> function <return|returns> a value consisting of four
 <lines> :
 
-        1. Parameters passed to the current handler (including leading
-           '@' for parameters passed by-reference)
-        2. Local variables created in the current handler
-        3. Local variables created in the current script but outside all
-           handlers 
-        4. Global variables
-
+1. Parameters passed to the current handler (including leading
+'@' for parameters passed by-reference)
+2. Local variables created in the current handler
+3. Local variables created in the current script but outside all
+handlers 
+4. Global variables
 
 Within each line, the variable or parameter names are separated by
 commas. 

--- a/docs/dictionary/function/vectorDotProduct.lcdoc
+++ b/docs/dictionary/function/vectorDotProduct.lcdoc
@@ -40,8 +40,7 @@ keys from each array. It is equivalent to the following:
 
     put 0 into runningTotal
     repeat for each key currentKey in firstArray
-
-    add firstArray[currentKey] * secondArray[currentKey] to runningTotal
+        add firstArray[currentKey] * secondArray[currentKey] to runningTotal
     end repeat
 
 
@@ -49,8 +48,7 @@ The names of the keys in <firstArray> must be the same as names of the
 keys of <secondArray>.
 
 References: sum (function), matrixMultiply (function),
-transposeMatrix (function), function (glossary), array (glossary),
-return (glossary)
+function (glossary), array (glossary), return (glossary)
 
 Tags: math
 

--- a/docs/dictionary/function/within.lcdoc
+++ b/docs/dictionary/function/within.lcdoc
@@ -63,7 +63,9 @@ area, and false if the <point> is in the <stack|stack's> <title bar> or
 borders. 
 
 The expression
-<point> is within the rect of <object(glossary)> 
+
+    <point> is within the rect of <object(glossary)> 
+
 is equivalent to
 
     within(<object(glossary)>, <point>)

--- a/docs/dictionary/keyword/while.lcdoc
+++ b/docs/dictionary/keyword/while.lcdoc
@@ -27,14 +27,13 @@ as a condition continues to be true.
 LiveCode evaluates the condition each time the loop repeats, at the top
 of the loop (before the statements in the <repeat structure> are
 executed). If the condition is false, the <loop> is skipped and
-<execute|execution> <resume|resumes> with the <statement> after the <end
-repeat> statement.
+<execute|execution> <resume|resumes> with the <statement> after the 
+<end repeat> statement.
 
-If the condition is already false when LiveCode reaches the <repeat
-statement>, the <loop> is not <execute|executed> at all.
+If the condition is already false when LiveCode reaches the <repeat>
+statement, the <loop> is not <execute|executed> at all.
 
-References: repeat statement (control structure),
-repeat structure (control structure), repeat (control structure),
+References: repeat (control structure),
 keyword (glossary), resume (glossary), statement (glossary),
 loop (glossary), control structure (glossary), execute (glossary),
 forever (keyword), for (keyword), end repeat (keyword)

--- a/docs/dictionary/property/vGrid.lcdoc
+++ b/docs/dictionary/property/vGrid.lcdoc
@@ -34,8 +34,8 @@ with a grid of cells.
 If the  <vGrid> <property> is true, LiveCode draws a vertical line at
 each <tab stop> position in the <field(keyword)>. The lines are drawn in
 the <field(object)|field's> <borderColor>. This <property> is useful for
-<field(object)|fields> that are used like a spreadsheet, with each <tab
-stop> marking a column.
+<field(object)|fields> that are used like a spreadsheet, with each 
+<tab stop> marking a column.
 
 Any text in a column is truncated when it reaches the right edge of the
 column. To show the entire contents of the column, drag over the text to

--- a/docs/dictionary/property/width.lcdoc
+++ b/docs/dictionary/property/width.lcdoc
@@ -51,8 +51,8 @@ The <width> of an object cannot be set to zero. Attempting to do so will
 set the <width> to 1 instead.
 
 >*Cross-platform note:*  On <Mac OS> and <OS X|OS X systems>, the
-> maximum <width> of an <image> is 16384 divided by the screen's <bit
-> depth>. (For example, if the number of colors is "Millions", the
+> maximum <width> of an <image> is 16384 divided by the screen's 
+> <bit depth>. (For example, if the number of colors is "Millions", the
 > maximum image width is 4096 <pixels>.)
 
 >*Note:* The current architecture uses 16-bit signed integers for all

--- a/docs/dictionary/property/windowBoundingRect.lcdoc
+++ b/docs/dictionary/property/windowBoundingRect.lcdoc
@@ -21,11 +21,11 @@ Value:
 The <windowBoundingRect> consists of four <integer|integers> separated
 by commas. By default the coordinates are in the same format as those
 returned by the <screenRect>. This means they are relative to the
-topleft of the primary monitor and may therefore be negative. On <Mac
-OS|Mac OS systems>, the <default> <windowBoundingRect> is adjusted to
-leave room for the <menu bar>. On <Windows|Windows systems>, the
-<default> <windowBoundingRect> is adjusted to leave room for the <task
-bar>. 
+topleft of the primary monitor and may therefore be negative. On 
+<Mac OS|Mac OS systems>, the <default> <windowBoundingRect> is adjusted 
+to leave room for the <menu bar>. On <Windows|Windows systems>, the
+<default> <windowBoundingRect> is adjusted to leave room for the 
+<task bar>. 
 
 Description:
 Use the <windowBoundingRect> <property> to ensure free space on the

--- a/docs/dictionary/property/windowManagerPlace.lcdoc
+++ b/docs/dictionary/property/windowManagerPlace.lcdoc
@@ -25,8 +25,8 @@ Value (bool):
 The <windowManagerPlace> of a <stack> is true or false.
 
 Description:
-Use the <windowManagerPlace> <property> to determine how the <stack
-window> is placed on <Unix|Unix systems>.
+Use the <windowManagerPlace> <property> to determine how the 
+<stack window> is placed on <Unix|Unix systems>.
 
 If the <windowManagerPlace> <property> is true, the window manager uses
 the "mwm" <resource|resources> "clientAutoPlace" and

--- a/docs/dictionary/property/xExtent.lcdoc
+++ b/docs/dictionary/property/xExtent.lcdoc
@@ -23,8 +23,8 @@ Description:
 Use the <xExtent> <property> to control the appearance of an <EPS|EPS
 object>. 
 
-An EPS object's <xExtent> is the width in <points> of the <PostScript>.
-This controls the size of the <PostScript> when it's printed.
+An EPS object's <xExtent> is the width in <points> of the <postScript>.
+This controls the size of the <postScript> when it's printed.
 
 The <xExtent> of an <EPS|EPS object> is equal to the third <item> in the
 <object|object's> <boundingBox> <property>.

--- a/docs/dictionary/property/xOffset.lcdoc
+++ b/docs/dictionary/property/xOffset.lcdoc
@@ -6,7 +6,7 @@ Syntax: set the xOffset of <EPSObject> to <number>
 
 Summary:
 Specifies the location of the left edge of an <EPS|EPS object's>
-<PostScript> code.
+<postScript> code.
 
 Introduced: 1.0
 

--- a/docs/dictionary/property/yExtent.lcdoc
+++ b/docs/dictionary/property/yExtent.lcdoc
@@ -23,8 +23,8 @@ Description:
 Use the <yExtent> <property> to control the appearance of an <EPS|EPS
 object>. 
 
-An EPS object's <yExtent> is the height in <points> of the <PostScript>
-object. This controls the size of the <PostScript> object when it's
+An EPS object's <yExtent> is the height in <points> of the <postScript>
+object. This controls the size of the <postScript> object when it's
 rendered. 
 
 The <yExtent> of an <EPS|EPS object> is equal to the fourth <item> in

--- a/docs/glossary/v/variable-watcher.lcdoc
+++ b/docs/glossary/v/variable-watcher.lcdoc
@@ -9,9 +9,9 @@ Part of the LiveCode <development environment>, a pane that displays the
 current values of <variable|variables> during script
 <execute|execution>. 
 
-To display the variable watcher, click the variables pane in the <script
-editor>. To display the variable watcher from the Menubar, choose Debug
-→ Variables. If you are not debugging a script, this will allow you to
+To display the variable watcher, click the variables pane in the 
+<script editor>. To display the variable watcher from the Menubar, choose 
+Debug → Variables. If you are not debugging a script, this will allow you to
 watch global variables.
 
 References: debugger (glossary), variable (glossary), execute (glossary),


### PR DESCRIPTION
command/unload-extension.lcdoc - Fixed broken link
function/URLDecode.lcodoc - Fixed broken link.
glossary/v/variable-watcher.lcdoc - Fixed broken link.
function/variableNames.lcdoc - Formatted ordered list to not show up as a code example.
function/vectorDotProduct.lcdoc - Formatted code example for readability. Removed unused, non-existent entry.
property/vGrid.lcdoc - Fixed broken link.
keyword/while.lcdoc - Fixed broken links. Removed non-existent references.
property/width.lcdoc - Fixed broken link.
property/windowBoundingRect.lcdoc - Fixed broken links.
property/windowManagerPlace.lcdoc - Fixed broken link.
function/within.lcdoc - Formatted code example.
command/write-to-drive.lcdoc - Fixed references anomaly.
command/write-to-process.lcdoc - Fixed broken link. Removed non-existent reference.
property/xExtent.lcdoc - Fixed broken links.
property/xOffset.lcdoc - Fixed broken links.
property/yExtent.lcdoc - Fixed broken links.