### PR TITLE
[21826] Ensure mobilePickPhoto works in all Android devices

### DIFF
--- a/docs/notes/bugfix-21826.md
+++ b/docs/notes/bugfix-21826.md
@@ -1,0 +1,1 @@
+# Ensure mobilePickPhoto "camera" does not fail in some Android 8+ devices

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2047,18 +2047,7 @@ public class Engine extends View implements EngineApi
 			return;
 		}
 
-        // getPath() returns a path starting with /, e.g. /storage/emulated/0/Android/data/<app_id>/cache/..
-        // This path is appended to content://<app_id>.fileprovider/share/, resulting in an URI like:
-        //
-        // content://<app_id>.fileprovider//storage/emulated/0/Android/data/<app_id>/cache/..
-        //
-        // This is not a problem in general, but in _some_ devices (e.g. Huawei nova e3) this URI is
-        // normalized to:
-        //
-        // content://<app_id>.fileprovider/storage/emulated/0/Android/data/<app_id>/cache/..
-        //
-        // This results in the URI not being found. So use .substring(1) to remove the first slash
-		String t_path = m_temp_image_file.getPath().substring(1);
+		String t_path = m_temp_image_file.getPath();
 
 		Uri t_uri;
 		t_uri = FileProvider.getProvider(getContext()).addPath(t_path, t_path, "image/jpeg", true, ParcelFileDescriptor.MODE_WRITE_ONLY);

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2047,7 +2047,18 @@ public class Engine extends View implements EngineApi
 			return;
 		}
 
-		String t_path = m_temp_image_file.getPath();
+        // getPath() returns a path starting with /, e.g. /storage/emulated/0/Android/data/<app_id>/cache/..
+        // This path is appended to content://<app_id>.fileprovider/share/, resulting in an URI like:
+        //
+        // content://<app_id>.fileprovider//storage/emulated/0/Android/data/<app_id>/cache/..
+        //
+        // This is not a problem in general, but in _some_ devices (e.g. Huawei nova e3) this URI is
+        // normalized to:
+        //
+        // content://<app_id>.fileprovider/storage/emulated/0/Android/data/<app_id>/cache/..
+        //
+        // This results in the URI not being found. So use .substring(1) to remove the first slash
+		String t_path = m_temp_image_file.getPath().substring(1);
 
 		Uri t_uri;
 		t_uri = FileProvider.getProvider(getContext()).addPath(t_path, t_path, "image/jpeg", true, ParcelFileDescriptor.MODE_WRITE_ONLY);

--- a/engine/src/java/com/runrev/android/FileProvider.java
+++ b/engine/src/java/com/runrev/android/FileProvider.java
@@ -87,6 +87,18 @@ public class FileProvider
 
 	private String getUriStringForFilePath(String p_path)
 	{
+        // If p_path begins with slash, then the resulting URI will be like e.g. :
+        
+        // content://<app_id>.fileprovider//storage/emulated/0/Android/data/<app_id>/cache/..
+        //
+        // This is not a problem in general, but in _some_ devices (e.g. Huawei nova e3) this URI is
+        // normalized to:
+        //
+        // content://<app_id>.fileprovider/storage/emulated/0/Android/data/<app_id>/cache/..
+        //
+        // This results in the URI not being found. So use .substring(1) to remove the first slash, if any
+        if (p_path.charAt(0) == '/')
+            p_path = p_path.substring(1);
 		return m_content_uri_base + "/" + p_path;
 	}
 


### PR DESCRIPTION
`getPath()` returns a path starting with `/`, e.g. `/storage/emulated/0/Android/data/<app_id>/cache/..`
     
This path is appended to `content://<app_id>.fileprovider/share/`, resulting in an URI like:
      
`content://<app_id>.fileprovider//storage/emulated/0/Android/data/<app_id>/cache/..`
     
This is not a problem in general, but in _some_ devices (e.g. Huawei nova e3) this URI is normalized to:

`content://<app_id>.fileprovider/storage/emulated/0/Android/data/<app_id>/cache/..`

This results in the URI not being found. 

This patch removes the leading slash from the path appended to `content://<app_id>.fileprovider/share/`, to make sure that the resulting URI does not need to be normalized.

Tested in several devices, including the one that exhibited the problem originally.