### PR TITLE
[[ Bug 21932 ]] Fix memory leak when executing sqlite queries

### DIFF
--- a/docs/notes/bugfix-21932.md
+++ b/docs/notes/bugfix-21932.md
@@ -1,0 +1,1 @@
+# Fix memory leak when performing queries using sqlite revdb driver


### PR DESCRIPTION
This patch fixes a memory leak when executing sqlite queries using
the revdb sqlite driver.

See the corresponding thirdparty commit for further details.