### PR TITLE
[Dictionary] child node to Database library

### DIFF
--- a/docs/dictionary/command/click.lcdoc
+++ b/docs/dictionary/command/click.lcdoc
@@ -42,8 +42,8 @@ Any expression that evaluates to a point--a vertical and horizontal
 distance from the top left of the current stack, separated by a comma.
 
 key:
-One of,,, or. You can specify up to three keys, separated by commas. (On
-Windows and Unix,indicates the Control key.)
+One of shiftKey, commandKey, optionKey, altKey or controlKey. You can 
+specify up to three keys, separated by commas.
 
 Description:
 Use the <click> <command> to simulate the action of a click, instead of

--- a/docs/dictionary/function/cipherNames.lcdoc
+++ b/docs/dictionary/function/cipherNames.lcdoc
@@ -33,5 +33,5 @@ is the default, others have fixed sized key lengths.
 
 References: encrypt (command), Standalone Application Settings (glossary),
 function (glossary), LiveCode custom library (glossary),
-SSL & Encryption library (library)
+standalone application (glossary), SSL & Encryption library (library)
 

--- a/docs/dictionary/function/clickCharChunk.lcdoc
+++ b/docs/dictionary/function/clickCharChunk.lcdoc
@@ -44,11 +44,11 @@ released does not affect the <value> <return|returned> by the
 
 The first and second character numbers in the return value are always
 identical, unless the click was on a field but there was no text under
-it. In this case, the <clickCharChunk> <return|returns> a <chunk
-expression> of the form char charNumber to charNumber - 1 of field
-fieldNumber indicating the start of the clickLine. For example, if the
-mouse is over an empty <field>, the <clickCharChunk> <return|returns>
-char 1 to 0 of field fieldNumber.
+it. In this case, the <clickCharChunk> <return|returns> a 
+<chunk expression> of the form char charNumber to charNumber - 1 of 
+field fieldNumber indicating the start of the clickLine. For example, 
+if the mouse is over an empty <field>, the <clickCharChunk> 
+<return|returns> char 1 to 0 of field fieldNumber.
 
 If the field is locked, the <clickCharChunk> <function> is most useful
 within a <handler> (such as <mouseDown> or <mouseUp>) that is

--- a/docs/dictionary/function/controlKey.lcdoc
+++ b/docs/dictionary/function/controlKey.lcdoc
@@ -24,18 +24,17 @@ Example:
 if controlKey() is down then go back
 
 Returns:
-The <controlKey> <function(control structure)> <return|returns> <down>
+The <controlKey> <function> <return|returns> <down>
 if the key is pressed and <up> if it's not. On Unix and Windows systems,
-the commandKey function <return|returns> the same value as the
-<controlKey> <function(control structure)>: the two
-<function(glossary)|functions> are synonyms.
+the <commandKey> <function> <return|returns> the same value as the
+<controlKey> <function>: the two <function|functions> are synonyms.
 
 Description:
 Use the <controlKey> <function> to check whether the user is pressing
 the Control key.
 
 References: down (constant), left (constant), up (constant),
-function (control structure), keysDown (function), return (glossary),
+commandKey (function), keysDown (function), return (glossary), 
 function (glossary), commandKeyDown (message)
 
 Tags: ui

--- a/docs/dictionary/function/cos.lcdoc
+++ b/docs/dictionary/function/cos.lcdoc
@@ -48,7 +48,7 @@ provide an angle in <degree|degrees>, use the following
     end cosInDegrees
 
 
-References: pi (constant), function (control structure),
+References: pi (constant), function (glossary),
 radian (glossary), custom function (glossary), return (glossary),
 degree (glossary)
 

--- a/docs/dictionary/function/date.lcdoc
+++ b/docs/dictionary/function/date.lcdoc
@@ -49,13 +49,13 @@ month, a space, the day of the month, a comma, and the year.
 
 The internet date form returns the following parts, separated by spaces:
 
-        * the day of the week followed by a comma
-        * the day of the month
-        * the three-letter abbreviation for the month name
-        * the four-digit year
-        * the time in 24-hour format, including seconds, delimited by
-          colons 
-        * the four-digit time zone relative to UTC (Greenwich) time.
+* the day of the week followed by a comma
+* the day of the month
+* the three-letter abbreviation for the month name
+* the four-digit year
+* the time in 24-hour format, including seconds, delimited by
+  colons 
+* the four-digit time zone relative to UTC (Greenwich) time.
 
 
 Description:

--- a/docs/dictionary/property/colorMap.lcdoc
+++ b/docs/dictionary/property/colorMap.lcdoc
@@ -45,8 +45,8 @@ while running the <application>.
 If you leave a line blank when setting the <colorMap>, the color
 corresponding to that <line> is left unchanged.
 
->*Cross-platform note:*  On <Windows|Windows systems>, colors 110 and
-> 246256 cannot be changed.
+>*Cross-platform note:*  On <Windows|Windows systems>, colors 1-10 and
+> 246-256 cannot be changed.
 
 On Unix systems, setting the <colorMap> <property> sets the
 <privateColors> <property> to true.

--- a/docs/dictionary/property/coloroverlay.lcdoc
+++ b/docs/dictionary/property/coloroverlay.lcdoc
@@ -32,31 +32,21 @@ Graphic Effects card of the property inspector which has full control
 over each parameter. To control the effect by script use the 
 following properties: 
 
-colorOverlay["color"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The color of the overlay, in the format
+- colorOverlay["color"] : The color of the overlay, in the format 
 red,green,blue where each value is between 0 and 255.
 
-colorOverlay["blendMode"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How the overlay is blended with the
+- colorOverlay["blendMode"] : How the overlay is blended with the 
 object. This is one of the following values:
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "normal" :
-the glow is laid directly over the object.
+  - "normal" : the glow is laid directly over the object.
+  - "multiply" : this results in a darkening effect
+  - "colorDodge" : this results in a lightening effect
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- "multiply"
-: this results in a darkening effect
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-
-"colorDodge" : this results in a lightening effect
-
-colorOverlay["opacity"]
-
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;How opaque the overlay is. The value is
+colorOverlay["opacity"] : How opaque the overlay is. The value is
 between 0 (fully transparent) and 255 (fully opaque).
 
 References: innerShadow (property), innerGlow (property),
 dropShadow (property), outerGlow (property), blendLevel (property),
 ink (property)
+
 

--- a/docs/dictionary/property/constantMask.lcdoc
+++ b/docs/dictionary/property/constantMask.lcdoc
@@ -25,8 +25,8 @@ By default, the <constantMask> <property> of newly created
 <image(object)|images> is set to false.
 
 Description:
-Use the <constantMask> <property> to enable display of certain <animated
-GIF> <image(object)|images>.
+Use the <constantMask> <property> to enable display of certain 
+<animated GIF> <image(object)|images>.
 
 Some animated GIF images use an optimization technique in which the mask
 data is used to hold information about differences between successive

--- a/docs/dictionary/property/constraints.lcdoc
+++ b/docs/dictionary/property/constraints.lcdoc
@@ -26,12 +26,12 @@ set the pan of me to item 2 of line 1 of the constraints of me
 Value (enum):
 The <constraints> is a list consisting of three lines:
 
-        - The minimum and maximum <pan>, separated by commas.
-        - The minimum and maximum <tilt>, separated by commas.
-        - The minimum and maximum <zoom>, separated by commas.
+ - The minimum and maximum <pan>, separated by commas.
+ - The minimum and maximum <tilt>, separated by commas.
+ - The minimum and maximum <zoom>, separated by commas.
 
 Each value is a number.
-This property is read:only and cannot be set
+This property is read-only and cannot be set
 
 
 Description:

--- a/docs/dictionary/property/customKeys.lcdoc
+++ b/docs/dictionary/property/customKeys.lcdoc
@@ -63,9 +63,8 @@ deleted. Setting the <customKeys> to empty deletes all
 <custom property|custom properties> in the current custom property set.
 
 References: undefine (command), object (glossary), property (glossary),
-custom property (glossary), customPropertySet (glossary),
-custom property set (glossary), line (keyword),
-customPropertySets (property)
+custom property (glossary), custom property set (glossary), 
+line (keyword), customPropertySet(property), customPropertySets (property)
 
 Tags: properties
 

--- a/docs/dictionary/property/customProperties.lcdoc
+++ b/docs/dictionary/property/customProperties.lcdoc
@@ -27,13 +27,13 @@ Example:
 put the customProperties["mySet"] of me into myArray
 
 Value:
-The <customProperties> of an <object(glossary)> is an <array> of <custom
-property|custom properties> and their <value|values>. The name of each
-<custom property> is the <array> <key>.
+The <customProperties> of an <object(glossary)> is an <array> of 
+<custom property|custom properties> and their <value|values>. The name 
+of each <custom property> is the <array> <key>.
 
 Description:
-Use the <customProperties> <property> to set or retrieve all the <custom
-property|custom properties> of an <object(glossary)> at once.
+Use the <customProperties> <property> to set or retrieve all the 
+<custom property|custom properties> of an <object(glossary)> at once.
 
 The <customProperties> specifies the <property|properties> in the
 <object|object's> current <customPropertySet>. (The <object(glossary)>

--- a/docs/glossary/c/Common-library.lcdoc
+++ b/docs/glossary/c/Common-library.lcdoc
@@ -5,10 +5,10 @@ Synonyms: common libraries, common library
 Type: library
 
 Description:
-One of the <LiveCode custom libraries>, which implements
-<function|functions> and <command|commands> that are shared between
-other <custom libraries> or used for miscellaneous purposes.
+One of the <LiveCode custom library|LiveCode custom libraries>, which 
+implements <function|functions> and <command|commands> that are shared 
+between other <LiveCode custom library|custom libraries> 
+or used for miscellaneous purposes.
 
-References: LiveCode custom libraries (glossary), command (glossary),
-function (glossary), custom libraries (glossary)
-
+References: LiveCode custom library (glossary), command (glossary),
+function (glossary)

--- a/docs/glossary/c/child-node.lcdoc
+++ b/docs/glossary/c/child-node.lcdoc
@@ -8,8 +8,8 @@ Description:
 A <node> beneath another <node> in an <XML tree>. Any <node> can have
 any number of child nodes.
 
-A child node corresponds to an element that is enclosed in the <parent
-node>. 
+A child node corresponds to an element that is enclosed in the 
+<parent node>. 
 
 References: node (glossary), XML tree (glossary), parent node (glossary)
 

--- a/docs/glossary/c/cursor.lcdoc
+++ b/docs/glossary/c/cursor.lcdoc
@@ -5,8 +5,8 @@ Synonyms: cursor
 Type: glossary
 
 Description:
-The arrow, hand, or other small picture that shows you where the <mouse
-pointer> is on the screen.
+The arrow, hand, or other small picture that shows you where the 
+<mouse pointer> is on the screen.
 
 References: mouse pointer (glossary)
 

--- a/docs/glossary/d/Database-library.lcdoc
+++ b/docs/glossary/d/Database-library.lcdoc
@@ -6,11 +6,10 @@ Type: library
 
 Description:
 The <LiveCode custom library|LiveCode custom library> that supports
-connections to MySQL, PostgreSQL, <Open Database Connectivity
-(ODBC)|ODBC>, Valentina, and Oracle (LiveCode Enterprise only)
-databases. 
+connections to MySQL, PostgreSQL, <ODBC>, Valentina, and Oracle 
+(LiveCode Enterprise only) databases. 
 
-References: Open Database Connectivity (ODBC) (glossary),
+References: ODBC (glossary),
 LiveCode custom library (glossary)
 
 Tags: database


### PR DESCRIPTION
child node (glossary) - Fixed broken link.
cipherNames (function) - Added missing reference.
click (command) - Added keys that this command will accept.
clickCharChunk (function) - Fixed broken link.
colorMap (property) - Corrected apparent character encoding issue.
Common library (glossary) - Fixed broken links and references.
constraints (property) - Removed indentation from list to display as a list and not as code.
controlKey (function) - Added a reference. Had all mentions of `function` go to the same one entry as they were all talking about functions in the same one context.
cos (function) - Changed function reference type to glossary; seemed more appropriate.
cursor (glossary) - Fixed broken link.
customKeys (property) - Corrected reference type.
customPropertySet (property) - Fixed broken links.
Database library (library) - Corrected reference.
date (function) - Removed indentation from list to display as a list and not as code.