### PR TITLE
Ensure visual effect "scroll" does honor rect

### DIFF
--- a/docs/notes/bugfix-21738.md
+++ b/docs/notes/bugfix-21738.md
@@ -1,1 +1,0 @@
-# Ensure hide with visual effect scroll right/left/down/up does the correct effect

--- a/docs/notes/bugfix-21869.md
+++ b/docs/notes/bugfix-21869.md
@@ -1,0 +1,1 @@
+# Ensure visual effect "scroll" does honor rect 

--- a/engine/src/stacke.cpp
+++ b/engine/src/stacke.cpp
@@ -758,25 +758,21 @@ Boolean scrolleffect_step(const MCRectangle &drect, MCStackSurface *p_target, MC
 	{
 		case VE_LEFT:
 			width = drect.width * t_position;
-            t_start_dst.origin.x -= width;
 			t_end_dst = MCGRectangleTranslate(t_end_src, t_end_src.size.width - width, 0.0);
 			break;
 			
 		case VE_RIGHT:
 			width = drect.width * t_position;
-            t_start_dst.origin.x += width;
 			t_end_dst = MCGRectangleTranslate(t_end_src, -t_end_src.size.width + width, 0.0);
 			break;
 			
 		case VE_UP:
 			height = drect.height * t_position;
-            t_start_dst.origin.y -= height;
 			t_end_dst = MCGRectangleTranslate(t_end_src, 0.0, t_end_src.size.height - height);
 			break;
 			
 		case VE_DOWN:
 			height = drect.height * t_position;
-            t_start_dst.origin.y += height;
 			t_end_dst = MCGRectangleTranslate(t_end_src, 0.0, -t_end_src.size.height + height);
 			break;
 			


### PR DESCRIPTION
This bug (https://quality.livecode.com/show_bug.cgi?id=21869) was introduced by the PR for bug 21738 (https://quality.livecode.com/show_bug.cgi?id=21738).

After some research I _think_ bug 21738 is not actually a bug (its behavior has been the same since LC 6-). 

For now, this patch just reverts https://github.com/livecode/livecode/pull/6823, so as we release a 9.0.3 without any regressions. 

I'll set 21738 to EXPERT_REVIEW so as we decide what is the expected behavior