### PR TITLE
[[ Bug 21924 ]] Fix memory leak when choosing item from macOS popup menu

### DIFF
--- a/docs/notes/bugfix-21924.md
+++ b/docs/notes/bugfix-21924.md
@@ -1,0 +1,1 @@
+# Fix memory leak when choosing popup menu item on macOS

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -411,7 +411,7 @@ void MCButton::macopenmenu(void)
 				MCAutoStringRef t_label;
 				MCPlatformGetMenuItemProperty(m_system_menu, s_popup_menuitem, kMCPlatformMenuItemPropertyTitle, kMCPlatformPropertyTypeMCString, &(&t_label));
                 
-				/* UNCHECKED */ MCStringCopy(*t_label, label);
+                MCValueAssign(label, *t_label);
 				flags |= F_LABEL;
 				
                 // SN-2014-08-25: [[ Bug 13240 ]] We need to keep the actual popup_menustring,


### PR DESCRIPTION
This patch fixes the failure to release the previously chosen popup
menu button label when a new one (from a pick from a macOS popup menu)
replaces it. The leak was caused by using MCValueCopy to overwrite the
label instance variable, rather than using MCValueAssign to assign
to it.