### PR TITLE
[21900] Fix mobileComposeMail crashing iOS app when attachment has no name

### DIFF
--- a/docs/notes/bugfix-21900.md
+++ b/docs/notes/bugfix-21900.md
@@ -1,0 +1,1 @@
+# Fix crash on iOS when calling mobileComposeMail with an attachment without data  

--- a/engine/src/mbliphonemail.mm
+++ b/engine/src/mbliphonemail.mm
@@ -258,12 +258,13 @@ static void compose_mail_prewait(void *p_context)
 			else
 				t_type = MCStringConvertToAutoreleasedNSString(ctxt -> attachments[i] . type);
 			
+            // "addAttachmentData:" requires that all three arguments are non-nil
 			if (ctxt -> attachments[i] . name == nil)
-				t_name = nil;
+				t_name = @"";
 			else
 				t_name = MCStringConvertToAutoreleasedNSString(ctxt -> attachments[i] . name);
 				
-			[ctxt -> dialog addAttachmentData: t_data mimeType: t_type fileName: t_name];
+            [ctxt -> dialog addAttachmentData: t_data mimeType: t_type fileName: t_name];
 		}
 	}
 


### PR DESCRIPTION
Calling `addAttachmentData: ..` with a `nil` filename causes a crash, so ensure `t_name` is empty instead of `nil`. In this case no attachment appears, which matches the behavior on Android.