### PR TITLE
[[ Bug 21933 ]] Add com.livecode.assert to list of builtin module names

### DIFF
--- a/docs/notes/bugfix-21933.md
+++ b/docs/notes/bugfix-21933.md
@@ -1,0 +1,1 @@
+# Ensure modules dependent on com.livecode.assert can be installed

--- a/extensions/script-libraries/extension-utils/extension-utils.livecodescript
+++ b/extensions/script-libraries/extension-utils/extension-utils.livecodescript
@@ -271,6 +271,7 @@ private function __extensionIsBuiltin pID
       case "com.livecode.foreign"
       case "com.livecode.arithmetic"
       case "com.livecode.array"
+      case "com.livecode.assert"
       case "com.livecode.binary"
       case "com.livecode.bitwise"
       case "com.livecode.byte"


### PR DESCRIPTION
Builtin modules must be listed in the appropriate place in
extension-utils so that the IDE knows not to search for them in
the list of installed extensions when they are used as dependencies.

This patch ensures the builtin module com.livecode.assert is
included in this list.