### PR TITLE
[[ Bug 21925 ]] Fix memory leak when using macOS Debug method

### DIFF
--- a/docs/notes/bugfix-21925.md
+++ b/docs/notes/bugfix-21925.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using put [ into msg ] on macOS when there is no message box

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -2964,7 +2964,10 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
     {
 		CFStringRef t_string;
 		if (MCStringConvertToCFStringRef(p_string, t_string))
+        {
 			NSLog(CFSTR("%@"), t_string);
+            CFRelease(t_string);
+        }
     }
 	
 	virtual real64_t GetCurrentTime(void)


### PR DESCRIPTION
This patch ensures that the CFStringRef which is created so
that a debug message can be emitted using NSLog is released
after use on macOS. This method is used when a 'put into msg'
operation is performed, there is no message box target and
the msgChanged message is unhandled or passed.