### PR TITLE
[[ Bug 21916 ]] Fix memory leak when using printing on macOS

### DIFF
--- a/docs/notes/bugfix-21916.md
+++ b/docs/notes/bugfix-21916.md
@@ -1,0 +1,1 @@
+# Fix memory leak when reconfiguring the printer on macOS

--- a/engine/src/osxprinter.cpp
+++ b/engine/src/osxprinter.cpp
@@ -553,6 +553,8 @@ void MCMacOSXPrinter::SetProperties(bool p_include_output)
 		t_page_width = ceil(t_width);
 		t_page_height = ceil(t_height);
 
+        if (m_paper != nullptr)
+            PMRelease(m_paper);
         m_paper = t_pm_paper;
         PMRetain(t_pm_paper);
 	}


### PR DESCRIPTION
This patch fixes a leak of a PMPaper object when the macOS printer
is reconfigured/reset. The leak is caused by failing to release the
previous held PMPaper object before it is updated with a revised
one when setting the system printer properties.