### PR TITLE
[[ Bug 21921 ]] Ensure MCGRegion destructor is called

### DIFF
--- a/docs/notes/bugfix-21921.md
+++ b/docs/notes/bugfix-21921.md
@@ -1,0 +1,1 @@
+# Fix memory leak when redrawing non-rectangular update regions

--- a/libgraphics/src/region.cpp
+++ b/libgraphics/src/region.cpp
@@ -31,7 +31,7 @@ bool MCGRegionCreate(MCGRegionRef &r_region)
 	t_region = nil;
 	
 	if (t_success)
-		t_success = MCMemoryNew(t_region);
+		t_success = MCMemoryCreate(t_region);
 
 	if (t_success)
 		r_region = t_region;
@@ -46,7 +46,7 @@ void MCGRegionDestroy(MCGRegionRef p_region)
 	if (p_region == nil)
 		return;
 	
-	MCMemoryDelete(p_region);
+	MCMemoryDestroy(p_region);
 }
 
 bool MCGRegionCopy(MCGRegionRef p_region, MCGRegionRef &r_copy)


### PR DESCRIPTION
This patch changes the use of MCMemoryNew/MCMemoryDelete to
MCMemoryCreate/MCMemoryDestroy. This is necessary because the
internal __MCGRegion struct has an implicit constructor due to
it wrapping an SkRegion which needs a destructor when the region
becomes complex (i.e. not being a single rectangle).