### PR TITLE
The tagged words disappear in the Dictionary

### DIFF
--- a/libscript/src/assert.lcb
+++ b/libscript/src/assert.lcb
@@ -61,12 +61,12 @@ may require that its parameters have a particular structure or fall
 within a particular range, or may need the system to be in a specific
 state.
 
-Note that if the <Condition> is false, this statement will throw an
+Note that if the Condition is false, this statement will throw an
 error with the slightly-unhelpful message that "assertion failed".
-Usually, it will be more useful to use <ExpectsPreconditionWithReason>
+Usually, it will be more useful to use <ExpectPreconditionWithReason>
 instead.
 
-Related: ExpectPreconditionWithReason(statement).
+Related: ExpectPreconditionWithReason (statement).
 
 Tags: Assertions
 */


### PR DESCRIPTION
Condition & ExpectsPreconditionWithReason disappear when viewed in the dictionary.
Not sure what the reason for Condition not working as a tag is so I just removed the enclosure.
ExpectsPreconditionWithReason has an 's' after Expect.
ExpectPreconditionWithReason should fix it.