### PR TITLE
[[ Bug 21887 ]] Use auto classes to manage MCTextChunkIterator instances

### DIFF
--- a/docs/notes/bugfix-21887.md
+++ b/docs/notes/bugfix-21887.md
@@ -1,0 +1,2 @@
+# Fix memory leaks in LCB 'number of chars in' and 'is among the chars of' operators
+

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -417,7 +417,7 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
     index_t t_sequenced_iterator;
     const byte_t *t_data_ptr;
     
-    MCTextChunkIterator *tci = nil;
+    MCAutoPointer<MCTextChunkIterator> tci;
     
     if (!ctxt . TryToEvaluateExpression(endcond, line, pos, EE_REPEAT_BADFORCOND, &t_condition))
         return;
@@ -551,7 +551,7 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
                 
             default:
             {
-                t_found = MCStringsTextChunkIteratorNext(ctxt, tci);
+                t_found = MCStringsTextChunkIteratorNext(ctxt, *tci);
                 endnext = tci -> IsExhausted();
                 
                 if (!t_found)
@@ -595,8 +595,6 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
         
         done = done || endnext;
     }
-    
-    delete tci;
 }
 
 void MCKeywordsExecRepeatWith(MCExecContext& ctxt, MCStatement *statements, MCExpression *step, MCExpression *startcond, MCExpression *endcond, MCVarref *loopvar, real8 stepval, uint2 line, uint2 pos)

--- a/engine/src/exec-strings-chunk.cpp
+++ b/engine/src/exec-strings-chunk.cpp
@@ -64,12 +64,11 @@ void MCStringsCountChunksInRange(MCExecContext& ctxt, Chunk_term p_chunk_type, M
         return;
     }
 
-    MCTextChunkIterator *tci;
+    MCAutoPointer<MCTextChunkIterator> tci;
     tci = MCStringsTextChunkIteratorCreateWithRange(ctxt, p_string, p_range, p_chunk_type);
     
     r_count = tci -> CountChunks();
     
-    delete tci;
     return;
 }
 
@@ -1145,9 +1144,7 @@ MCTextChunkIterator *MCStringsTextChunkIteratorCreate(MCExecContext& ctxt, MCStr
 {
     if (p_chunk_type == CT_TOKEN)
     {
-        MCTextChunkIterator *tci;
-        tci = new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type));
-        return tci;
+        return new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type));
     }
     
     return MCChunkCreateTextChunkIterator(p_text, nil, MCChunkTypeFromChunkTerm(p_chunk_type), ctxt . GetLineDelimiter(), ctxt . GetItemDelimiter(), ctxt . GetStringComparisonType());
@@ -1157,9 +1154,7 @@ MCTextChunkIterator *MCStringsTextChunkIteratorCreateWithRange(MCExecContext& ct
 {
     if (p_chunk_type == CT_TOKEN)
     {
-        MCTextChunkIterator *tci;
-        tci = new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type), p_range);
-        return tci;
+        return new (nothrow) MCTextChunkIterator_Tokenized(p_text, MCChunkTypeFromChunkTerm(p_chunk_type), p_range);
     }
     
     return MCChunkCreateTextChunkIterator(p_text, &p_range, MCChunkTypeFromChunkTerm(p_chunk_type), ctxt . GetLineDelimiter(), ctxt . GetItemDelimiter(), ctxt . GetStringComparisonType());

--- a/engine/src/exec-strings.cpp
+++ b/engine/src/exec-strings.cpp
@@ -1531,13 +1531,12 @@ bool MCStringsEvalIsAmongTheChunksOf(MCExecContext& ctxt, MCStringRef p_chunk, M
     MCChunkType t_type;
     t_type = MCChunkTypeFromChunkTerm(p_chunk_type);
     
-    MCTextChunkIterator *tci;
-    tci = MCStringsTextChunkIteratorCreate(ctxt, p_text, p_chunk_type);
+    MCAutoPointer<MCTextChunkIterator> tci = 
+            MCStringsTextChunkIteratorCreate(ctxt, p_text, p_chunk_type);
 
     bool t_result;
     t_result = tci -> IsAmong(p_chunk);
     
-    delete tci;
     return t_result;
 
 }
@@ -1680,12 +1679,11 @@ __MCStringsEvalChunkOffset(MCExecContext& ctxt,
     MCChunkType t_type;
     t_type = MCChunkTypeFromChunkTerm(p_chunk_type);
     
-    MCTextChunkIterator *tci;
-    tci = MCStringsTextChunkIteratorCreate(ctxt, p_string, p_chunk_type);
+    MCAutoPointer<MCTextChunkIterator> tci =
+            MCStringsTextChunkIteratorCreate(ctxt, p_string, p_chunk_type);
     
     uindex_t t_offset = tci -> ChunkOffset(p_chunk, p_start_offset, nil, ctxt . GetWholeMatches());
     
-    delete tci;
     return t_offset;
 }
 

--- a/libscript/src/module-char.cpp
+++ b/libscript/src/module-char.cpp
@@ -48,8 +48,8 @@ bool MCCharStoreChunk(MCStringRef &x_target, MCStringRef p_value, MCRange p_grap
 
 extern "C" MC_DLLEXPORT_DEF void MCCharEvalNumberOfCharsIn(MCStringRef p_target, index_t& r_output)
 {
-    MCTextChunkIterator *tci;
-    tci = MCChunkCreateTextChunkIterator(p_target, nil, kMCChunkTypeCharacter, nil, nil, kMCStringOptionCompareExact);
+    MCAutoPointer<MCTextChunkIterator> tci =
+            MCChunkCreateTextChunkIterator(p_target, nil, kMCChunkTypeCharacter, nil, nil, kMCStringOptionCompareExact);
     r_output = tci -> CountChunks();
 }
 
@@ -65,8 +65,8 @@ extern "C" MC_DLLEXPORT_DEF void MCCharEvalIsAmongTheCharsOf(MCStringRef p_needl
         return;
     }
     
-    MCTextChunkIterator *tci;
-    tci = MCChunkCreateTextChunkIterator(p_target, nil, kMCChunkTypeCharacter, nil, nil, kMCStringOptionCompareExact);
+    MCAutoPointer<MCTextChunkIterator> tci =
+            MCChunkCreateTextChunkIterator(p_target, nil, kMCChunkTypeCharacter, nil, nil, kMCStringOptionCompareExact);
     r_output = tci -> IsAmong(p_needle);
 }
 


### PR DESCRIPTION
This patch replaces the use of explicit deallocation of MCTextChunkIterator
instances with auto classes. By doing this memory leaks in the LCB
'is among the chars of' and 'the number of chars in' operators are eliminated.