### PR TITLE
[Dictionary] backgroundColor to charSet

### DIFF
--- a/docs/dictionary/function/base64Encode.lcdoc
+++ b/docs/dictionary/function/base64Encode.lcdoc
@@ -7,7 +7,7 @@ Syntax: the base64Encode of <data>
 Syntax: base64Encode(<data>)
 
 Summary:
-<return|Returns> a base 64- <encodedstring>.
+<return|Returns> a base 64-<encode|encoded> string.
 
 Introduced: 1.0
 
@@ -46,8 +46,8 @@ For technical information about base 64 encoding, see [RFC 2045, section
 
 References: function (control structure), numToChar (function),
 md5Digest (function), base64Decode (function), encode (glossary),
-binary file (glossary), encodedstring (glossary), return (glossary),
-inverse (keyword), characters (keyword), line (keyword), string (keyword)
+binary file (glossary), return (glossary), inverse (keyword), 
+characters (keyword), line (keyword), string (keyword)
 
 Tags: text processing
 

--- a/docs/dictionary/function/binaryDecode.lcdoc
+++ b/docs/dictionary/function/binaryDecode.lcdoc
@@ -106,13 +106,11 @@ dataTypes as there is data for. Check the <value> that the
 was actually converted. Here is an example:
 
     on convertStuff dataToConvert
-    global headerData,placeholder,bodyData,footerData
-    put binaryDecode("i5x2a24xi2",dataToConvert, \
-
-    headerData,placeholder,bodyData,placeholder,footerData) \
-    into convertResult
-    if convertResult &lt; 3 then return "Error: data was corrupted"
-
+        global headerData,placeholder,bodyData,footerData
+        put binaryDecode("i5x2a24xi2",dataToConvert, \
+              headerData,placeholder,bodyData,placeholder, \ 
+              footerData) into convertResult
+        if convertResult &lt; 3 then return "Error: data was corrupted"
     end convertStuff
 
 

--- a/docs/dictionary/function/binaryDecode.lcdoc
+++ b/docs/dictionary/function/binaryDecode.lcdoc
@@ -107,6 +107,7 @@ was actually converted. Here is an example:
 
     on convertStuff dataToConvert
         global headerData,placeholder,bodyData,footerData
+        local convertResult
         put binaryDecode("i5x2a24xi2",dataToConvert, \
               headerData,placeholder,bodyData,placeholder, \ 
               footerData) into convertResult

--- a/docs/dictionary/keyword/binfile.lcdoc
+++ b/docs/dictionary/keyword/binfile.lcdoc
@@ -25,16 +25,16 @@ Use the <binfile> <keyword> to work with <binary file|binary files>.
 
 The <binfile> <URL scheme|scheme> indicates a <binary file> which is
 located on the user's system. The <file> is specified by either a
-<absolute file path|full path> starting with "/", or a <relative file
-path|relative path> starting from the <defaultFolder>.
+<absolute file path|full path> starting with "/", or a 
+<relative file path|relative path> starting from the <defaultFolder>.
 
 A URL container can be used anywhere another container type is used.
 
 When you put data into a <binfile> <URL> or get data from it, LiveCode
 does not translate <end-of-line marker|end-of-line markers> (<ASCII> 10
 and <ASCII> 13) between the current <platform|platform's> standard and
-LiveCode's internal standard of a linefeed. This ensures that <binary
-file|binary data>, which may contain such characters, is not
+LiveCode's internal standard of a linefeed. This ensures that 
+<binary file|binary data>, which may contain such characters, is not
 accidentally corrupted.
 
 If you are working with text data (such as text in fields), use the

--- a/docs/dictionary/operator/less-than-or-equals.lcdoc
+++ b/docs/dictionary/operator/less-than-or-equals.lcdoc
@@ -56,10 +56,10 @@ If the <caseSensitive> <property> is true, the comparison between two
 letters. If the <caseSensitive> <property> is false, the comparison is
 not <case-sensitive>, so "a" is considered equivalent to "A".
 
->*Cross-platform note:* The synonym ≤ can be used only on <OS X|OS X
-> systems>. If you use a <script> containing the ≤ character on a
-> <Windows> or <Unix|Unix system>, a <error|script error> may result. To
-> ensure cross-platform compatibility, use the synonym <&lt;=> instead.
+>*Cross-platform note:* The synonym ≤ can be used only on 
+> <OS X|OS X systems>. If you use a <script> containing the ≤ character 
+> on a <Windows> or <Unix|Unix system>, a <error|script error> may result. 
+> To ensure cross-platform compatibility, use the synonym <&lt;=> instead.
 
 References: min (function), max (function), value (function),
 return (glossary), string (glossary), property (glossary),

--- a/docs/dictionary/property/backgroundColor.lcdoc
+++ b/docs/dictionary/property/backgroundColor.lcdoc
@@ -63,8 +63,8 @@ the color specified by <backgroundColor>. The setting of the
 <backgroundColor> <property> has different effects, depending on the
 <object type>:
 
-* The <backgroundColor> of a <stack> or <card> fills the entire <stack
-  window>, as well as determining the <backgroundColor> of each
+* The <backgroundColor> of a <stack> or <card> fills the entire 
+  <stack window>, as well as determining the <backgroundColor> of each
   <object(glossary)> in the <stack> or <card> that does not have its own
   <backgroundColor>. 
 
@@ -83,9 +83,9 @@ the color specified by <backgroundColor>. The setting of the
   <button(object)|button's> outline. If the button's <style> is
   "checkbox", the <backgroundColor> fills the checkbox. If the
   <button(object)|button's> style is "radioButton", the
-  <backgroundColor> has no effect. If the <button(keyword)> is a <tabbed
-  button>, the <backgroundColor> fills the tab area and the frontmost
-  tab, but does not affect the other tabs.
+  <backgroundColor> has no effect. If the <button(keyword)> is a 
+  <tabbed button>, the <backgroundColor> fills the tab area and the 
+  frontmost tab, but does not affect the other tabs.
 
 
 >*Cross-platform note:* If the <lookAndFeel> is set to
@@ -149,12 +149,12 @@ if the <lookAndFeel> was set to "Appearance Manager", the setting of the
 <backgroundColor> had no effect on standard <button|buttons>.
 
 References: answer color (command), group (command), object (glossary),
-video clip (glossary), property (glossary), foregroundPattern (glossary),
+video clip (glossary), property (glossary),
 tabbed button (glossary), highlight (glossary), stack window (glossary),
 object type (glossary), Mac OS (glossary), OS X (glossary),
 chunk (glossary), object hierarchy (glossary), color palette (glossary),
 button menu (glossary), keyword (glossary), audio clip (glossary),
-EPS (glossary), owner (glossary), lookAndFeel (glossary),
+EPS (glossary), owner (glossary),
 Windows (glossary), word (glossary), image (keyword), effective (keyword),
 field (keyword), button (keyword), word (keyword), player (keyword),
 card (keyword), scrollbar (keyword), graphic (keyword),
@@ -169,7 +169,7 @@ firstIndent (property), tabstops (property), spaceBelow (property),
 listStyle (property), style (property), rightIndent (property),
 listDepth (property), hgrid (property), foregroundColor (property),
 linkHiliteColor (property), hScrollbar (property), owner (property),
-lookAndFeel (property), borderColor (property), formattedWidth (property)
+lookAndFeel (property), borderColor (property), formattedWidth (property),
 
 Tags: ui
 

--- a/docs/dictionary/property/backgroundPattern.lcdoc
+++ b/docs/dictionary/property/backgroundPattern.lcdoc
@@ -37,7 +37,7 @@ An <imageID> is the ID of an <image> to use for a pattern. LiveCode
 looks for the specified <image> first in the <current stack>, then in
 other open <stacks>.
 
-By default, the <backgroundPattern> for all <object|objects> is empty.
+By default, the <backgroundPattern> for all <object(glossary)|objects> is empty.
 
 Description:
 Use the <backgroundPattern> <property> to specify the pattern used for
@@ -56,7 +56,7 @@ Pattern images can be color or black-and-white.
 > pattern, both an image's dimensions should be one of 8, 16, 32, 64,
 > or 128. 
 
-The <backgroundPattern> of <control(object)|controls> is drawn starting
+The <backgroundPattern> of <control(glossary)|controls> is drawn starting
 at the <control(object)|control's> upper left corner: if the
 <control(keyword)> is moved, the pattern does not shift.
 
@@ -74,10 +74,10 @@ depending on the <object type>:
   <backgroundPattern>. 
 
 
->*Cross-platform note:*  On <Mac OS>, <OS X>, and <Windows|Windows
-> systems>, if the backgroundColor and <backgroundPattern> of all
-> <object|objects> in the <object hierarchy> is empty, the background
-> set by the system is used.
+>*Cross-platform note:*  On <Mac OS>, <OS X>, and 
+> <Windows|Windows systems>, if the backgroundColor and <backgroundPattern> 
+> of all <object|objects> in the <object hierarchy> is empty, the 
+> background set by the system is used.
 
 * The <backgroundPattern> of a <group> determines the
   <backgroundPattern> of each <object(glossary)> in the <group> that
@@ -147,7 +147,7 @@ Unix (glossary), object type (glossary), EPS (glossary),
 current stack (glossary), effective (keyword), field (keyword),
 image (keyword), button (keyword), card (keyword), scrollbar (keyword),
 player (keyword), graphic (keyword), control (keyword), graphic (object),
-button (object), field (object), stack (object), control (object),
+button (object), field (object), stack (object),
 metal (property), pixels (property), opaque (property),
 patterns (property), width (property), height (property),
 style (property), backgroundPattern (property), lookAndFeel (property),

--- a/docs/dictionary/property/beepPitch.lcdoc
+++ b/docs/dictionary/property/beepPitch.lcdoc
@@ -25,7 +25,7 @@ The <beepPitch> is an <integer> between zero and 20000.
 Description:
 Use the <beepPitch> <property> to make the beep sound higher or lower.
 
-The <pitchFrequency> is the frequency in Hz (cycles per second). A value
+The *pitchFrequency* is the frequency in Hz (cycles per second). A value
 of 440 is A above middle C. Halving the frequency lowers the pitch one
 octave; doubling the frequency raises it one octave.
 

--- a/docs/dictionary/property/bottomPattern.lcdoc
+++ b/docs/dictionary/property/bottomPattern.lcdoc
@@ -77,7 +77,7 @@ depending on the <object type>:
 
 
 * The <bottomPattern> of a <button> forms a border on the bottom and
-  right edges of the <button>. If the button"s <threeD> <property> is
+  right edges of the <button>. If the button's <threeD> <property> is
   false, the <bottomPattern> has no effect.
 
 

--- a/docs/dictionary/property/caseSensitive.lcdoc
+++ b/docs/dictionary/property/caseSensitive.lcdoc
@@ -27,10 +27,10 @@ comparisons.
 
 The <caseSensitive> <property> <control|controls> the <behavior> of the
 all <string> comparisons, including the comparison <operator|operators>
-<=>, &gt;, &lt; , &gt;=, &lt;=, <is in>, <is among>, <is not among>, and
-<contains>; the <command|commands> <filter>, <find>, and <replace>; and
-the <function|functions> <offset>, <itemOffset>, <wordOffset>,
-<lineOffset>, and <replaceText>.
+<=>, <&gt;>, <&lt;>, <&gt;=>, <&lt;=>, <is in>, <is among>, 
+<is not among>,  and <contains>; the <command|commands> <filter>, 
+<find>, and <replace>; and the <function|functions> <offset>, 
+<itemOffset>, <wordOffset>, <lineOffset>, and <replaceText>.
 
 If the <caseSensitive> <property> is set to true, all the <LiveCode>
 terms listed above, as well as all other <string> comparisons, treat
@@ -73,8 +73,9 @@ expression (glossary), command (glossary), function (glossary),
 LiveCode (glossary), custom property (glossary), key (glossary),
 message (glossary), handler (glossary), 
 string (keyword), = (operator), contains (operator), &gt; (operator),
-is among (operator), is not among (operator), &lt;= (operator),
-is in (operator), wholeMatches (property)
+&gt;= (operator), is among (operator), is not among (operator), 
+&lt; (operator), &lt;= (operator), is in (operator), 
+wholeMatches (property)
 
 Tags: database
 

--- a/docs/dictionary/property/charSet.lcdoc
+++ b/docs/dictionary/property/charSet.lcdoc
@@ -38,8 +38,8 @@ perceptible amount of time, so it's a good idea to save a stack destined
 for a particular platform on that platform before delivering it to
 users. 
 
-The <charSet> <property> is changed for all <stacks> in the same <stack
-file> when the <stack file> is saved, so it is not possible for two
+The <charSet> <property> is changed for all <stacks> in the same 
+<stack file> when the <stack file> is saved, so it is not possible for two
 <stacks> in the same file to have a different <charSet>.
 
 References: numToChar (function), stacks (function), platform (function),

--- a/docs/glossary/c/CGI.lcdoc
+++ b/docs/glossary/c/CGI.lcdoc
@@ -5,9 +5,9 @@ Synonyms: cgi program, cgi
 Type: glossary
 
 Description:
-Common Gateway Interface: a method  to transfer data between a <web
-server> and a program that does something with the data. Also, a program
-designed to handle data from a <web server>.
+Common Gateway Interface: a method  to transfer data between a 
+<web server> and a program that does something with the data. Also, a 
+program designed to handle data from a <web server>.
 
 References: web server (glossary)
 

--- a/docs/glossary/c/character.lcdoc
+++ b/docs/glossary/c/character.lcdoc
@@ -8,10 +8,10 @@ Description:
 A single text symbol: a letter, number, punctuation mark, or control
 character. 
 
-Characters can be <single-byte character|single-byte> or <double-byte
-character|double-byte> (<Unicode>). When using the word "character" in a
-<chunk expression>, <single-byte character|single-byte characters> are
-assumed. 
+Characters can be <single-byte character|single-byte> or 
+<double-byte character|double-byte> (<Unicode>). When using the word 
+"character" in a <chunk expression>, 
+<single-byte character|single-byte characters> are assumed. 
 
 References: Unicode (glossary), double-byte character (glossary),
 single-byte character (glossary), chunk expression (glossary)


### PR DESCRIPTION
backgroundColor (property) - Removed references to non-existent entries. Fixed broken links.
backgroundPattern (property) - Removed reference to non-existent entry, made adjustments to fit this change.
base64Encode (function) - Removed reference to non-existent entry, made adjustments to fit this change.
beepPitch (property) - Added standard italics markdown to use of parameter name outside of syntax; wasn’t appearing with angle brackets.
binaryDecode (function) - Formatted code example for neatness (hopefully).
binfile (keyword) - Fixed broken links.
bottomPattern (property) - Replaced double quote in the middle of a word with an apostrophe
caseSensitive (property) - (Hopefully) added references and links for operators
<= (operator) - Fixed broken link
CGI (glossary) - Fixed broken link
character (glossary) - Fixed broken link
charSet (property) - Fixed broken link