### PR TITLE
[[ Bug 21917 ]] Fix leak of NSEvent in core macOS event processing

### DIFF
--- a/docs/notes/bugfix-21917.md
+++ b/docs/notes/bugfix-21917.md
@@ -1,0 +1,1 @@
+# Fix memory leak when tracking mouse on macOS

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -798,6 +798,8 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
 	{
 		if ([t_event type] == NSLeftMouseDown || [t_event type] == NSLeftMouseDragged)
 		{
+            if (s_last_mouse_event != nullptr)
+                [s_last_mouse_event release];
 			s_last_mouse_event = t_event;
 			[t_event retain];
 			[NSApp sendEvent: t_event];


### PR DESCRIPTION
This patch fixes a leak of an NSEvent used to keep track of the last
processed mouse event during mouse tracking. The previously cached
mouse event object was not being released before being updated with
the most recent one.