### PR TITLE
[[ Bug 21919 ]] Fix memory leak when deleting system font refs on macOS

### DIFF
--- a/docs/notes/bugfix-21919.md
+++ b/docs/notes/bugfix-21919.md
@@ -1,0 +1,2 @@
+# Fix memory leak when fonts are loaded and unloaded on macOS
+

--- a/engine/src/osxflst.cpp
+++ b/engine/src/osxflst.cpp
@@ -128,13 +128,15 @@ MCFontnode::~MCFontnode()
 {
     MCValueRelease(reqname);
     
-    // Don't delete the fontstruct for system fonts (it is still cached elsewhere)
+    /* The actual font handle for system fonts is cached by the theme related
+     * code on Mac so don't release it here. */
     if ((reqstyle & FA_SYSTEM_FONT) == 0)
     {
         // MM-2014-06-02: [[ CoreText ]] Updated to use core text fonts.
         coretext_font_destroy(font -> fid);
-        delete font;
     }
+    
+    delete font;
 }
 
 MCFontStruct *MCFontnode::getfont(MCNameRef fname, uint2 size, uint2 style)


### PR DESCRIPTION
This patch fixes a leak which occurs when references to system/theme fonts
are deleted on macOS. System font handles are cached globally separately
from the higher-level management of them (specifically in the theme-related
code) so mustn't be released. However, the MCFontstruct which is created
to wrap them must still be deleted. The leak occurs when the engine must
'purge fonts' to update references after a font has been explicitly
loaded and unloaded.