### PR TITLE
[21864] Ensure launch url can open a document on Android 6+

### DIFF
--- a/docs/notes/bugfix-21864.md
+++ b/docs/notes/bugfix-21864.md
@@ -1,0 +1,1 @@
+# Ensure launch url does open a document on Android 6+


### PR DESCRIPTION
Tested with all the variants of `launch url` we support:

- `file:`
- `binfile:`
- `tel:`
- `http(s):`

Tested on both old (5.1.1) and new (9.0) Android versions.