### PR TITLE
[[ Bug 21918 ]] Memory leak when manipulating four-char-codes on macOS

### DIFF
--- a/docs/notes/bugfix-21918.md
+++ b/docs/notes/bugfix-21918.md
@@ -1,0 +1,2 @@
+# Fix memory leak when using legacy macOS features relying on four-char-codes
+

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -87,14 +87,14 @@ inline FourCharCode FourCharCodeFromString(const char *p_string)
 
 bool FourCharCodeFromString(MCStringRef p_string, uindex_t p_start, FourCharCode& r_four_char_code)
 {
-    char *temp;
+    MCAutoStringRefAsCString t_temp;
     uint32_t t_four_char_code;
-    if (!MCStringConvertToCString(p_string, temp))
+    if (!t_temp.Lock(p_string))
         return false;
     
-    memcpy(&t_four_char_code, temp + p_start, 4);
+    memcpy(&t_four_char_code, *t_temp + p_start, 4);
     r_four_char_code = MCSwapInt32HostToNetwork(t_four_char_code);
-    delete temp;
+    
     return true;
 }
 
@@ -109,7 +109,7 @@ inline char *FourCharCodeToString(FourCharCode p_code)
 
 bool FourCharCodeToStringRef(FourCharCode p_code, MCStringRef& r_string)
 {
-    return MCStringCreateWithCString(FourCharCodeToString(p_code), r_string);
+    return MCStringCreateWithCStringAndRelease(FourCharCodeToString(p_code), r_string);
 }
 
 struct triplets


### PR DESCRIPTION
This patch fixes a leak in the macOS platform specific FourCharCodeFromString
function. In order to convert a string into a FourCharCode integer, the
string is temporarily converted to a CString. Previously, however, this
temporary CString was not being deleted. The explicit conversion has been replaced
by an AutoStringRefAsCString auto class which fixes the leak.