### PR TITLE
Ensure HealthKit related plist entries are included only when necessary

### DIFF
--- a/docs/notes/bugfix-21862.md
+++ b/docs/notes/bugfix-21862.md
@@ -1,0 +1,1 @@
+# Ensure HealthKit related plist entries are included only when necessary

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -131,10 +131,7 @@
 	<string>This application requires access to Photo Library</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>This application requires access to read the user's health data</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>This application requires access to update the user's health data</string>
+	${HEALTHKIT}
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		${APP_URL_WHITELIST}

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -94,9 +94,6 @@
 	<string>This application requires access to Photo Library</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>This application requires access to read the user's health data</string>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>This application requires access to update the user's health data</string>
+	${HEALTHKIT}
 </dict>
 </plist>

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1587,6 +1587,19 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    
    ----------
    
+   local tHealthKit
+   if pSettings["externals"] contains "mergHK" then
+      put "<key>NSHealthShareUsageDescription</key>" & CR & \
+            "<string>This application requires access to read the user's health data</string>" & CR & \
+            "<key>NSHealthUpdateUsageDescription</key>" & CR & \
+            "<string>This application requires access to update the user's health data</string>" \
+            into tHealthKit
+   else
+      put empty into tHealthKit
+   end if
+   
+   ----------
+   
    if pPlist is empty then
       put url ("binfile:" & tTemplateFile) into pPlist
    end if
@@ -1602,6 +1615,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    replace "${MINIMUM_OS_SUPPORT}" with "<string>" & tMinimumOSByArch["i386"] & "</string>" in pPlist
    replace "${CUSTOM_FONTS}" with tCustomFonts in pPlist
    replace "${DISABLE_ATS}" with tDisableATS in pPlist
+   replace "${HEALTHKIT}" with tHealthKit in pPlist
    
    -- PM-2018-01-15: [[Bug 20852]] Get info about Xcode/SDK versions
    if pTarget is "Device" then


### PR DESCRIPTION
It seems that now the app review from the AppStore is stricter and the app might be rejected if these HealthKit-related key-value pairs are present but no HealthKit functionality is used.