### PR TITLE
[[ Bug 21828 ]] Reduce time taken to compute minimum required file version for stack

### DIFF
--- a/docs/notes/bugfix-21828.md
+++ b/docs/notes/bugfix-21828.md
@@ -1,0 +1,1 @@
+# Reduce save time for stacks with groups shared on multiple cards

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5186,6 +5186,26 @@ struct MCRequiredStackFileVersionVisitor : public MCObjectVisitor
 {
 	uint32_t required_version;
 	
+	bool OnStack(MCStack *p_stack)
+	{
+		MCStack *t_substacks = p_stack->getsubstacks();
+		
+		if (t_substacks != nil)
+		{
+			/* Check minimum version required for substacks */
+			MCStack *t_stack = t_substacks;
+			do
+			{
+				if (!t_stack->visit(kMCObjectVisitorRecursive, 0, this))
+					return false;
+				t_stack = t_stack->next();
+			}
+			while (t_stack != t_substacks);
+		}
+
+		return OnObject(p_stack);
+	}
+	
 	bool OnObject(MCObject *p_object)
 	{
 		required_version = MCMax(required_version, p_object->getminimumstackfileversion());
@@ -5216,7 +5236,7 @@ uint32_t MCObject::geteffectiveminimumstackfileversion(void)
 {
 	MCRequiredStackFileVersionVisitor t_visitor;
 	t_visitor.required_version = kMCStackFileFormatMinimumExportVersion;
-	visit(kMCObjectVisitorHeirarchical | kMCObjectVisitorRecursive, 0, &t_visitor);
+	visit(kMCObjectVisitorRecursive, 0, &t_visitor);
 	return t_visitor.required_version;
 }
 


### PR DESCRIPTION
This patch modifies the MCRequiredStackFileVersionVisitor to check substacks rather than
using the heirarchical flag in visit options. This prevents repeat visits to shared groups
that are reachable from multiple cards.