### PR TITLE
added -fPIC and -fno-pie options to allow compiling on modern linux d…

### DIFF
--- a/config.py
+++ b/config.py
@@ -379,13 +379,13 @@ def configure_toolchain(opts):
     if opts['CC_PREFIX'] is not None:
         ccprefix = opts['CC_PREFIX']
     if opts['CC'] is None:
-        opts['CC'] = ccprefix + 'cc'
+        opts['CC'] = ccprefix + 'cc -fno-pie'
     if opts['CXX'] is None:
-        opts['CXX'] = ccprefix + 'c++'
+        opts['CXX'] = ccprefix + 'c++ -fno-pie'
     if opts['AR'] is None:
         opts['AR'] = ccprefix + 'ar'
     if opts['LINK'] is None:
-        opts['LINK'] = opts['CXX']
+        opts['LINK'] = opts['CXX'] + ' -no-pie'
     if opts['STRIP'] is None:
         opts['STRIP'] = ccprefix + 'strip'
     if opts['OBJCOPY'] is None:

--- a/config/linux-settings.gypi
+++ b/config/linux-settings.gypi
@@ -115,6 +115,7 @@
 		'-std=<(c++_std)',
 		'-fno-exceptions',
 		'-fno-rtti',
+		'-fPIC',
 	],
 	
 	'configurations':


### PR DESCRIPTION
Changes to two files to allow compiling on modern linux systems. Gcc since version 6.2 (my system now defaults to version 7.3.0) now defaults to the "-enable-default-pie" option for position independence, which prevents compilation. The patch to config.py forces "-fno-pie" as a compiler option instead and "-no-pie" as a linker option. The cef library compilation still fails unless the second patch to linux-settings.gpyi to force the "-fPIC" option is also installed.