### PR TITLE
[21871] Ensure no word "Standalone" is appended to the standalone name

### DIFF
--- a/docs/notes/bugfix-21871.md
+++ b/docs/notes/bugfix-21871.md
@@ -1,0 +1,1 @@
+# Ensure no word "Standalone" is appended to the standalone name when building a Linux 64 standalone

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -917,6 +917,7 @@ command revSaveAsLinuxStandalone pStack, pRestoreFileName, pFolder, @xStandalone
    set the itemDelimiter to slash
    put the effective filename of stack pStack into tOriginalFileName
    put item 1 to -2 of tOriginalFileName into tStackPath
+   set the itemDelimiter to comma
    
    -- keep a copy of the standalone settings to restore after each build
    local tStandaloneSettingsA
@@ -935,7 +936,7 @@ command revSaveAsLinuxStandalone pStack, pRestoreFileName, pFolder, @xStandalone
       else
          put "x86" into tArch
       end if
-      revStandalonePreBuild pStack, pFolder, "linux", tArch, tStackName, tStackFileList     
+      revStandalonePreBuild pStack, char 1 to -2 of tDirectory, "linux", tArch, tStackName, tStackFileList     
       if the result is not empty then 
          return the result
       end if


### PR DESCRIPTION
The `revStandalonePreBuild` command prepends the word "Standalone" to the standalone name, if there is already a file `pFolder & "/" & <standalone_name>`. When building for both `Linux` and `Linux 64`, the `revStandalonePreBuild` command is called twice, but both times with `pFolder`.

In this case `pFolder` is `/Users/panos/Downloads/<standalone_folder>/Linux`. So when `revStandalonePreBuild` is called for `Linux 64`, the file `pFolder & "/" & <standalone_name>` already exists (as it was created when building for `Linux`), so the word "Standalone" was prepended to the standalone name.

The fix is to call `revStandalonePreBuild` with `tDirectory` instead, as `tDirectory` is:
- `/Users/panos/Downloads/<standalone_folder>/Linux/`
- `/Users/panos/Downloads/<standalone_folder>/Linux x64/`

But we don't want the last `/`, so we actually need `char 1 to -2 of tDirectory`
