### PR TITLE
[[ Bug 21931 ]] Fix leak when executing send or call command

### DIFF
--- a/docs/notes/bugfix-21931.md
+++ b/docs/notes/bugfix-21931.md
@@ -1,0 +1,1 @@
+# Fix memory leak when executing send or call commands

--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -1219,7 +1219,7 @@ static void MCEngineSplitScriptIntoMessageAndParameters(MCExecContext& ctxt, MCS
             MCExecValue t_value;
             ctxt . eval_ctxt(ctxt, *t_expression, t_value);
             if (!ctxt.HasError())
-                newparam->set_exec_argument(ctxt, t_value);
+                newparam->give_exec_argument(t_value);
             else
                 newparam->setvalueref_argument(*t_expression);
             


### PR DESCRIPTION
This patch fixes a memory leak when executing a send or a call
command. The leak arose when an expression in the argument list
string successfully evaluated to a value. Rather than give the
resulting (exec) value to the parameter as an argument, it was
being set meaning it ended up being over-retained.