### PR TITLE
[[ Bug ]] Fix crash and behavior of popup widget

### DIFF
--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2722,9 +2722,25 @@ void MCInterfaceExecPopupWidget(MCExecContext &ctxt, MCNameRef p_kind, MCPoint *
 	
 	MCPoint t_at;
 	if (p_at != nil)
-		t_at = *p_at;
+    {
+        if (!MCtargetptr)
+        {
+            ctxt . LegacyThrow(EE_SUBWINDOW_NOSTACK);
+            return;
+        }
+        
+		t_at = MCtargetptr->getstack()->stacktogloballoc(*p_at);
+    }
 	else
-		t_at = MCPointMake(MCmousex, MCmousey);
+    {
+        if (!MCmousestackptr)
+        {
+            ctxt . LegacyThrow(EE_SUBWINDOW_NOSTACK);
+            return;
+        }
+        
+		t_at = MCmousestackptr->stacktogloballoc(MCPointMake(MCmousex, MCmousey));
+    }
 	
 	MCAutoValueRef t_result;
 	if (!MCWidgetPopupAtLocationWithProperties(p_kind, t_at, p_properties, &t_result) || MCValueIsEmpty(*t_result))

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -366,9 +366,6 @@ static MCWidgetPopup *s_widget_popup = nil;
 
 bool MCWidgetPopupAtLocationWithProperties(MCNameRef p_kind, const MCPoint &p_at, MCArrayRef p_properties, MCValueRef &r_result)
 {
-	MCPoint t_at;
-	t_at = MCmousestackptr->stacktogloballoc(p_at);
-	
 	MCWidgetPopup *t_popup;
 	t_popup = nil;
 	
@@ -386,7 +383,7 @@ bool MCWidgetPopupAtLocationWithProperties(MCNameRef p_kind, const MCPoint &p_at
     t_popup -> setparent(MCdispatcher);
 	MCdispatcher -> add_transient_stack(t_popup);
 	
-	if (!t_popup->openpopup(p_kind, t_at, p_properties))
+	if (!t_popup->openpopup(p_kind, p_at, p_properties))
 	{
 		t_popup->close();
 		delete t_popup;
@@ -426,9 +423,17 @@ extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecPopupAtLocationWithProperties
 	MCGPoint t_point;
 	MCCanvasPointGetMCGPoint(p_at, t_point);
 	
-	MCPoint t_at;
-	t_at = MCGPointToMCPoint(MCWidgetMapPointToGlobal(MCcurrentwidget, t_point));
-	
+    MCWidget *t_host;
+    t_host = MCWidgetGetHost(MCcurrentwidget);
+    
+    if (!t_host->getstack()->getopened() || !t_host->getstack()->isvisible())
+    {
+        return nil;
+    }
+    
+    MCPoint t_at;
+	t_at = t_host->getstack()->globaltostackloc(MCGPointToMCPoint(MCWidgetMapPointToGlobal(MCcurrentwidget, t_point)));
+    
 	MCNewAutoNameRef t_kind;
 	/* UNCHECKED */ MCNameCreate(p_kind, &t_kind);
 	


### PR DESCRIPTION
This patch resolves a crash of popup widget when called in the absence of
a valid mouse stack. `MCWidgetPopupAtLocationWithProperties` no longer
translates the location parameter to a global location based on the mouse
stack. All translation is done prior to the call.

- When called from LCB the point is now translated relative to the host
widget stack which is what it is documented to do.
- When called from LCS the translation is relative to the target. This
allows for non-mouse events to call `popup widget`. For example, tabbing
a text field into focus. If no location was specified in LCS then the
mouse location is used and therefore translation is relative to the mouse
stack. Execution errors are now thrown if it is not possible to obtain a
valid global location.