### PR TITLE
Prevent hang when opening the script of an edited group with cmd+alt+click

### DIFF
--- a/docs/notes/bugfix-21819.md
+++ b/docs/notes/bugfix-21819.md
@@ -1,0 +1,1 @@
+# Prevent hang when opening the script of an edited group with cmd+alt+click

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -1573,7 +1573,7 @@ MCCard *MCStack::getchildbyname(MCNameRef p_name)
                 return cptr;
             cptr = cptr->next();
         }
-        while (cptr != cards);
+        while (cptr != cards && cptr != savecards);
         return nil;
     }
     MCCard *found = nil;
@@ -1582,9 +1582,10 @@ MCCard *MCStack::getchildbyname(MCNameRef p_name)
         found = cptr->findname(CT_CARD, p_name);
         if (found != nil && found->countme(backgroundid, (state & CS_MARKED) != 0))
             break;
+        
         cptr = cptr->next();
     }
-    while (cptr != cards);
+    while (cptr != cards && cptr != savecards);
     
     return found;
 }

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -1554,11 +1554,15 @@ MCCard *MCStack::getchildbyname(MCNameRef p_name)
 		cards->setparent(this);
 	}
     
-    MCCard *cptr;
-	if (editing != NULL && savecards != NULL)
-		cptr = savecards;
-	else
-		cptr = cards;
+    MCCard *cptr, *cptr_sentinal;
+    if (editing != NULL && savecards != NULL)
+    {
+        cptr_sentinal = cptr = savecards;
+    }
+    else
+    {
+        cptr_sentinal = cptr = cards;
+    }
     
     uint2 t_num = 0;
     if (MCU_stoui2(MCNameGetString(p_name), t_num))
@@ -1573,7 +1577,7 @@ MCCard *MCStack::getchildbyname(MCNameRef p_name)
                 return cptr;
             cptr = cptr->next();
         }
-        while (cptr != cards && cptr != savecards);
+        while (cptr != cptr_sentinal);
         return nil;
     }
     MCCard *found = nil;
@@ -1585,7 +1589,7 @@ MCCard *MCStack::getchildbyname(MCNameRef p_name)
         
         cptr = cptr->next();
     }
-    while (cptr != cards && cptr != savecards);
+    while (cptr != cptr_sentinal);
     
     return found;
 }


### PR DESCRIPTION
If in Edit Group mode, then the starting value of `cptr` is `savecards`

This patch prevents an infinite loop by checking `cptr` against `savecards` as well