### PR TITLE
[[ Bug 21923 ]] Fix memory leak when computing formattedWidth of buttons

### DIFF
--- a/docs/notes/bugfix-21923.md
+++ b/docs/notes/bugfix-21923.md
@@ -1,0 +1,1 @@
+# Fix memory leak when getting the formattedWidth of buttons

--- a/engine/src/exec-interface-button.cpp
+++ b/engine/src/exec-interface-button.cpp
@@ -940,15 +940,15 @@ void MCButton::GetFormattedWidth(MCExecContext& ctxt, integer_t& r_width)
 				fwidth = 0;
 			else
             {
-                MCArrayRef lines;
-                MCStringSplit(t_label, MCSTR("\n"), nil, kMCCompareExact, lines);
-                uindex_t line_count = MCArrayGetCount(lines);
+                MCAutoArrayRef lines;
+                MCStringSplit(t_label, MCSTR("\n"), nil, kMCCompareExact, &lines);
+                uindex_t line_count = MCArrayGetCount(*lines);
                 int32_t max_length = 0;
                 
                 for (uindex_t i = 0; i < line_count; ++i)
                 {
                     MCValueRef line = nil;
-                    MCArrayFetchValueAtIndex(lines, i + 1, line);
+                    MCArrayFetchValueAtIndex(*lines, i + 1, line);
                     MCStringRef const string_line = static_cast<MCStringRef const>(line);
                     
                     int32_t string_line_length = MCFontMeasureText(m_font, string_line, getstack() -> getdevicetransform());


### PR DESCRIPTION
This patch fixes a memory leak in the computation of the formattedWith
of buttons. In order to compute the formatted width, the label string
is split into an array of lines which are then measured. The storage
of the evaluated lines array has been changed to use an auto class to
ensure that it is not leaked.