### PR TITLE
[[ Bug ]] Fix over-release crash in ListToNSArray

### DIFF
--- a/libfoundation/src/foundation-cf.cpp
+++ b/libfoundation/src/foundation-cf.cpp
@@ -514,7 +514,7 @@ bool MCValueConvertToCFTypeRef(MCValueRef p_value, bool p_use_lists, CFTypeRef& 
         default:
             if (MCValueGetTypeInfo(p_value) == kMCObjcObjectTypeInfo)
             {
-                r_cf_type = MCObjcObjectGetId((MCObjcObjectRef)p_value);
+                r_cf_type = CFRetain(MCObjcObjectGetId((MCObjcObjectRef)p_value));
                 return true;
             }
             break;


### PR DESCRIPTION
This patch fixes an over-release of any objective-c objects that are elements
of a list passed to `ListToNSArray`. `MCValueConvertToCFTypeRef` should return
a retained object which will be released when `MCAutoCustomPointer<const void, CFDeleter> t_cf_value;`
goes out of scope.

(cherry picked from commit 3688b014bd966dfe77abb46213b411396f0da8db)