### PR TITLE
[[ Bug 21860 ]] Fix encoding of svg paths containing relative commands

### DIFF
--- a/docs/notes/bugfix-21860.md
+++ b/docs/notes/bugfix-21860.md
@@ -1,0 +1,1 @@
+# Fix encoding of svg paths containing relative commands

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -1570,6 +1570,10 @@ private command _svgEncodeTransform @xContext, pTransform
 end _svgEncodeTransform
 
 private command _svgEncodePath @xContext, pPath
+	local tFirstX, tFirstY
+	put 0 into tFirstX
+	put 0 into tFirstY
+
 	local tLastX, tLastY
 	put 0 into tLastX
 	put 0 into tLastY
@@ -1591,11 +1595,15 @@ private command _svgEncodePath @xContext, pPath
 			put kMCGDrawingPathOpcodeMoveTo into tOpcode
 			put tScalars[1] into tLastX
 			put tScalars[2] into tLastY
+			put tLastX into tFirstX
+			put tLastY into tFirstY
 			break
 
 		case "Z"
 		case "z"
 			put kMCGDrawingPathOpcodeCloseSubpath into tOpcode
+			put tFirstX into tLastX
+			put tFirstY into tLastY
 			break
 
 		case "l"


### PR DESCRIPTION
This patch fixes a problem in svg paths making heavy use of relative
commands caused by close subpath not resetting the last point to
the first point of the subpath.

The first point is now recorded when a move command is encountered,
and this is used when a close command is encountered to update the
last point.