### PR TITLE
[[ Bug 10881 ]] Fix Android openGL compositor surface height issue

### DIFF
--- a/docs/notes/bugfix-10881.md
+++ b/docs/notes/bugfix-10881.md
@@ -1,0 +1,1 @@
+# Fix stack rendering when keyboard activated and deactivated on Android with acceleratedRendering

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -233,6 +233,7 @@
 							'libraries':
 							[
 								'-lGLESv1_CM',
+								'-lEGL',
 								'-ljnigraphics',
 								'-llog',
 								'-lm',

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -695,6 +695,16 @@ void MCScreenDC::do_fit_window(bool p_immediate_resize, bool p_post_message)
 	}
 }
 
+void MCScreenDC::refresh_current_window(void)
+{
+    if (m_current_window == nil)
+        return;
+    
+    MCStack *t_stack = (MCStack *)m_current_window;
+    
+    t_stack -> dirtyrect(t_stack -> view_getstackvisiblerect());
+}
+
 Window MCScreenDC::get_current_window(void)
 {
 	return m_current_window;
@@ -2769,8 +2779,8 @@ static void doSurfaceChangedCallback(void *p_is_init)
 	// We can now re-enable screen updates.
 	MCRedrawEnableScreenUpdates();
 
-	// Force a screen redraw
-	MCRedrawUpdateScreen();
+	// Force a redraw of the current window without re-rendering
+    static_cast<MCScreenDC *>(MCscreen) -> refresh_current_window();
 }
 
 JNIEXPORT void JNICALL Java_com_runrev_android_OpenGLView_doSurfaceChanged(JNIEnv *env, jobject object, jobject p_view)

--- a/engine/src/mbldc.h
+++ b/engine/src/mbldc.h
@@ -244,6 +244,7 @@ public:
 	// MW-2012-11-14: [[ Bug 10514 ]] Returns the current window on display.
 	Window get_current_window(void);
 	
+    void refresh_current_window(void);
 private:
 	// The top-left of the mobile 'window' in screen co-ordinates.
 	int32_t m_window_left;

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -850,6 +850,11 @@ Window MCScreenDC::get_current_window(void)
 	return m_current_window;
 }
 
+void MCScreenDC::refresh_current_window(void)
+{
+    
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern void *coretext_font_create_with_name_size_and_style(MCStringRef p_name, uint32_t p_size, bool p_bold, bool p_italic);

--- a/engine/src/tilecachegl.cpp
+++ b/engine/src/tilecachegl.cpp
@@ -40,6 +40,7 @@ extern void MCIPhoneSwitchToOpenGL(void);
 #define GL_GLEXT_PROTOTYPES
 #include <GLES/gl.h>
 #include <GLES/glext.h>
+#include <EGL/egl.h>
 extern void MCAndroidEnableOpenGLMode(void);
 extern void MCAndroidDisableOpenGLMode(void);
 #else
@@ -390,7 +391,17 @@ void MCTileCacheOpenGLCompositor_DeallocateTile(void *p_context, void *p_tile)
 
 static void MCTileCacheOpenGLCompositor_PrepareFrame(MCTileCacheOpenGLCompositorContext *self)
 {
-	self -> viewport_height = MCTileCacheGetViewport(self -> tilecache) . height;
+#if defined(_ANDROID_MOBILE)
+    EGLint t_height;
+    eglQuerySurface(eglGetCurrentDisplay(),
+                    eglGetCurrentSurface(EGL_DRAW),
+                    EGL_HEIGHT,
+                    &t_height);
+    
+    self -> viewport_height = t_height;
+#else
+    self -> viewport_height = MCTileCacheGetViewport(self -> tilecache) . height;
+#endif
 	self -> current_texture = 0;
 	self -> current_color = 0xffffffff;
 	self -> current_opacity = 255;


### PR DESCRIPTION
This patch fixes an issue on Android where the SurfaceView is being resized
when the keyboard is activated and deactivated. We do not resize the view for
keyboard activation and as the openGL coordinate system has bottom-left origin
the bottom of the stack was being rendered where the top should be.

This patch changes the openGL tile cache to request the surface height directly
through EGL APIs. As these APIs are unavailable on iOS the change is `#ifdef`d
for Android only.

Additionally to ensure the stack is re-drawn without necessarily re-rendering it
the patch implements a new `MCScreenDC::refresh_current_window()` API. This is
particularly important for when the keyboard is hidden as otherwise the area
previously occupied by it will be black.