### PR TITLE
[21870] Ensure no folder "Linux" is created if only "Linux x64" is checked

### DIFF
--- a/docs/notes/bugfix-21870.md
+++ b/docs/notes/bugfix-21870.md
@@ -1,0 +1,1 @@
+# Ensure no "Linux" folder is created if only "Linux x64" is checked

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -341,8 +341,11 @@ command revDoSaveAsStandalone pStack, pFolder, pSettings, @xStandalonePaths
          else
             put tOutputFolder into tTargetFolder
          end if
+         
          -- Make sure folder exists
-         revSBEnsureFolder tTargetFolder
+         if tStandaloneSettingsA[tPlatform] then
+            revSBEnsureFolder tTargetFolder
+         end if
          
          switch tPlatform
             case "iOS"


### PR DESCRIPTION
Use case: The user checks `Linux x64` and another non-Linux platform (e.g. `Windows`). In this case, the standalone builder would create the following folders:
- `Windows`(expected)
- `Linux` (empty folder, incorrectly created)
- `Linux x64` (expected)

This happened because `revSBEnsureFolder tTargetFolder` creates folders for the "main" platforms (it does not distinguish between Linux and Linux 64), so it would create a "Linux" folder if either "Linux" or "Linux x64" was checked.

Note that at a later stage the S/B will create a `Linux x64` folder if `Linux x64` is checked.

So this patch checks if `Linux` is actually selected before a `Linux` folder is created.