### PR TITLE
[[ Bug 21915 ]] Fix memory leak in 'the processor'

### DIFF
--- a/docs/notes/bugfix-21915.md
+++ b/docs/notes/bugfix-21915.md
@@ -1,0 +1,1 @@
+# Fix memory leak in 'the processor' function

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -1613,8 +1613,7 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
     
 	virtual bool GetMachine(MCStringRef& r_string)
     {
-		r_string = MCValueRetain(MCS_getprocessor());
-		return true;
+        return MCS_getprocessor(r_string);
     }
     
 	virtual bool GetAddress(MCStringRef& r_address)

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -159,7 +159,10 @@ void MCEngineEvalMachine(MCExecContext& ctxt, MCStringRef& r_string)
 
 void MCEngineEvalProcessor(MCExecContext& ctxt, MCStringRef& r_string)
 {
-    r_string = MCValueRetain(MCS_getprocessor());
+    if (MCS_getprocessor(r_string))
+        return;
+    
+    ctxt.Throw();
 }
 
 void MCEngineEvalSystemVersion(MCExecContext& ctxt, MCStringRef& r_string)

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -100,7 +100,7 @@ extern Boolean MCS_rmdir(MCStringRef path);
 extern uint4 MCS_getpid();
 extern bool MCS_getaddress(MCStringRef& r_string);
 extern bool MCS_getmachine(MCStringRef& r_string);
-extern MCStringRef MCS_getprocessor();
+extern bool MCS_getprocessor(MCStringRef& r_string);
 extern real8 MCS_getfreediskspace(void);
 extern bool MCS_getsystemversion(MCStringRef& r_string);
 extern bool MCS_loadtextfile(MCStringRef p_filename, MCStringRef& r_text);

--- a/engine/src/srvwindows.cpp
+++ b/engine/src/srvwindows.cpp
@@ -297,9 +297,8 @@ struct MCWindowsSystem: public MCSystemInterface
 
 	virtual bool GetMachine(MCStringRef& r_string)
 	{
-        r_string = MCValueRetain(MCS_getprocessor());
-        return true;
-	}
+        return MCS_getprocessor(r_string);
+    }
 
 	virtual void GetAddress(MCStringRef& r_address)
 	{

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -555,15 +555,9 @@ bool MCS_getsystemversion(MCStringRef& r_string)
 	return MCsystem->GetVersion(r_string);
 }
 
-MCStringRef MCS_getprocessor(void)
+bool MCS_getprocessor(MCStringRef& r_string)
 {
-    MCAutoStringRef t_arch;
-    if (!MCSInfoGetArchitecture(&t_arch))
-    {
-        return kMCEmptyString;
-    }
-    
-    return t_arch.Take();
+    return MCSInfoGetArchitecture(r_string);
 }
 
 bool MCS_getmachine(MCStringRef& r_string)


### PR DESCRIPTION
The refactoring of the internal support code the 'the processor'
function resulted in the introduction of a memory leak due to
over-retaining the return value of MCS_getprocessor().

The leak has been fixed by changing the signature of MCS_getprocessor()
to match the standard style of bool return value to indicate an error
and an out parameter to take the string result.