### PR TITLE
[[ Bug 21930 ]] Fix memory leak in use of GetVariableEx(UTF8) calls

### DIFF
--- a/docs/notes/bugfix-21930.md
+++ b/docs/notes/bugfix-21930.md
@@ -1,0 +1,1 @@
+# Fix memory leak in GetVariableEx and GetVariableEx external V0 functions

--- a/engine/src/externalv0.cpp
+++ b/engine/src/externalv0.cpp
@@ -905,6 +905,10 @@ static char *get_variable_ex(const char *arg1, const char *arg2,
     char *t_result;
     /* UNCHECKED */ MCStringNormalizeAndConvertToCString(*t_string, t_result);
     
+    /* Add the generated cstring to the pool that must be released when the
+     * external call finishes as the caller isn't responsible for freeing it. */
+    MCExternalAddAllocatedString(MCexternalallocpool, t_result);
+    
     // SN-2014-04-07 [[ Bug 12118 ]] revExecuteSQL writes incomplete data into SQLite BLOB columns
     // arg3 is not a char* but rather a MCString; whence setting the length should not be forgotten,
     // in case '\0' are present in the value fetched.
@@ -1425,7 +1429,11 @@ static char *get_variable_ex_utf8(const char *arg1, const char *arg2,
     char *t_result = nullptr;
     uindex_t t_char_count = 0;
     /* UNCHECKED */ convert_from_string(*t_string, p_is_text, t_result, t_char_count);
-
+    
+    /* Add the generated cstring/data to the pool that must be released when the
+     * external call finishes as the caller isn't responsible for freeing it. */
+    MCExternalAddAllocatedString(MCexternalallocpool, t_result);
+    
     // SN-2014-04-07 [[ Bug 12118 ]] revExecuteSQL writes incomplete data into SQLite BLOB columns
     // arg3 is not a char* but rather a MCString; whence setting the length should not be forgotten,
     // in case '\0' are present in the value fetched.


### PR DESCRIPTION
This patch fixes a memory leak when the GetVariableEx(UTF8) external
V0 APIs are used. The leak is caused because these two functions return
a buffer which the caller is not responsible for freeing. The
functions must convert and create the internal MCStringRef value to
the format requested and the buffer must be freed at some point.
To fix the leak, the converted buffers which are returned are added
to the string release pool used elsewhere in the V0 external API,
and are freed when control returns to the engine from the external
handler.