### PR TITLE
[[ Bug 21787 ]] Fix memory leak when implicitly deleting substacks

### DIFF
--- a/docs/notes/bugfix-21787.md
+++ b/docs/notes/bugfix-21787.md
@@ -1,0 +1,1 @@
+# Fix memory leak which occurs when substacks are deleted implicitly

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -367,14 +367,32 @@ void MCDispatch::removestack(MCStack *sptr)
 
 void MCDispatch::destroystack(MCStack *sptr, Boolean needremove)
 {
+    /* Make sure no messages are sent when destroying the given stack as this
+     * destruction method is only ever used for stacks which are not-yet-alive
+     * (e.g. failed to deserialize) or in restricted contexts (e.g. licensing
+     * dialog on startup). */
+    Boolean oldstate = MClockmessages;
+    MClockmessages = True;
+    
 	if (needremove)
     {
         MCStack *t_substacks = sptr -> getsubstacks();
-        while (t_substacks)
+        while(t_substacks != nullptr)
         {
+            /* The MCStack::dodel() method removes the stack from its mainstack 
+             * so we must explicitly delete it explicitly. Note that there is
+             * no need to scheduledelete() in this case as destroystack() is
+             * only called when it is known that no script is running from the
+             * stack. */
             t_substacks -> dodel();
+            delete t_substacks;
+            
+            /* Refetch the substacks list - the substack we just processed will
+             * have been removed from it. */
             t_substacks = sptr -> getsubstacks();
         }
+        
+        /* Release any references to the mainstack */
         sptr -> dodel();
     }
 	if (sptr == MCstaticdefaultstackptr)
@@ -383,9 +401,13 @@ void MCDispatch::destroystack(MCStack *sptr, Boolean needremove)
 		MCdefaultstackptr = MCstaticdefaultstackptr;
 	if (MCacptr && MCacptr->getmessagestack() == sptr)
 		MCacptr->setmessagestack(NULL);
-	Boolean oldstate = MClockmessages;
-	MClockmessages = True;
+    
+    /* Delete the stack explicitly. Note that there is no need to use
+     * scheduledelete here as destroystack() is only called when it is known
+     * that no script is running from the stack. */
 	delete sptr;
+    
+    /* Restore the previous message lock state. */
 	MClockmessages = oldstate;
 }
 

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -1419,8 +1419,17 @@ Boolean MCStack::del(bool p_check_flag)
 
     while (substacks)
     {
+        /* When a substack is deleted it removes itself from its mainstack,
+         * however it isn't actually destroyed - it must be explicitly
+         * scheduled for deletion. */
+        MCStack *t_substack = substacks;
         if (!substacks -> del(false))
             return False;
+        
+        /* Schedule the substack for deletion - unlike a main stack we don't
+         * need to check for it being in the MCtodestroy list as only mainstacks
+         * can ever be in that list. */
+        t_substack->scheduledelete();
     }
     
     return dodel();


### PR DESCRIPTION
This patch fixes a memory leak which occurs when a mainstack has
substacks and the mainstack is deleted.

When a stack is deleted it has all references to it removed and
then is scheduled for deletion (i.e. it is placed in the deleted
object pool for removal when the stack unwinds enough to ensure
there are no ptr references to it on the C stack).

If a stack has substacks then the substacks also have references
removed to them, including the references held by the mainstack.
This means that when the (main) stack is deleted from the deleted
object pool, it no longer has any references to its substacks.

This patch fixes the leak which occurs both when using the (very
context specific) destroystack() method in MCDispatcher and also
when using the general stack del() method.

In the first case it ensures that the substacks of the stack
passed to destroystack() are explicitly destroyed (using the
delete operator).

In the second case it ensures that scheduledelete() is called
for each substack after its del() method has been called.

The result is that regardless of how a stack comes to be
deleted, its MCStack object instance will be eventually
deleted (using the delete operator).