### PR TITLE
[21843] Ensure mobileComposeMail attachment is not lost when Gmail app is used

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -609,6 +609,7 @@ component Runtime.Android
 		file android:livecode_inputcontrol.xml
 		file android:notify_icon.png
 		file android:nfc_tech_filter.xml
+		file android:file_provider_paths.xml
 		executable android:Standalone[[BaseEditionTagUpper]] as Standalone
 		executable android:RevZip
 		executable android:RevXml

--- a/docs/notes/bugfix-21843.md
+++ b/docs/notes/bugfix-21843.md
@@ -1,0 +1,1 @@
+Ensure mobileComposeMail attachment is not lost when gmail app is used to send the email

--- a/docs/notes/bugfix-21843.md
+++ b/docs/notes/bugfix-21843.md
@@ -1,1 +1,1 @@
-Ensure mobileComposeMail attachment is not lost when gmail app is used to send the email
+# Ensure mobileComposeMail attachment is not lost when gmail app is used to send the email

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -423,6 +423,25 @@
 									'cp', '<@(_inputs)', '<@(_outputs)',
 								],
 							},
+                            {
+                                'action_name': 'copy_file_provider_paths',
+                                'message': 'Copying file provider paths file',
+                                
+                                'inputs':
+                                [
+                                'rsrc/android-file_provider_paths.xml',
+                                ],
+                                
+                                'outputs':
+                                [
+                                '<(PRODUCT_DIR)/file_provider_paths.xml',
+                                ],
+                                
+                                'action':
+                                [
+                                'cp', '<@(_inputs)', '<@(_outputs)',
+                                ],
+                            },
 						],
 						
 						'all_dependent_settings':
@@ -435,6 +454,7 @@
 									'<(PRODUCT_DIR)/livecode_inputcontrol.xml',
 									'<(PRODUCT_DIR)/notify_icon.png',
 									'<(PRODUCT_DIR)/nfc_tech_filter.xml',
+                                    '<(PRODUCT_DIR)/file_provider_paths.xml',
 								],
 							},
 						},

--- a/engine/rsrc/android-file_provider_paths.xml
+++ b/engine/rsrc/android-file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="share" path="/" />
+</paths>

--- a/engine/src/java/com/runrev/android/Email.java
+++ b/engine/src/java/com/runrev/android/Email.java
@@ -126,7 +126,7 @@ class Email
 			
 			Uri t_uri;
 			t_uri = FileProvider.getProvider(p_context).addPath(name, t_tempfile.getPath(), mime_type, true, ParcelFileDescriptor.MODE_READ_ONLY);
-
+            
 			return addAttachment(t_uri, mime_type, name);
 		}
 		catch (Exception e)

--- a/engine/src/java/com/runrev/android/FileProvider.java
+++ b/engine/src/java/com/runrev/android/FileProvider.java
@@ -53,7 +53,7 @@ public class FileProvider
 	{
 		m_infos = new HashMap<String, HashMap<String, String> >();
 		m_context = p_context;
-		m_content_uri_base = "content://" + p_context.getPackageName() + ".fileprovider";
+		m_content_uri_base = "content://" + p_context.getPackageName() + ".fileprovider/share";
 	}
 
 	private static FileProvider s_provider = null;

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -523,7 +523,6 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       end if
       replace "${PUSH_PERMISSIONS}" with tPushPermissions in tManifest
       replace "${PUSH_RECEIVER}" with tPushReceiver in tManifest
-      
       // Add the file provider to the manifest
       local tProvider
       put "<provider " & return into tProvider
@@ -531,6 +530,10 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       put "      android:authorities=" & quote & pSettings["android,identifier"] & ".fileprovider" & quote & return after tProvider
       put "      android:exported=" & quote & "true" & quote & return after tProvider
       put "      android:grantUriPermissions=" & quote & "true" & quote & " >" & return after tProvider
+      // Add meta-data tag
+      put "      <meta-data" & return after tProvider
+      put "            android:name=" & quote & "android.support.FILE_PROVIDER_PATHS" & quote & return after tProvider
+      put "            android:resource=" & quote & "@xml/file_provider_paths" & quote & " />" & return after tProvider
       put "    </provider>" & return after tProvider
       
       replace "${PROVIDER}" with tProvider in tManifest
@@ -737,6 +740,15 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
          throw "could not copy NFC tech filter file '" & tNFCTechFilter & "'"
       end if
       put tXMLResBuildFolder & slash & "nfc_tech_filter.xml" & return after tAssetFiles
+      
+      
+      local tFileProviderPaths
+      put mapFilePath(revMobileRuntimeFolder(pTarget) & slash & "file_provider_paths.xml") into tFileProviderPaths
+      put url ("binfile:" & tFileProviderPaths) into url ("binfile:" & tXMLResBuildFolder & slash & "file_provider_paths.xml")
+      if the result is not empty then
+         throw "could not copy file provider paths file '" & tFileProviderPaths & "'"
+      end if
+      put tXMLResBuildFolder & slash & "file_provider_paths.xml" & return after tAssetFiles
       
       if there is a file tIcon then
          put url ("binfile:" & tIcon) into url ("binfile:" & tDrawableResBuildFolder & slash & "icon.png")
@@ -1571,6 +1583,9 @@ function mapFilePath pPath
          break
       case "nfc_tech_filter.xml"
          put merge("[[tBinariesFolder]]/nfc_tech_filter.xml") into tPath
+         break
+      case "file_provider_paths.xml"
+         put merge("[[tBinariesFolder]]/file_provider_paths.xml") into tPath
          break
       case "livecode_inputcontrol.xml"
          put merge("[[tBinariesFolder]]/livecode_inputcontrol.xml") into tPath


### PR DESCRIPTION
Due to recent changes in Android permission model, it was no longer possible on devices running Android >= 6.0 to send an attachment using `mobileComposeMail` when the receiver app is Gmail. 

This patch ensures that our own implementation of FileProvider (a subclass of ContentProvider) does these necessary 3 things for successfully sharing an attachment  using `mobileComposeMail`:

1. Define the FileProvider in your AndroidManifest file (--> added meta-data tag)
2. Create an XML file that contains all paths that the FileProvider will share with other applications (see `android-file_provider_paths.xml`)
3. Ensure a valid URI is created in the Intent (see `m_content_uri_base`)

For more details, see
https://developer.android.com/reference/android/support/v4/content/FileProvider.html?hl=en

This patch is tested on 2 Android devices, running Android 5.1.1 and Android 9.