### PR TITLE
Merge develop 9.0 21.02.2019

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2018-10-11"
+constant kMergExtVersion = "2019-2-12"
 constant kTSNetVersion = "1.3.9"
 
 local sEngineDir

--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,7 +1,7 @@
 ﻿script "BuilderUtilities"
 
 constant kMergExtVersion = "2018-10-11"
-constant kTSNetVersion = "1.3.8"
+constant kTSNetVersion = "1.3.9"
 
 local sEngineDir
 local sWorkDir

--- a/builder/tools_builder.livecodescript
+++ b/builder/tools_builder.livecodescript
@@ -248,11 +248,6 @@ private command toolsBuilderMakePackage pVersion, pEdition, pPlatform, pEngineFo
    packageCompilerConfigureVariable tPackager, "ProductTitle", tProductName && getReadableVersion(pVersion)
    packageCompilerConfigureVariable tPackager, "ProductTag", tProductTag & "_" & getTaggedVersion(pVersion)
 
-   -- For Linux only, case-fold the product name to lowercase and
-   -- remove all spaces - we can just use the product tag
-   if pPlatform is "Linux" or pPlatform is "Linux-x86_64" or pPlatform is "Linux-armv6hf" then
-      put tProductTag into tProductName
-   end if
    packageCompilerConfigureVariable tPackager, "ProductName", tProductName
    
    -- The edition tags.

--- a/docs/dictionary/command/revXMLPutIntoNode.lcdoc
+++ b/docs/dictionary/command/revXMLPutIntoNode.lcdoc
@@ -25,8 +25,8 @@ revXMLPutIntoNode myCurrentNode,dataPaths["current"],field "Data", true
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 nodePath:
 The path to the node whose contents you want to set.
@@ -66,7 +66,8 @@ the <node|node's> start and end <tag|tags>.
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), revXMLAppend (command),
-result (function), uniDecode (function), XML tree (glossary),
+result (function), uniDecode (function), revXMLCreateTree (function), 
+revXMLCreateTreeFromFile (function), XML tree (glossary),
 Standalone Application Settings (glossary), tag (glossary),
 standalone application (glossary), Unicode (glossary), node (glossary),
 command (glossary), LiveCode custom library (glossary),

--- a/docs/dictionary/command/revXMLSetAttribute.lcdoc
+++ b/docs/dictionary/command/revXMLSetAttribute.lcdoc
@@ -55,8 +55,7 @@ If the attribute already exists, its value is set to the <newValue>.
 > <uniDecode> function to encode the text as UTF-8:
 
     revXMLSetAttribute myTree,the nodeName of me, \
-
-    uniDecode(the unicodeText of it,"UTF8")
+          uniDecode(the unicodeText of it,"UTF8")
 
 
 >*Important:*  The <revXMLSetAttribute> <command> is part of the 

--- a/docs/dictionary/command/revZipCloseArchive.lcdoc
+++ b/docs/dictionary/command/revZipCloseArchive.lcdoc
@@ -23,11 +23,9 @@ revZipCloseArchive the cArchive of me
 
 Parameters:
 archivePath:
-The absolute path to the zip archive to close. >*Note:* Any changes you
-make to an open zip archive will not be applied until you close the
-archive using this command. If revZipCloseArchive encounters an error,
-the result is set to an error code beginning with "ziperr", otherwise
-the result will be empty.
+The absolute path to the zip archive to close. 
+>*Note:* Any changes you make to an open zip archive will not be 
+>applied until you close the archive using this command. 
 
 The result:
 If <revZipCloseArchive> encounters an error, the result is set to an

--- a/docs/dictionary/command/revZipExtractItemToVariable.lcdoc
+++ b/docs/dictionary/command/revZipExtractItemToVariable.lcdoc
@@ -35,8 +35,8 @@ otherwise the result will be empty.
 Description:
 Use the <revZipExtractItemToVariable> command to load an item from a zip
 archive into memory as a variable in your LiveCode program. The archive
-must already have been opened by using the <revZipOpenArchive
-(command)>command. 
+must already have been opened by using the <revZipOpenArchive (command)> 
+command. 
 
 References: revZipOpenArchive (command),
 revZipExtractItemToFile (command), revZipEnumerateItems (function)

--- a/docs/dictionary/command/rotate.lcdoc
+++ b/docs/dictionary/command/rotate.lcdoc
@@ -62,9 +62,8 @@ the <angle> <property> affects only the screen display of the
 <image(keyword)>, not the actual picture data in it, so setting it
 repeatedly does not introduce distortion.
 
-    >*Note:*Rotating an image using good or best <resizeQuality> might
-    > cause the mask to be promoted to an alpha channel.
-
+>*Note:*Rotating an image using good or best <resizeQuality> might
+> cause the mask to be promoted to an alpha channel.
 
 >*Note:* As rotate is an image editing operation, the target image needs
 > to be on the currently visible card of an open stack to function.

--- a/docs/dictionary/command/topLevel.lcdoc
+++ b/docs/dictionary/command/topLevel.lcdoc
@@ -27,14 +27,14 @@ stack:
 Any stack reference.
 
 Description:
-Use the <topLevel> <command> to display a <stack> in an <editable
-window>. 
+Use the <topLevel> <command> to display a <stack> in an 
+<editable window>. 
 
 An editable window can be resized (if its resizable <property> is true),
 and its <control|controls> can be <selected>, moved, and changed. To
-edit a <stack> of a different style (a <palette>, <modeless>, or <modal
-dialog box|modal dialog>), use the <topLevel> <command> to display it in
-an <editable window>.
+edit a <stack> of a different style (a <palette>, <modeless>, or 
+<modal dialog box|modal dialog>), use the <topLevel> <command> to 
+display it in an <editable window>.
 
 The <topLevel> <command> closes the <stack> and reopens it as an
 <editable window>, so <closeStack> and <openStack>, <closeCard> and
@@ -50,11 +50,11 @@ does not close and reopen it.
 References: palette (command), lock messages (command), drawer (command),
 modeless (command), choose (command), property (glossary),
 current card (glossary), execute (glossary), message (glossary),
-editable window (glossary), command (glossary),
+editable window (glossary), command (glossary), control (glossary),
 modal dialog box (glossary), openCard (message), closeStack (message),
 closeCard (message), closeBackground (message), openStack (message),
-openBackground (message), stack (object), control (object),
-cantModify (property), selected (property)
+openBackground (message), stack (object), cantModify (property), 
+selected (property)
 
 Tags: windowing
 

--- a/docs/dictionary/command/undo.lcdoc
+++ b/docs/dictionary/command/undo.lcdoc
@@ -20,11 +20,11 @@ Description:
 The undo command undoes the last action performed by the user. Undoable
 actions include:
 
-	* Using the paint tools
-	* Deleting controls by selecting them with the Pointer tool and
-      pressing Delete
-	* Moving controls with the Pointer tool
-	* Editing actions (such as typing, cutting, and pasting) in a field
+ * Using the paint tools
+ * Deleting controls by selecting them with the Pointer tool and
+pressing Delete
+ * Moving controls with the Pointer tool
+ * Editing actions (such as typing, cutting, and pasting) in a field
 
 
 The undo command cannot be used to undo actions performed by a script.

--- a/docs/dictionary/command/ungroup.lcdoc
+++ b/docs/dictionary/command/ungroup.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: ungroup
 
 Summary:
-Makes a <group(glossary)|group's> <object|objects> into <card
-control|card objects>, deleting the <group(command)>.
+Makes a <group(glossary)|group's> <object|objects> into 
+<card control|card objects>, deleting the <group(command)>.
 
 Associations: group
 

--- a/docs/dictionary/function/revOpenDatabase.lcdoc
+++ b/docs/dictionary/function/revOpenDatabase.lcdoc
@@ -47,6 +47,8 @@ put revOpenDatabase("sqlite", "mydb.sqlite", "extensions" )
 -- enable loadable extensions for this connection
 put revOpenDatabase("sqlite", "mydb.sqlite", "binary,extensions" )
 -- enable both 'new' binary mode and loadable extensions
+put revOpenDatabase("sqlite", "file:/Users/johnsmith/Desktop/mydb.sqlite", "uri" )
+-- enable support for uri filenames for this connection
 
 Example:
 get revOpenDatabase("mysql", "localhost", "dbName", myUsr, myPass, false, "/var/mysql.sock", 1, true)
@@ -207,7 +209,7 @@ Use the <revOpenDatabase> function to start working with a database.
 > 'SSL Encryption' from among the available 'script libraries' in the
 > standalone application settings panel.
 
-The version of SQLite has been updated to 3.15.0.
+The version of SQLite has been updated to 3.26.0.
 
 The SQLite RTREE and FTS5 modules are now available.
 
@@ -220,6 +222,20 @@ the encoding that used to occur) - this means databases can be made to
 contain binary data which is compatible with other applications. To
 utilize this functionality, the 'binary' option must be passed to the
 revOpenDatabase() call when creating the database connection.
+
+URI filenames are now supported. To utilize this functionality, the 'uri'
+option must be passed to the revOpenDatabase() call when creating the database
+connection.
+
+URI filenames are useful because they allow appending parameter strings to the filname.
+For example, in order to enable shared cache mode, you must open the database with a
+filename of the form:
+
+`file:<pathtodbfile>?cache=shared`
+
+You can also open a database for read only access:
+
+`file:<pathtodbfile>?mode=ro`
 
 The SQLite revOpenDatabase() call no longer requires 5 arguments and
 only requires a minimum of 2.

--- a/docs/dictionary/function/revXMLRPC_GetHost.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetHost.lcdoc
@@ -28,8 +28,8 @@ The number returned by the <revXMLRPC_CreateRequest> when you created the
 executed an <XML-RPC> request.
 
 Returns (string):
-The <revXMLRPC_GetHost> <function> returns the <IP address> or <domain
-name> of the <host> that is the target of the <XML-RPC document>.
+The <revXMLRPC_GetHost> <function> returns the <IP address> or 
+<domain name> of the <host> that is the target of the <XML-RPC document>.
 
 Description:
 Use the <revXMLRPC_GetHost> <function> to retrieve the host that is the

--- a/docs/dictionary/function/revXMLRPC_GetPath.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetPath.lcdoc
@@ -29,8 +29,8 @@ executed an <XML-RPC> request.
 
 Returns (string):
 The <revXMLRPC_GetPath> <function> returns the <file path>, which allows
-the <host> to determine which resource is the target of the <XML-RPC
-document>.
+the <host> to determine which resource is the target of the 
+<XML-RPC document>.
 
 Description:
 Use the <revXMLRPC_GetPath> <function> to retrieve the path that is the

--- a/docs/dictionary/function/revXMLRPC_GetSocket.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetSocket.lcdoc
@@ -28,9 +28,9 @@ executed an <XML-RPC> request.
 
 Returns (string):
 The <revXMLRPC_GetSocket> <function> returns the socket connection that
-is established with the <host>. By default, <XML-RPC> uses the <post
-command> to execute an <XML-RPC> request, but this has the overhead of
-opening and closing a new socket every time. You can avoid this by
+is established with the <host>. By default, <XML-RPC> uses the 
+<post command> to execute an <XML-RPC> request, but this has the overhead 
+of opening and closing a new socket every time. You can avoid this by
 re-using an already opened <socket>.
 
 Description:

--- a/docs/dictionary/function/revXMLRootNode.lcdoc
+++ b/docs/dictionary/function/revXMLRootNode.lcdoc
@@ -25,8 +25,8 @@ put revXMLRootNode(thisTree) into myStartNode
 
 Parameters:
 treeID:
-The number returned by the revXMLCreateTree or revXMLCreateTreeFromFile
-function when you created the XML tree.
+The number returned by the <revXMLCreateTree> or <revXMLCreateTreeFromFile>
+function when you created the <XML tree>.
 
 Returns:
 The <revXMLRootNode> <function> returns a node path.
@@ -51,6 +51,7 @@ If the <revXMLRootNode> <function> encounters an error, it
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), function (control structure),
+revXMLCreateFile (function), revXMLCreateFileFromTree (function),
 revXMLNextSibling (function), revXMLPreviousSibling (function),
 revXMLParent (function), revXMLFirstChild (function),
 Standalone Application Settings (glossary), root node (glossary),

--- a/docs/dictionary/function/revXMLText.lcdoc
+++ b/docs/dictionary/function/revXMLText.lcdoc
@@ -46,8 +46,8 @@ Returns:
 The <revXMLText> function returns XML text.
 
 Description:
-Use the <revXMLText> <function> to turn an <XML tree> back into an <XML
-document>. 
+Use the <revXMLText> <function> to turn an <XML tree> back into an 
+<XML document>. 
 
 If the <revXMLText> <function> encounters an error, it <return|returns>
 an error message starting with "xmlerr".

--- a/docs/dictionary/function/revXMLTrees.lcdoc
+++ b/docs/dictionary/function/revXMLTrees.lcdoc
@@ -28,8 +28,8 @@ The <revXMLTrees> <function> returns a list of tree IDs, one per <line>.
 
 Description:
 Use the <revXMLTrees> <function> to find out which <XML tree|XML trees>
-have been created, or when you want to perform an action on all the <XML
-tree|XML trees> you're working with.
+have been created, or when you want to perform an action on all the 
+<XML tree|XML trees> you're working with.
 
 Each tree ID is the number returned by the <revXMLCreateTree> or
 <revXMLCreateTreeFromFile> <function> when you created the <XML tree>.

--- a/docs/dictionary/function/revXMLValidateDTD.lcdoc
+++ b/docs/dictionary/function/revXMLValidateDTD.lcdoc
@@ -32,8 +32,8 @@ DTDText:
 A Document Type Definition.
 
 Returns:
-The <revXMLValidateDTD> <function> <return|returns> empty if the <XML
-tree> validates against the DTD.
+The <revXMLValidateDTD> <function> <return|returns> empty if the 
+<XML tree> validates against the DTD.
 
 Description:
 Use the <revXMLValidateDTD> <function> to <validate> an <XML tree>

--- a/docs/dictionary/function/tool.lcdoc
+++ b/docs/dictionary/function/tool.lcdoc
@@ -22,11 +22,11 @@ Example:
 if the tool is not "browse tool" then choose browse tool
 
 Returns (enum):
-The <tool> <function> <return|returns> one of the following <tool>
-names:browse, pointer, button, field, scrollbar, graphic, image, player,
-select, pencil, bucket, brush, eraser, spray can, rectangle, line, round
-rect, oval, polygon, curve, regular polygon, dropperfollowed by the word
-"tool" 
+The <tool> <function> <return|returns> one of the following 
+<tool> names: browse, pointer, button, field, scrollbar, graphic, image, 
+player, select, pencil, bucket, brush, eraser, spray can, rectangle, line, 
+round rect, oval, polygon, curve, regular polygon, or dropper, 
+followed by the word "tool" 
 
 
 Description:

--- a/docs/dictionary/function/topStack.lcdoc
+++ b/docs/dictionary/function/topStack.lcdoc
@@ -42,8 +42,8 @@ For example, an editable window has a mode of 1, and a
 <palette(command)> has a mode of 4. If several
 <palette(glossary)|palettes> and <editable window|editable windows> are
 open, the <topStack> is the frontmost editable <stack>, although
-<palette(glossary)|palettes> may be in front of it. If all the <editable
-window|editable windows> are then closed, the frontmost
+<palette(glossary)|palettes> may be in front of it. If all the 
+<editable window|editable windows> are then closed, the frontmost
 <palette(command)> becomes the <topStack>, since there is now no window
 with a lower <mode>.
 

--- a/docs/dictionary/function/truewordOffset.lcdoc
+++ b/docs/dictionary/function/truewordOffset.lcdoc
@@ -18,7 +18,7 @@ Example:
 truewordOffset("Chile",tListOfCountries) -- returns 48
 
 Example:
-truewordOffset("d'Ãªtre","Ce n'est pas tant d'Ãªtre riche qui fait le bonheur, c'est de le devenir.") -- returns 5
+truewordOffset("d'être","Ce n'est pas tant d'être riche qui fait le bonheur, c'est de le devenir.") -- returns 5
 
 Parameters:
 stringToFind (string):

--- a/docs/dictionary/keyword/menu.lcdoc
+++ b/docs/dictionary/keyword/menu.lcdoc
@@ -45,7 +45,7 @@ The syntax for menu item strings is:
     [&lt;flags&gt;] &lt;label&gt; ['/' &lt;accelerator&gt; ['|' &lt;tag&gt;]]
 
 
-Where `&lt;flags&gt;` may include:
+Where &lt;flags&gt; may include:
 
 * `!c`, `!n`, `!r`: the menu item has respectively, a check, no check,
   or a selected radio button
@@ -55,15 +55,15 @@ Where `&lt;flags&gt;` may include:
   menu item; use this to create submenus
 
 
-The `&lt;accelerator&gt;` can be specified as one of:
+The &lt;accelerator&gt; can be specified as one of:
 
-* `&lt;char&gt;`: Command key + specified char
-* `&lt;keyname&gt;`: Named key without modifiers
-* `&lt;modifiers&gt; &lt;char&gt;`: Specified modifiers + character
-* `&lt;modifiers&gt; &lt;keyname&gt;`: Specified modifiers + named key
+* &lt;char&gt;: Command key + specified char
+* &lt;keyname&gt;: Named key without modifiers
+* &lt;modifiers&gt; &lt;char&gt;: Specified modifiers + character
+* &lt;modifiers&gt; &lt;keyname&gt;: Specified modifiers + named key
 
 
-In the `&lt;accelerator&gt;`, `&lt;modifiers&gt;` is either:
+In the &lt;accelerator&gt;, &lt;modifiers&gt; is either:
 
 * a space separated list of: 'command' or 'cmd', 'control' or 'ctrl',
   'option' or 'opt', 'alt', 'shift'; in this case the keyname/char

--- a/docs/dictionary/keyword/to.lcdoc
+++ b/docs/dictionary/keyword/to.lcdoc
@@ -29,11 +29,11 @@ set the cIsRaining of me to true
 Description:
 Use the <to> <keyword> to complete a <command> that requires it.
 
-The <to> <keyword> is used with the <add>, <convert>, <copy>, <create
-alias>, <drag>, <exit to top>, <export>, <go>, <move>, <open socket>,
-<post>, print card, <rename>, <seek>, <send>, <send to program>, <write
-to file>, <write to process>, <write to socket>, and <write to driver>
-<command|commands>. 
+The <to> <keyword> is used with the <add>, <convert>, <copy>, 
+<create alias>, <drag>, <exit to top>, <export>, <go>, <move>, 
+<open socket>, <post>, print card, <rename>, <seek>, <send>, 
+<send to program>, <write to file>, <write to process>, 
+<write to socket>, and <write to driver> <command|commands>. 
 
 It is also used to designate the final color in visual effects, and with
 the set <command> to designate the new <property> setting.

--- a/docs/dictionary/keyword/uInt1.lcdoc
+++ b/docs/dictionary/keyword/uInt1.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt1
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 1-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 1-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,9 +23,9 @@ read from file myFile for 3 uInt1
 Description:
 Use the <uInt1> <keyword> to read data from a <binary file>.
 
-If you specify <uInt1> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
+If you specify <uInt1> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is returned 
+as a series of numbers separated by commas, one for each unsigned <integer>
 read. 
 
 References: read from socket (command), read from process (command),

--- a/docs/dictionary/keyword/uInt2.lcdoc
+++ b/docs/dictionary/keyword/uInt2.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt2
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 2-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 2-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,10 +23,10 @@ read from file "/etc/datoids" for 1 uInt2
 Description:
 Use the <uInt2> <keyword> to read data from a <binary file>.
 
-If you specify <uInt2> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
-read. 
+If you specify <uInt2> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+unsigned <integer> read. 
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/keyword/uInt4.lcdoc
+++ b/docs/dictionary/keyword/uInt4.lcdoc
@@ -7,9 +7,9 @@ Type: keyword
 Syntax: uInt4
 
 Summary:
-Used with the <read from file>, <read from process>, and <read from
-socket> <command|commands> to signify a <chunk> of <binary file|binary
-data> the size of an unsigned 4-byte <integer>.
+Used with the <read from file>, <read from process>, and 
+<read from socket> <command|commands> to signify a <chunk> of 
+<binary file|binary data> the size of an unsigned 4-byte <integer>.
 
 Introduced: 1.0
 
@@ -23,10 +23,10 @@ read from file it for 17 uInt4
 Description:
 Use the <uInt4> <keyword> to read data from a <binary file>.
 
-If you specify <uInt4> as the <chunk> type in a <read from file>, <read
-from process>, or <read from socket> <command>, the data is returned as
-a series of numbers separated by commas, one for each unsigned <integer>
-read. 
+If you specify <uInt4> as the <chunk> type in a <read from file>, 
+<read from process>, or <read from socket> <command>, the data is 
+returned as a series of numbers separated by commas, one for each 
+unsigned <integer> read. 
 
 References: read from socket (command), read from process (command),
 write to driver (command), read from file (command), keyword (glossary),

--- a/docs/dictionary/message/undoKey.lcdoc
+++ b/docs/dictionary/message/undoKey.lcdoc
@@ -30,8 +30,8 @@ unless "Suspend LiveCode UI" is turned on in the Development <menu>.
 This means that the <undoKey> <message> is not received by a <stack> if
 it's running in the <development environment>.
 
-The <undoKey> <message> is sent when the user presses Command-Z (on <Mac
-OS|Mac OS systems>), Control-Z (on <Windows|Windows systems>),
+The <undoKey> <message> is sent when the user presses Command-Z (on 
+<Mac OS|Mac OS systems>), Control-Z (on <Windows|Windows systems>),
 Alt-Backspace (on <Unix|Unix systems>), or the keyboard <Undo> key.
 
 The message is sent to the active (focused) control, or to the current

--- a/docs/dictionary/property/ID.lcdoc
+++ b/docs/dictionary/property/ID.lcdoc
@@ -54,12 +54,6 @@ be used for <image> IDs:
 * 200,000-299,999: reserved for application use
 
 
-For all other objects, the <ID> <property> is assigned when the
-<object(glossary)> is created and never changes. This means that for all
-<object|objects> except <stacks> and <image(object)|images>, the <ID>
-<property> is guaranteed to be persistent. An <object|object's> <name>
-or <number> may change, but its <ID> does not.
-
 For all objects, the <ID> is guaranteed to be unique within a <stack>.
 IDs are not reused if the <object(glossary)> is deleted.
 

--- a/docs/dictionary/property/RTFText.lcdoc
+++ b/docs/dictionary/property/RTFText.lcdoc
@@ -52,12 +52,13 @@ Paragraphs with a non-empty listStyle are appropriately marked in
 and also with the new listtable tags.
 
 By using both sets of tags a reasonable degree of interoperability is
-> achieved with both TextEdit (and other Cocoa applications) on Mac, and
-> Word and WordPad on Windows.
+achieved with both TextEdit (and other Cocoa applications) on Mac, and
+Word and WordPad on Windows.
 >*Note:* Unfortunately, OpenOffice does not have particularly good rtf
 > import / export capabilities (it doesn't even round-trip correctly
 > through itself!) and thus copying / pasting of lists between LiveCode
 > and OpenOffice will not work reliably or correctly.
+
 >*Important:* Because the RTF standard does not include the box,
 > threeDbox, and link styles supported by LiveCode, the <RTFText>
 > property does not necessarily include all information necessary to
@@ -66,7 +67,7 @@ By using both sets of tags a reasonable degree of interoperability is
 > htmlTextproperty instead.
 
 For technical information about the RTF format, see the article at
-&lt;http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp&gt;. 
+[http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp]. 
 
 References: charToNum (function), format (glossary), RTF (glossary),
 field (keyword), HTMLText (property), foregroundColor (property),

--- a/docs/dictionary/property/outputLineEndings.lcdoc
+++ b/docs/dictionary/property/outputLineEndings.lcdoc
@@ -30,10 +30,10 @@ The type of line ending to use.
 
 
 Description:
-Use the <outputTextEncoding> property to determine what text conversion
-to perform when writing text strings to stdout.
+Use the <outputLineEndings> property to determine what line ending
+conversion to perform on text output.
 
-<outputTextEncoding> is only available when running in CGI mode
+<outputLineEndings> is only available when running in CGI mode
 (Server). 
 
 The quoted literals *must* be used when setting this property - the
@@ -43,5 +43,4 @@ line-ending. The reason behind this is two-fold - (1) it is more
 line-ending rather than the sequence of bytes to use (2) 'cr' and 'lf'
 are defined as the same numToChar(10) constant on all platforms.
 
-References: outputTextEncoding (property)
-
+References:

--- a/docs/dictionary/property/right.lcdoc
+++ b/docs/dictionary/property/right.lcdoc
@@ -37,11 +37,12 @@ Description:
 Use the <right> <property> to change the horizontal placement of a
 <control> or window.
 
-The <right> of a <stack> is in <absolute (screen)
-coordinates(glossary)>. The <right> of a <card> is always the width of
-the <stack window>; setting the <right> of a <card> does not cause a
-<error|script error>, but it has no effect. The <right> of a <group> or
-<control> is in <relative (window) coordinates(glossary)>.
+The <right> of a <stack> is in 
+<absolute coordinates|absolute (screen) coordinates>. The <right> of a 
+<card> is always the width of the <stack window>; setting the <right> of 
+a <card> does not cause a <error|script error>, but it has no effect. 
+The <right> of a <group> or <control> is in 
+<relative coordinates|relative (window) coordinates>.
 
 Changing the <right> of an <object(glossary)> shifts it to the new
 position without resizing it. To change an <object|object's> width, set

--- a/docs/dictionary/property/roundRadius.lcdoc
+++ b/docs/dictionary/property/roundRadius.lcdoc
@@ -35,13 +35,13 @@ If the graphic's style <property> is not "roundRect", the setting of
 this <property> has no effect.
 
 The global setting of the <roundRadius> <property> <control|controls>
-the appearance of round rectangles drawn with the <roundRect> <paint
-tool>. Once a paint rounded rectangle is drawn, its appearance cannot be
-changed by changing the <global> <roundRadius> <property>.
+the appearance of round rectangles drawn with the <roundRect> 
+<paint tool>. Once a paint rounded rectangle is drawn, its appearance 
+cannot be changed by changing the <global> <roundRadius> <property>.
 
-References: global (command), property (glossary),
+References: global (command), control (glossary), property (glossary),
 non-negative (glossary), paint tool (glossary), roundRect (keyword),
-integer (keyword), graphic (keyword), control (object),
+integer (keyword), graphic (keyword),
 roundEnds (property), pixels (property)
 
 Tags: ui

--- a/docs/dictionary/property/rowDelimiter.lcdoc
+++ b/docs/dictionary/property/rowDelimiter.lcdoc
@@ -11,7 +11,8 @@ Specifies the <character|character(s)> used to separate rows in a
 string. 
 
 Introduced: 2.8.1
-Changed:7.0.0
+
+Changed: 7.0.0
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/tilt.lcdoc
+++ b/docs/dictionary/property/tilt.lcdoc
@@ -25,8 +25,8 @@ Value:
 The <tilt> is a number between -90 and 90.
 
 Description:
-Use the <tilt> <property> to find out where the user is in a <QuickTime
-VR> movie.
+Use the <tilt> <property> to find out where the user is in a 
+<QuickTime VR> movie.
 
 The user can move the view of a QuickTime VR movie using the
 navigational controls in the player; a handler can change the view by

--- a/docs/dictionary/property/toggleHilites.lcdoc
+++ b/docs/dictionary/property/toggleHilites.lcdoc
@@ -25,8 +25,8 @@ By default, the <toggleHilites> <property> of newly created
 <field(object)|fields> is set to false.
 
 Description:
-Use the <toggleHilites> <property> to control the <behavior> of <list
-field|list fields>.
+Use the <toggleHilites> <property> to control the <behavior> of 
+<list field|list fields>.
 
 If a field's <toggleHilites> <property> is set to true, clicking a
 <selected> line deselects the line. If the <toggleHilites> is false,

--- a/docs/dictionary/property/toggleHilites.lcdoc
+++ b/docs/dictionary/property/toggleHilites.lcdoc
@@ -36,16 +36,16 @@ If the field's <listBehavior> <property> is false, the setting of the
 <toggleHilites> <property> has no effect.
 
 >*Important:*  Setting the <toggleHilites> to true automatically sets
-> the <field|field's> <noncontiguousHilites> and <multipleLines>
+> the <field|field's> <noncontiguousHilites> and <multipleHilites>
 > <properties> to true. (However, setting the <toggleHilites> to false
 > does not set these <properties> back to false.) To set the
 > <toggleHilites> to true and the <noncontiguousHilites> or
-> <multipleLines> to false, be sure to set the <toggleHilites> first,
+> <multipleHilites> to false, be sure to set the <toggleHilites> first,
 > then set the other <properties> to false.
 
 References: property (glossary), behavior (glossary),
 list field (glossary), field (keyword), field (object),
-multipleLines (property), toggleHilites (property), properties (property),
+multipleHilites (property), toggleHilites (property), properties (property),
 listBehavior (property), selected (property),
 noncontiguousHilites (property), threeDHilite (property),
 hilitedLine (property)

--- a/docs/dictionary/property/toolTipDelay.lcdoc
+++ b/docs/dictionary/property/toolTipDelay.lcdoc
@@ -25,8 +25,8 @@ The <toolTipDelay> is a <non-negative> <integer>.
 By default, the <toolTipDelay> is 500 (half a second).
 
 Description:
-Use the <toolTipDelay> <property> to control the responsiveness of <tool
-tip|tool tips>.
+Use the <toolTipDelay> <property> to control the responsiveness of 
+<tool tip|tool tips>.
 
 A tool tip is a small box containing a line or two of text, which pops
 up on the screen when the mouse pointer hovers over a control. Use the

--- a/docs/dictionary/property/topLeft.lcdoc
+++ b/docs/dictionary/property/topLeft.lcdoc
@@ -39,11 +39,11 @@ Description:
 Use the <topLeft> <property> to change the placement of a <control> or
 window. 
 
-The <topLeft> of a <stack> is in <absolute (screen)
-coordinates(glossary)>. The first <item> (the <left>) of a card's
+The <topLeft> of a <stack> is in <absolute coordinates|absolute (screen) 
+coordinates>. The first <item> (the <left>) of a card's
 <topLeft> <property> is always zero; the second <item> (the <top>) is
-always zero. The <topLeft> of a <group> or <control> is in <relative
-(window) coordinates(glossary)>.
+always zero. The <topLeft> of a <group> or <control> is in 
+<relative coordinates|relative (window) coordinates>.
 
 In window coordinates, the point 0,0 is at the top left of the stack
 window. In screen coordinates, the point 0,0 is at the top left of the

--- a/docs/dictionary/property/topPattern.lcdoc
+++ b/docs/dictionary/property/topPattern.lcdoc
@@ -44,12 +44,12 @@ pattern used to draw the raised edge of the <object(glossary)>.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
-> <height> and <width> must be a power of 2. To be used on <Windows> and
-> <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
-> be used as a fully cross-platform pattern, both an image's dimensions
-> should be one of 8, 16, 32, 64, or 128.
+>*Cross-platform note:*  To be used as a pattern on 
+> <Mac OS|Mac OS systems>, an <image> must be 128x128 <pixels> or less, 
+> and both its <height> and <width> must be a power of 2. To be used on
+> <Windows> and <Unix|Unix systems>, <height> and <width> must be 
+> divisible by 8. To be used as a fully cross-platform pattern, both an 
+> image's dimensions should be one of 8, 16, 32, 64, or 128.
 
 The <topPattern> of <control(object)|controls> is drawn starting at the
 <control(object)|control's> upper right corner: if the
@@ -104,8 +104,8 @@ depending on the <object type>:
   bottom and right edges of the scroll area.
 
 
-* The <topPattern> of a <graphic>, <image>, <audio clip>, or <video
-  clip> has no effect.
+* The <topPattern> of a <graphic>, <image>, <audio clip>, or 
+  <video clip> has no effect.
 
 
 * The <topPattern> of a <player> or <EPS|EPS object> forms a border on
@@ -120,13 +120,13 @@ References: group (command), stacks (function), object (glossary),
 property (glossary), EPS (glossary), audio clip (glossary),
 Windows (glossary), object type (glossary), Mac OS (glossary),
 keyword (glossary), Unix (glossary), video clip (glossary),
-current stack (glossary), effective (keyword), field (keyword),
-image (keyword), button (keyword), card (keyword), scrollbar (keyword),
-player (keyword), graphic (keyword), control (keyword), button (object),
-field (object), stack (object), control (object), pixels (property),
-textStyle (property), owner (property), height (property),
-width (property), topColor (property), bottom (property),
-hiliteBorder (property), bottomPattern (property),
+current stack (glossary), control (glossary), effective (keyword), 
+field (keyword), image (keyword), button (keyword), card (keyword), 
+scrollbar (keyword), player (keyword), graphic (keyword), 
+control (keyword), button (object), field (object), stack (object), 
+pixels (property), textStyle (property), owner (property), 
+height (property), width (property), topColor (property), 
+bottom (property), hiliteBorder (property), bottomPattern (property),
 threeDHilite (property), threeD (property)
 
 Tags: ui

--- a/docs/dictionary/property/tracks.lcdoc
+++ b/docs/dictionary/property/tracks.lcdoc
@@ -21,11 +21,11 @@ put the tracks of player myPlayerName into myNode
 Value (enum):
 The <tracks> is a list of tracks, one per <line>. Each <line> consists
 of four <items>, separated by commas:
+ - the track ID (an integer)
+ - the track media type (for example, "audio", "video", or
+ "VR Panorama" )
 
-        - the track ID (an integer)
-        - the track media type (for example, "audio", "video", or
-          "VR Panorama" ) This property is read:only and cannot be set
-
+ This property is read-only and cannot be set
 
 Description:
 Use the <tracks> <property> to find out the contents of a <QuickTime>
@@ -41,7 +41,7 @@ This property was removed from the Windows platform in version 8.1.0,
 due to the change of player implementation from QuickTime to DirectShow.
 
 References: QuickTime (glossary), property (glossary), items (keyword),
-line (keyword), trackCount (property)
+line (keyword), duration (property), trackCount (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/traversalOn.lcdoc
+++ b/docs/dictionary/property/traversalOn.lcdoc
@@ -5,8 +5,8 @@ Type: property
 Syntax: set the traversalOn of <object> to {true | false}
 
 Summary:
-Specifies whether a <control> can become the <active (focused)
-control(glossary)>. 
+Specifies whether a <control> can become the 
+<active control|active (focused) control>. 
 
 Associations: field, button, group
 

--- a/docs/dictionary/property/twelveHourTime.lcdoc
+++ b/docs/dictionary/property/twelveHourTime.lcdoc
@@ -33,7 +33,7 @@ of the <convert> command when a time specifier is used.
 If the <twelveHourTime> is true, the time function <return|returns> a
 value including AM or PM. If the <twelveHourTime> is false, AM or PM is
 not included; instead, the hour is not reset to 1 after noon. For
-example, the time 2:35 PM <a/>in 12-hour time is equivalent to 14:35 in
+example, the time 2:35 PM in 12-hour time is equivalent to 14:35 in
 24-hour time.
 
 References: convert (command), function (control structure),

--- a/docs/dictionary/property/umask.lcdoc
+++ b/docs/dictionary/property/umask.lcdoc
@@ -22,8 +22,7 @@ set the umask to 0077
 
 Description:
 Use the <umask> command to set the access permissions for
-
-    <files> and <folders> created by LiveCode.
+<files> and <folders> created by LiveCode.
 
 
 The umask is a positive integer, or empty.
@@ -31,18 +30,20 @@ The umask is a positive integer, or empty.
 By default, the umask is set to the user's Unix "umask" setting.
 
 The <umask> blocks specific permissions from being granted for newly
-created <files> and <folders>. It affects <files> created with the <open
-file> <command>, <folders> created with the <create folder> <command>,
-and <files> and <folders> created on the local system with the <URL>
-<keyword>. 
+created <files> and <folders>. It affects <files> created with the 
+<open file> <command>, <folders> created with the <create folder> 
+<command>, and <files> and <folders> created on the local system with 
+the <URL> <keyword>. 
 
 The <umask> is most easily represented in <octal>.  Each digit of the
 <octal> representation of the <umask> specifies a set of permissions:
-<ul> <li> Read permission (4) lets a user read or copy the file or
-folder.</li> <li> Write permission (2) lets a user change the contents
-of the file or folder.</li> <li> Execute permission (1) lets a user run
+ - Read permission (4) lets a user read or copy the file or
+folder.
+ - Write permission (2) lets a user change the contents
+of the file or folder.
+ - Execute permission (1) lets a user run
 the file (if it is a program file), or work with files in the
-folder.</li> </ul>
+folder.
 
 Each digit is the sum of the permission values that are to be blocked.
 For example, to specify that read and execute permission should both be

--- a/docs/dictionary/property/unicodeFormattedText.lcdoc
+++ b/docs/dictionary/property/unicodeFormattedText.lcdoc
@@ -21,8 +21,8 @@ aided unicode text manipulation is no longer required. This property
 should not be used in new code; simply get the formattedText as normal.
 The following are now equivalent:
 
-get the unicodeFormattedText of field 1
-get textEncode(the formattedText of field 1, "UTF16")
+    get the unicodeFormattedText of field 1
+    get textEncode(the formattedText of field 1, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodeLabel.lcdoc
+++ b/docs/dictionary/property/unicodeLabel.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeLabel of button 1 to tText
-set the label of button 1 to textDecode(tText, "UTF16")
+    set the unicodeLabel of button 1 to tText
+    set the label of button 1 to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodePlainText.lcdoc
+++ b/docs/dictionary/property/unicodePlainText.lcdoc
@@ -20,8 +20,8 @@ aided unicode text manipulation is no longer required. This property
 should not be used in new code; simply get the plainText as normal. The
 following are now equivalent:
 
-get the unicodePlainText of field 1
-get textEncode(the plainText of field 1, "UTF16")
+    get the unicodePlainText of field 1
+    get textEncode(the plainText of field 1, "UTF16")
 
 OS: mac, windows, linux
 

--- a/docs/dictionary/property/unicodeTitle.lcdoc
+++ b/docs/dictionary/property/unicodeTitle.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeTitle of this stack to tText
-set the title of this stack to textDecode(tText, "UTF16")
+    set the unicodeTitle of this stack to tText
+    set the title of this stack to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/unicodeTooltip.lcdoc
+++ b/docs/dictionary/property/unicodeTooltip.lcdoc
@@ -21,8 +21,8 @@ Assigning values other than those returned from uniEncode to this
 property will not produce the desired results.The following are now
 equivalent: 
 
-set the unicodeTooltip of button 1 to tText
-set the tooltip of button 1 to textDecode(tText, "UTF16")
+    set the unicodeTooltip of button 1 to tText
+    set the tooltip of button 1 to textDecode(tText, "UTF16")
 
 OS: mac, windows, linux, ios, android
 

--- a/docs/dictionary/property/yOffset.lcdoc
+++ b/docs/dictionary/property/yOffset.lcdoc
@@ -6,7 +6,7 @@ Syntax: set the yOffset of <EPSObject> to <points>
 
 Summary:
 Specifies the location of the top edge of an <EPS|EPS object's>
-<PostScript> code.
+<postScript> code.
 
 Introduced: 1.0
 
@@ -25,8 +25,8 @@ Use the <yOffset> <property> to control the placement of an <EPS|EPS
 object> on the paper when it's printed.
 
 The <yOffset> is the distance in <points> from the top edge of the paper
-to the top edge of the <PostScript> object. This controls the placement
-of the <PostScript> object when it's rendered.
+to the top edge of the <postScript> object. This controls the placement
+of the <postScript> object when it's rendered.
 
 The <yOffset> of an <EPS|EPS object> is equal to the second <item> in
 the object's <boundingBox> <property>.

--- a/docs/dictionary/property/yScale.lcdoc
+++ b/docs/dictionary/property/yScale.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the yScale of <EPSObject> to <number>
 
 Summary:
-Specifies the ratio of the height of an <EPS|EPS object's> <PostScript>
+Specifies the ratio of the height of an <EPS|EPS object's> <postScript>
 bounding box to the object's screen height.
 
 Introduced: 1.0
@@ -28,12 +28,12 @@ Use the <yScale> <property> to control an <EPS|EPS object's> screen
 appearance. 
 
 The <number> 1 indicates no scaling--that is, the <EPS|EPS object's>
-height is the same as the height specified by the <PostScript> code it
+height is the same as the height specified by the <postScript> code it
 contains. Numbers greater than one indicate that the <object|object's>
-height is less than the <PostScript> height; the screen
+height is less than the <postScript> height; the screen
 <object(glossary)> is scaled down. Numbers less than one indicate that
-the <object|object's> height is greater than the <PostScript> height,
-and the screen <object(glossary)> is scaled up from the <PostScript>.
+the <object|object's> height is greater than the <postScript> height,
+and the screen <object(glossary)> is scaled up from the <postScript>.
 
 In geometric terms, yScale = yExtent/height.
 

--- a/docs/dictionary/property/zoomBox.lcdoc
+++ b/docs/dictionary/property/zoomBox.lcdoc
@@ -32,9 +32,9 @@ Use the <zoomBox> property to display the zoom box or maximize box in a
 window's title bar.
 
 The terminology varies depending on platform. The <zoomBox> <property>
-determines whether the <zoom box> (Mac OS and OS X systems) or <maximize
-button|maximize box> (Unix and <Windows|Windows systems>) appears in a
-<stack window|stack window's> <title bar>.
+determines whether the <zoom box> (Mac OS and OS X systems) or 
+<maximize button|maximize box> (Unix and <Windows|Windows systems>) 
+appears in a <stack window|stack window's> <title bar>.
 
 >*Note:* On <OS X|OS X systems>, if the <zoomBox> <property> is false,
 > the <zoom box> is disabled rather than hidden.

--- a/docs/notes/bugfix-12851.md
+++ b/docs/notes/bugfix-12851.md
@@ -1,0 +1,1 @@
+# Fixed outputLineEndings' documentation describing outputTextEncoding

--- a/docs/notes/bugfix-12876.md
+++ b/docs/notes/bugfix-12876.md
@@ -1,0 +1,1 @@
+# Ensure the IDE can be launched when the installer finishes

--- a/docs/notes/bugfix-18702.md
+++ b/docs/notes/bugfix-18702.md
@@ -1,0 +1,1 @@
+# Ensure Alt+<number_sequence> does produce unicode characters on Windows

--- a/docs/notes/bugfix-21382.md
+++ b/docs/notes/bugfix-21382.md
@@ -1,0 +1,1 @@
+# Removed unwanted HTML entries from the menu dictionary entry

--- a/docs/notes/bugfix-21382.md
+++ b/docs/notes/bugfix-21382.md
@@ -1,1 +1,1 @@
-# Removed unwanted HTML entries from the menu dictionary entry
+# Removed unwanted HTML entities from the menu dictionary entry

--- a/docs/notes/bugfix-21589.md
+++ b/docs/notes/bugfix-21589.md
@@ -1,0 +1,1 @@
+# Show list of windows in dock menu on MacOS

--- a/docs/notes/bugfix-21683.md
+++ b/docs/notes/bugfix-21683.md
@@ -1,0 +1,1 @@
+# Fix crash when setting a widget read-only property

--- a/docs/notes/bugfix-21775.md
+++ b/docs/notes/bugfix-21775.md
@@ -1,0 +1,1 @@
+# Updated SQLite to version 3.26.0

--- a/docs/notes/bugfix-21796.md
+++ b/docs/notes/bugfix-21796.md
@@ -1,0 +1,1 @@
+# Build iOS 12.1 binaries for the tsNet external

--- a/docs/notes/bugfix-21805.md
+++ b/docs/notes/bugfix-21805.md
@@ -1,0 +1,1 @@
+# Ensure stack with windowshape will display if setting its "visible" to true after "go invisible"

--- a/docs/notes/bugfix-21817.md
+++ b/docs/notes/bugfix-21817.md
@@ -1,0 +1,1 @@
+# Removed outdated information about setting IDs for controls.

--- a/docs/notes/bugfix-21821.md
+++ b/docs/notes/bugfix-21821.md
@@ -1,0 +1,1 @@
+# Enabled JSON storage/retrieval within a SQLite database

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -483,6 +483,12 @@ void MCStack::SetVisible(MCExecContext& ctxt, uint32_t part, bool setting)
 
 		}
 		MCscreen->sync(getw());
+        
+#ifdef _WINDOWS_DESKTOP
+        // On Windows force a reload, otherwise a stack with a windowshape does not show
+        if (setting)
+            loadwindowshape();
+#endif
 	}
 }
 

--- a/engine/src/executionerrors.h
+++ b/engine/src/executionerrors.h
@@ -2777,6 +2777,9 @@ enum Exec_errors
     // {EE-0909} android permission: bad permission name
     EE_BAD_PERMISSION_NAME,
     
+    // {EE-0910} Property: value is not a data
+    EE_PROPERTY_NOTADATA
+    
 };
 
 extern const char *MCexecutionerrors;

--- a/engine/src/mac-menu.mm
+++ b/engine/src/mac-menu.mm
@@ -1367,6 +1367,14 @@ bool MCPlatformInitializeMenu(void)
                                                  length: kDiamondTiffImageLength
                                            freeWhenDone: NO]];
     
+    if (![NSApp windowsMenu])
+    {
+        // prepend an up to date "Window" list to the Dock menu
+        NSMenu* t_windows_menu = [[NSMenu alloc] initWithTitle:@"Window"];
+        [NSApp setWindowsMenu:t_windows_menu];
+        [t_windows_menu release];
+    }
+    
     return true;
 }
 

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -835,7 +835,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 				// Pressing Alt and the key "+" starts a number-typing sequence.
 				//  Otherwise, we are not in such a sequence - be it because a normal
 				//  char has been typed, or because the sequence is terminated.
-				isInAltPlusSequence = (t_keysym == '+' && MCmodifierstate == MS_ALT);
+				isInAltPlusSequence = (MCmodifierstate == MS_ALT);
 
 				// We don't want to send any Key message for the "+" pressed
 				//  to start the Alt+<number> sequence
@@ -969,6 +969,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
 				// codepoint.
 				// SN-2015-05-18: [[ Bug 15040 ]] We don't send any key message
 				//  if we are in an Alt+<number> sequence.
+                isInAltPlusSequence = (MCmodifierstate == MS_ALT);
 				if (!isInAltPlusSequence)
 					MCdispatcher->wkup(dw, *t_string, keysym);
 				curinfo->handled = curinfo->reset = True;

--- a/engine/src/w32dcw32.cpp
+++ b/engine/src/w32dcw32.cpp
@@ -832,7 +832,7 @@ LRESULT CALLBACK MCWindowProc(HWND hwnd, UINT msg, WPARAM wParam,
             // field, so we assume that we must process it.
 			if (!curinfo->live || curinfo->keymove == KM_KEY_DOWN || deadcharfollower || isInAltPlusSequence)
 			{
-				// Pressing Alt and the key "+" starts a number-typing sequence.
+				// Pressing Alt starts a number-typing sequence.
 				//  Otherwise, we are not in such a sequence - be it because a normal
 				//  char has been typed, or because the sequence is terminated.
 				isInAltPlusSequence = (MCmodifierstate == MS_ALT);

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -670,26 +670,40 @@ bool MCWidget::setcustomprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNameRe
         CatchError(ctxt);
         
         Exec_errors t_error;
+        bool t_throw = false;
         
         MCResolvedTypeInfo t_resolved_type;
         if (!MCTypeInfoResolve(t_set_type, t_resolved_type))
             return false;
         
         if ( t_resolved_type . named_type == kMCBooleanTypeInfo)
+        {
             t_error = EE_PROPERTY_NAB;
-        
+            t_throw = true;
+        }
         else if (t_resolved_type . named_type == kMCNumberTypeInfo)
+        {
             t_error = EE_PROPERTY_NAN;
+            t_throw = true;
+        }
         else if (t_resolved_type . named_type == kMCStringTypeInfo)
+        {
             t_error = EE_PROPERTY_NAS;
+            t_throw = true;
+        }
         else if (t_resolved_type . named_type == kMCArrayTypeInfo || t_resolved_type . named_type == kMCProperListTypeInfo)
+        {
             t_error = EE_PROPERTY_NOTANARRAY;
+            t_throw = true;
+        }
         else if (t_resolved_type . named_type == kMCDataTypeInfo)
+        {
             t_error = EE_PROPERTY_NOTADATA;
-        else
-            t_error = EE_PROPERTY_CANTSET;
-            
-        ctxt . LegacyThrow(t_error);
+            t_throw = true;
+        }
+        
+        if (t_throw)
+            ctxt . LegacyThrow(t_error);
         return false;
     }
     

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -668,6 +668,28 @@ bool MCWidget::setcustomprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNameRe
         !MCExtensionConvertFromScriptType(ctxt, t_set_type, InOut(t_value)))
     {
         CatchError(ctxt);
+        
+        Exec_errors t_error;
+        
+        MCResolvedTypeInfo t_resolved_type;
+        if (!MCTypeInfoResolve(t_set_type, t_resolved_type))
+            return false;
+        
+        if ( t_resolved_type . named_type == kMCBooleanTypeInfo)
+            t_error = EE_PROPERTY_NAB;
+        
+        else if (t_resolved_type . named_type == kMCNumberTypeInfo)
+            t_error = EE_PROPERTY_NAN;
+        else if (t_resolved_type . named_type == kMCStringTypeInfo)
+            t_error = EE_PROPERTY_NAS;
+        else if (t_resolved_type . named_type == kMCArrayTypeInfo || t_resolved_type . named_type == kMCProperListTypeInfo)
+            t_error = EE_PROPERTY_NOTANARRAY;
+        else if (t_resolved_type . named_type == kMCDataTypeInfo)
+            t_error = EE_PROPERTY_NOTADATA;
+        else
+            t_error = EE_PROPERTY_CANTSET;
+            
+        ctxt . LegacyThrow(t_error);
         return false;
     }
     

--- a/extensions/widgets/clock/tests/properties.livecodescript
+++ b/extensions/widgets/clock/tests/properties.livecodescript
@@ -40,7 +40,6 @@ on TestSettingLocalTimeZone
 	TestAssert "timeZone successfully set to local", the timeZone of widget "testClock" is ""
 end TestSettingLocalTimeZone
 
-<<<<<<< HEAD
 on TestGetDefaultFaceColor
    TestAssert "dayFaceColor on creation is 224,224,224,64", the dayFaceColor of widget "testClock" is "224,224,224,64"
    TestAssert "nightFaceColor on creation is black", the nightFaceColor of widget "testClock" is "0,0,0,255"

--- a/extensions/widgets/clock/tests/properties.livecodescript
+++ b/extensions/widgets/clock/tests/properties.livecodescript
@@ -38,3 +38,18 @@ on TestSettingLocalTimeZone
  	set the timeZone of widget "testClock" to ""
 	TestAssert "timeZone successfully set to local", the timeZone of widget "testClock" is ""
 end TestSettingLocalTimeZone
+
+
+on TestSetReadOnlyPropOfWidget
+
+   local tName
+   put the name of widget "testClock" into tName
+   TestAssertThrow "set read-only prop", \
+         "_TestSetReadOnlyPropOfWidgetError", the long id of me, \ 
+         "EE_PROPERTY_CANTSETOBJECT", tName
+         
+end TestSetReadOnlyPropOfWidget
+
+command _TestSetReadOnlyPropOfWidgetError pWidget
+   set the isDay of pWidget to true
+end _TestSetReadOnlyPropOfWidgetError

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -398,7 +398,7 @@ MCScriptCreateErrorExpectedError(MCErrorRef& r_error)
 						  nil);
 }
 
-bool MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptInstanceRef p_instance, MCNameRef p_property)
+bool MCScriptThrowCannotSetReadOnlyPropertyError(MCScriptInstanceRef p_instance, MCNameRef p_property)
 {
     return MCErrorCreateAndThrow(kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo,
                                  "module",

--- a/libscript/src/script-error.cpp
+++ b/libscript/src/script-error.cpp
@@ -397,3 +397,13 @@ MCScriptCreateErrorExpectedError(MCErrorRef& r_error)
 						  MCSTR("error propagated without error object"),
 						  nil);
 }
+
+bool MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptInstanceRef p_instance, MCNameRef p_property)
+{
+    return MCErrorCreateAndThrow(kMCScriptCannotSetReadOnlyPropertyErrorTypeInfo,
+                                 "module",
+                                 p_instance -> module -> name,
+                                 "property",
+                                 p_property,
+                                 nil);
+}

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -422,7 +422,7 @@ MCScriptSetPropertyInInstance(MCScriptInstanceRef self,
 	
     // If there is no setter for the property then this is an error.
     if (t_setter == nil)
-        return MCScriptThrowAttemptToSetReadOnlyPropertyError(self, p_property);
+        return MCScriptThrowCannotSetReadOnlyPropertyError(self, p_property);
     
 	/* LOAD CHECK */
 	__MCScriptAssert__(t_setter != nil,

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -420,6 +420,10 @@ MCScriptSetPropertyInInstance(MCScriptInstanceRef self,
 	MCScriptDefinition *t_setter;
 	t_setter = t_property_def->setter != 0 ? self->module->definitions[t_property_def->setter - 1] : nil;
 	
+    // If there is no setter for the property then this is an error.
+    if (t_setter == nil)
+        return MCScriptThrowAttemptToSetReadOnlyPropertyError(self, p_property);
+    
 	/* LOAD CHECK */
 	__MCScriptAssert__(t_setter != nil,
 					   "property has no setter");

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -606,6 +606,11 @@ MCScriptInternalHandlerQuery(MCHandlerRef handler,
 bool
 MCScriptThrowPropertyNotFoundError(MCScriptInstanceRef instance,
 								   MCNameRef property);
+
+bool
+MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptInstanceRef instance,
+                                   MCNameRef property);
+
 bool
 MCScriptThrowHandlerNotFoundError(MCScriptInstanceRef instance,
 								  MCNameRef handler);

--- a/libscript/src/script-private.h
+++ b/libscript/src/script-private.h
@@ -608,7 +608,7 @@ MCScriptThrowPropertyNotFoundError(MCScriptInstanceRef instance,
 								   MCNameRef property);
 
 bool
-MCScriptThrowAttemptToSetReadOnlyPropertyError(MCScriptInstanceRef instance,
+MCScriptThrowCannotSetReadOnlyPropertyError(MCScriptInstanceRef instance,
                                    MCNameRef property);
 
 bool

--- a/revdb/src/sqlite_connection.cpp
+++ b/revdb/src/sqlite_connection.cpp
@@ -78,6 +78,8 @@ Bool DBConnection_SQLITE::connect(char **args, int numargs)
 		//   path encoded as UTF-8.
 		fname = os_path_to_native_utf8(args[0]);
 		
+        bool t_use_uri = false;
+        
 		// MW-2014-01-29: [[ Sqlite382 ]] If there's a second argument, then interpret
 		//   it as an options string.
 		if (numargs >= 2)
@@ -98,6 +100,8 @@ Bool DBConnection_SQLITE::connect(char **args, int numargs)
 					m_enable_binary = true;
 				if ((t_end - t_start) == 10 && strncasecmp(t_start, "extensions", 10) == 0)
 					m_enable_extensions = true;
+                if ((t_end - t_start) == 3 && strncasecmp(t_start, "uri", 3) == 0)
+                    t_use_uri = true;
 				
 				// If the end points to NUL we are done.
 				if (*t_end == '\0')
@@ -111,7 +115,7 @@ Bool DBConnection_SQLITE::connect(char **args, int numargs)
 		try
 		{
 			mDB.setDatabase(fname);
-			if(mDB.connect() == DB_CONNECTION_NONE) 
+			if(mDB.connect(t_use_uri) == DB_CONNECTION_NONE)
 			{
 				ret = False;
 			}

--- a/tests/lcs/core/database/sqlite_uri.livecodescript
+++ b/tests/lcs/core/database/sqlite_uri.livecodescript
@@ -40,13 +40,11 @@ on TestBinaryWithOptionURI
    put lDatabaseDir & "/sqlite-uri.db?mode=ro" into tDatabaseFileReadOnly
    __createDatabase tDatabaseFileReadOnly, true
    TestAssert "check creation of a read-only SQLite database with uri option", lDatabaseID is not a number
-   __deleteDatabase tDatabaseFileReadOnly
    
    local tDatabaseFileReadWrite  
    put lDatabaseDir & "/sqlite-uri.db?mode=rw" into tDatabaseFileReadWrite
    __createDatabase tDatabaseFileReadWrite, true
    TestAssert "check creation of SQLite read-write database with uri option", lDatabaseID is not a number
-   __deleteDatabase tDatabaseFileReadWrite
    
    local tDatabaseFileReadWriteCreate 
    put lDatabaseDir & "/sqlite-uri.db?mode=rwc" into tDatabaseFileReadWriteCreate

--- a/tests/lcs/core/database/sqlite_uri.livecodescript
+++ b/tests/lcs/core/database/sqlite_uri.livecodescript
@@ -1,0 +1,66 @@
+script "TestSQLiteUri"
+local lDatabaseID, lDatabaseDir
+
+private command __createDatabase pDatabaseFile, pURI
+   if pURI is false then
+      put revOpenDatabase("sqlite",pDatabaseFile,,,,) into lDatabaseID
+   else
+      put revOpenDatabase("sqlite","file:" & pDatabaseFile,"uri",,,) into lDatabaseID
+   end if
+end __createDatabase
+
+private command __deleteDatabase pDatabaseFile
+   revCloseDatabase lDatabaseID
+   delete file pDatabaseFile
+end __deleteDatabase
+
+
+on TestSetup
+   TestSkipIfNot "database", "sqlite"
+   TestSkipIfNot "external", "revsecurity"
+   
+   TestLoadExternal "revdb"
+   
+   put TestGetEngineRepositoryPath() & "/_tests/_build/sqlite_uri_test" into lDatabaseDir
+   create directory lDatabaseDir
+end TestSetup
+
+on TestTeardown
+   delete directory lDatabaseDir
+end TestTeardown
+
+on TestBinaryWithOptionURI
+   local tDatabaseFile   
+   put lDatabaseDir & "/sqlite-uri.db" into tDatabaseFile
+   __createDatabase tDatabaseFile, true
+   TestAssert "check creation of SQLite database with uri option", lDatabaseID is a number
+   __deleteDatabase tDatabaseFile
+   
+   local tDatabaseFileReadOnly  
+   put lDatabaseDir & "/sqlite-uri.db?mode=ro" into tDatabaseFileReadOnly
+   __createDatabase tDatabaseFileReadOnly, true
+   TestAssert "check creation of a read-only SQLite database with uri option", lDatabaseID is not a number
+   __deleteDatabase tDatabaseFileReadOnly
+   
+   local tDatabaseFileReadWrite  
+   put lDatabaseDir & "/sqlite-uri.db?mode=rw" into tDatabaseFileReadWrite
+   __createDatabase tDatabaseFileReadWrite, true
+   TestAssert "check creation of SQLite read-write database with uri option", lDatabaseID is not a number
+   __deleteDatabase tDatabaseFileReadWrite
+   
+   local tDatabaseFileReadWriteCreate 
+   put lDatabaseDir & "/sqlite-uri.db?mode=rwc" into tDatabaseFileReadWriteCreate
+   __createDatabase tDatabaseFile, true
+   TestAssert "check creation of read-write-create SQLite database with uri option", lDatabaseID is a number
+   __deleteDatabase tDatabaseFileReadWriteCreate
+   
+end TestBinaryWithOptionURI
+
+on TestBinaryWithoutOptionURI
+   local tDatabaseFile
+   
+   put lDatabaseDir & "/sqlite-no-uri.db" into tDatabaseFile
+   __createDatabase tDatabaseFile, false
+   TestAssert "check creation of SQLite database without uri option", lDatabaseID is a number
+   __deleteDatabase tDatabaseFile
+end TestBinaryWithoutOptionURI

--- a/tests/lcs/core/database/sqlite_uri.livecodescript
+++ b/tests/lcs/core/database/sqlite_uri.livecodescript
@@ -50,7 +50,7 @@ on TestBinaryWithOptionURI
    
    local tDatabaseFileReadWriteCreate 
    put lDatabaseDir & "/sqlite-uri.db?mode=rwc" into tDatabaseFileReadWriteCreate
-   __createDatabase tDatabaseFile, true
+   __createDatabase tDatabaseFileReadWriteCreate, true
    TestAssert "check creation of read-write-create SQLite database with uri option", lDatabaseID is a number
    __deleteDatabase tDatabaseFileReadWriteCreate
    

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -86,6 +86,19 @@ on TestWidgetThrowInOnCreate
    delete stack "WidgetThrowOnSaveTest"
 end TestWidgetThrowInOnCreate
 
+on TestSetReadOnlyPropOfWidget
+   local tSVG
+   create widget "mySVG" as "com.livecode.widget.svgpath"
+   put it into tSVG
+   TestAssertThrow "set read-only prop", \
+         "_TestSetReadOnlyPropOfWidgetError", the long id of me, \ 
+         "EE_PROPERTY_CANTSETOBJECT", tSVG
+end TestSetReadOnlyPropOfWidget
+
+private command _TestSetReadOnlyPropOfWidgetError pWidget
+   set the scaledWidth of pWidget to 100
+end _TestSetReadOnlyPropOfWidgetError
+
 on TestWidgetRetainRep
    create stack "WidgetRetainRepTest"
    set the defaultStack to "WidgetRetainRepTest"

--- a/tests/lcs/core/engine/widget.livecodescript
+++ b/tests/lcs/core/engine/widget.livecodescript
@@ -86,19 +86,6 @@ on TestWidgetThrowInOnCreate
    delete stack "WidgetThrowOnSaveTest"
 end TestWidgetThrowInOnCreate
 
-on TestSetReadOnlyPropOfWidget
-   local tSVG
-   create widget "mySVG" as "com.livecode.widget.svgpath"
-   put it into tSVG
-   TestAssertThrow "set read-only prop", \
-         "_TestSetReadOnlyPropOfWidgetError", the long id of me, \ 
-         "EE_PROPERTY_CANTSETOBJECT", tSVG
-end TestSetReadOnlyPropOfWidget
-
-private command _TestSetReadOnlyPropOfWidgetError pWidget
-   set the scaledWidth of pWidget to 100
-end _TestSetReadOnlyPropOfWidgetError
-
 on TestWidgetRetainRep
    create stack "WidgetRetainRepTest"
    set the defaultStack to "WidgetRetainRepTest"

--- a/tools/SymbolicatorScript.livecodescript
+++ b/tools/SymbolicatorScript.livecodescript
@@ -786,7 +786,9 @@ function symbolsForAddresses pAddresses, pAppBundle, pLoadAddress
    local tCommand
    local tSymbols
    replace return with space in pAddresses
-   put "xcrun atos -o" && escapeArg(tExecutable) && "-l" && format("%#x", pLoadAddress) && pAddresses into tCommand
+   --put "xcrun atos -o" && escapeArg(tExecutable) && "-l" && format("%#x", pLoadAddress) && pAddresses into tCommand
+   put "xcrun atos -o" && escapeArg(tExecutable) && "-arch x86_64 " && "-l" && pLoadAddress && pAddresses into tCommand
+   
    get shell(tCommand)
    if the result is not zero then throw "failed to symbolicate address list using atos:" && it
    put it into tSymbols


### PR DESCRIPTION
Trivial conflict in `extensions/widgets/clock/tests/properties.livecodescript`, because of different test being added in both `develop` and `develop-9.0`. Resolved conflict by keeping all the newly added tests.