### PR TITLE
[[ Bug 21942 ]] Fix 2038 problem in mobilePickDate

### DIFF
--- a/docs/notes/bugfix-21942.md
+++ b/docs/notes/bugfix-21942.md
@@ -1,0 +1,1 @@
+# mobilePickDate current, start and end dates have max date in 2038

--- a/engine/src/mblandroiddialog.cpp
+++ b/engine/src/mblandroiddialog.cpp
@@ -153,7 +153,7 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     if (s_in_popup_dialog)
         return false;
     
-    int32_t t_current, t_min, t_max;
+    real64_t t_current, t_min, t_max;
     bool t_use_min, t_use_max;
 
     // Avoid to leave t_min/t_max uninitialised, even though showDatePicker
@@ -170,7 +170,7 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     {
         MCAutoValueRef t_val;
 		MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_UNDEFINED, &t_val);
-		/* UNCHECKED */ ctxt.ConvertToInteger(*t_val, t_current);
+		/* UNCHECKED */ ctxt.ConvertToReal(*t_val, t_current);
     }
     else
         t_current = MCS_time();
@@ -179,20 +179,20 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     {
         MCAutoValueRef t_val;
 		MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_UNDEFINED, &t_val);
-        /* UNCHECKED */ ctxt.ConvertToInteger(*t_val, t_min);
+        /* UNCHECKED */ ctxt.ConvertToReal(*t_val, t_min);
     }
     if (t_use_max)
     {
         MCAutoValueRef t_val;
 		MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_UNDEFINED, &t_val);
-        /* UNCHECKED */ ctxt.ConvertToInteger(*t_val, t_max);
+        /* UNCHECKED */ ctxt.ConvertToReal(*t_val, t_max);
     }
 
     s_in_popup_dialog = true;
     s_dialog_result = kMCDialogResultUnknown;
 	// IM-2012-10-31 [[ BZ 10483 ]] - make sure we have the timezone bias for the date
 	MCS_getlocaldatetime(s_selected_date);
-    MCAndroidEngineRemoteCall("showDatePicker", "vbbiii", nil, t_use_min, t_use_max, t_min, t_max, t_current);
+    MCAndroidEngineRemoteCall("showDatePicker", "vbbjjj", nil, t_use_min, t_use_max, t_min, t_max, t_current);
     
     while(s_in_popup_dialog)
 		MCscreen -> wait(60.0, True, True);
@@ -243,7 +243,7 @@ bool MCSystemPickTime(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     else
     {
         MCAutoNumberRef t_time;
-		/* UNCHECKED */ MCNumberCreateWithInteger(MCS_time(), &t_time);
+		/* UNCHECKED */ MCNumberCreateWithReal(MCS_time(), &t_time);
         MCD_convert_to_datetime(ctxt, *t_time, CF_SECONDS, CF_UNDEFINED, t_current);
     }
     

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -103,7 +103,7 @@ UIViewController *MCIPhoneGetViewController(void);
 
 // HC-2011-09-28 [[ Picker Buttons ]] Added arguments to force the display of buttons
 // HC-2011-11-01 [[ BUG 9848 ]] Date Picker does not work with dates before the UNIX epoch. Changed r_current, p_start and p_end from uint to int.
-- (void) startDatePicker:(NSString *)p_style andCurrent: (int32_t)r_current andStart: (int32_t)p_start andEnd: (int32_t)p_end andStep: (uint32_t)p_step andCancel: (bool)p_use_cancel andDone: (bool)p_use_done andButtonRect: (MCRectangle) p_button_rect
+- (void) startDatePicker:(NSString *)p_style andCurrent: (real64_t)p_current andStart: (real64_t)p_start andEnd: (real64_t)p_end andStep: (uint32_t)p_step andCancel: (bool)p_use_cancel andDone: (bool)p_use_done andButtonRect: (MCRectangle) p_button_rect
 {	
 	// set up the wait status
 	m_running = true;
@@ -142,8 +142,8 @@ UIViewController *MCIPhoneGetViewController(void);
 		
 		// set up the current date of the datePicker display
 		// HC-2011-11-01 [[ BUG 9848 ]] Date Picker does not work with dates before the UNIX epoch. Changed if condition to allow for values other than 0.
-        if (r_current != 0)
-            [datePicker setDate:[NSDate dateWithTimeIntervalSince1970:r_current] animated:YES];
+        if (p_current != 0)
+            [datePicker setDate:[NSDate dateWithTimeIntervalSince1970:p_current] animated:YES];
 		
 		// set up the start date of the datePicker display
 		// HC-2011-11-01 [[ BUG 9848 ]] Date Picker does not work with dates before the UNIX epoch. Changed if condition to allow for values other than 0.
@@ -263,8 +263,8 @@ UIViewController *MCIPhoneGetViewController(void);
 		
 		// set up the current date of the datePicker display
 		// HC-2011-11-01 [[ BUG 9848 ]] Date Picker does not work with dates before the UNIX epoch. Changed if condition to allow for values other than 0.
-        if (r_current != 0)
-            [datePicker setDate:[NSDate dateWithTimeIntervalSince1970:r_current] animated:YES];
+        if (p_current != 0)
+            [datePicker setDate:[NSDate dateWithTimeIntervalSince1970:p_current] animated:YES];
 
 		// set up the start date of the datePicker display
 		// HC-2011-11-01 [[ BUG 9848 ]] Date Picker does not work with dates before the UNIX epoch. Changed if condition to allow for values other than 0.
@@ -291,7 +291,7 @@ UIViewController *MCIPhoneGetViewController(void);
 		NSMutableArray *t_toolbar_items;
 		t_toolbar_items = [[NSMutableArray alloc] init];
 		// HC-2011-09-28 [[ Picker Buttons ]] Enable cancel button on request.
-		if (r_current == 0 || p_use_cancel) 
+		if (p_current == 0 || p_use_cancel) 
 			[t_toolbar_items addObject: [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemCancel target: self action: @selector(cancelDatePickWheel:)]];
 		[t_toolbar_items addObject: [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemFlexibleSpace target: self action: nil]];
 		[t_toolbar_items addObject: [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemDone target: self action: @selector(dismissDatePickWheel:)]];
@@ -558,9 +558,9 @@ static com_runrev_livecode_MCIPhonePickDateWheelDelegate *s_pick_date_wheel_dele
 struct datepicker_t
 {
 	NSString *style;
-	int32_t current;
-	int32_t min;
-	int32_t max;
+	real64_t current;
+	real64_t min;
+	real64_t max;
 	int32_t step;
 	bool use_cancel;
 	bool use_done;
@@ -599,21 +599,21 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     t_style = [NSString stringWithCString: "date" encoding: NSMacOSRomanStringEncoding];
     
     // Convert the current datatime to seconds
-    int32_t r_current;
+    real64_t t_current;
     if (p_current == nil)
-        r_current = 0;
+        t_current = 0;
     else
     {
         MCAutoValueRef t_date;
 		if (!MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_SECONDS, &t_date))
             return false;
 		
-		if (!ctxt.ConvertToInteger(*t_date, r_current))
+		if (!ctxt.ConvertToReal(*t_date, t_current))
 			return false;
     }
 
     // Convert the min datatime to seconds
-    int32_t t_min;
+    real64_t t_min;
     if (p_min == nil)
         t_min = 0;
     else
@@ -622,12 +622,12 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
 		if (!MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_SECONDS, &t_min_val))
             return false;
 		
-		if (!ctxt.ConvertToInteger(*t_min_val, t_min))
+		if (!ctxt.ConvertToReal(*t_min_val, t_min))
 			return false;
     }
     
     // Convert the max datatime to seconds
-    int32_t t_max;
+    real64_t t_max;
     if (p_max == nil)
         t_max = 0;
     else
@@ -636,13 +636,13 @@ bool MCSystemPickDate(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
 		if (!MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_SECONDS, &t_max_val))
             return false;
         
-		if (!ctxt.ConvertToInteger(*t_max_val, t_max))
+		if (!ctxt.ConvertToReal(*t_max_val, t_max))
 			return false;
     } 
 
 	datepicker_t date_ctxt;
 	date_ctxt . style = t_style;
-	date_ctxt . current = r_current;
+	date_ctxt . current = t_current;
 	date_ctxt . min = t_min;
 	date_ctxt . max = t_max;
 	date_ctxt . step = 0;
@@ -682,50 +682,50 @@ bool MCSystemPickTime(MCDateTime *p_current, MCDateTime *p_min, MCDateTime *p_ma
     t_style = [NSString stringWithCString: "time" encoding: NSMacOSRomanStringEncoding];
 
     // Convert the current datatime to seconds
-    int32_t r_current;
+    real64_t t_current;
     if (p_current == nil)
-        r_current = 0;
+        t_current = 0;
     else
     {
-        MCAutoValueRef t_current;
-		if (!MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_SECONDS, &t_current))
+        MCAutoValueRef t_date;
+        if (!MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_SECONDS, &t_date))
             return false;
         
-		if (!ctxt.ConvertToInteger(*t_current, r_current))
-			return false;
+        if (!ctxt.ConvertToReal(*t_date, t_current))
+            return false;
     }
     
     // Convert the min datatime to seconds
-    int32_t t_min;
+    real64_t t_min;
     if (p_min == nil)
         t_min = 0;
     else
     {
         MCAutoValueRef t_min_val;
-		if (!MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_SECONDS, &t_min_val))
-			return false;
-		
-		if (!ctxt.ConvertToInteger(*t_min_val, t_min))
-			return false;
+        if (!MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_SECONDS, &t_min_val))
+            return false;
+        
+        if (!ctxt.ConvertToReal(*t_min_val, t_min))
+            return false;
     }
     
     // Convert the max datatime to seconds
-    int32_t t_max;
+    real64_t t_max;
     if (p_max == nil)
         t_max = 0;
     else
     {
         MCAutoValueRef t_max_val;
-		if (!MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_SECONDS, &t_max_val))
-			return false;
-		
-		if (!ctxt.ConvertToInteger(*t_max_val, t_max))
-			return false;
-    } 
+        if (!MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_SECONDS, &t_max_val))
+            return false;
+        
+        if (!ctxt.ConvertToReal(*t_max_val, t_max))
+            return false;
+    }
     
 	datepicker_t date_ctxt;
 	date_ctxt . style = t_style;
-	date_ctxt . current = r_current;
+	date_ctxt . current = t_current;
 	date_ctxt . min = t_min;
 	date_ctxt . max = t_max;
 	date_ctxt . step = p_step;
@@ -765,50 +765,50 @@ bool MCSystemPickDateAndTime(MCDateTime *p_current, MCDateTime *p_min, MCDateTim
     t_style = [NSString stringWithCString: "dateTime" encoding: NSMacOSRomanStringEncoding];
 
     // Convert the current datatime to seconds
-    int32_t r_current;
+    real64_t t_current;
     if (p_current == nil)
-        r_current = 0;
+        t_current = 0;
     else
     {
-        MCAutoValueRef t_current;
-		if (!MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_SECONDS, &t_current))
+        MCAutoValueRef t_date;
+        if (!MCD_convert_from_datetime(ctxt, *p_current, CF_SECONDS, CF_SECONDS, &t_date))
             return false;
         
-		if (!ctxt.ConvertToInteger(*t_current, r_current))
-			return false;
+        if (!ctxt.ConvertToReal(*t_date, t_current))
+            return false;
     }
     
     // Convert the min datatime to seconds
-    int32_t t_min;
+    real64_t t_min;
     if (p_min == nil)
         t_min = 0;
     else
     {
         MCAutoValueRef t_min_val;
-		if (!MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_SECONDS, &t_min_val))
-			return false;
-		
-		if (!ctxt.ConvertToInteger(*t_min_val, t_min))
-			return false;
+        if (!MCD_convert_from_datetime(ctxt, *p_min, CF_SECONDS, CF_SECONDS, &t_min_val))
+            return false;
+        
+        if (!ctxt.ConvertToReal(*t_min_val, t_min))
+            return false;
     }
     
     // Convert the max datatime to seconds
-    int32_t t_max;
+    real64_t t_max;
     if (p_max == nil)
         t_max = 0;
     else
     {
         MCAutoValueRef t_max_val;
-		if (!MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_SECONDS, &t_max_val))
-			return false;
-		
-		if (!ctxt.ConvertToInteger(*t_max_val, t_max))
-			return false;
-    } 
+        if (!MCD_convert_from_datetime(ctxt, *p_max, CF_SECONDS, CF_SECONDS, &t_max_val))
+            return false;
+        
+        if (!ctxt.ConvertToReal(*t_max_val, t_max))
+            return false;
+    }
     
 	datepicker_t date_ctxt;
 	date_ctxt . style = t_style;
-	date_ctxt . current = r_current;
+	date_ctxt . current = t_current;
 	date_ctxt . min = t_min;
 	date_ctxt . max = t_max;
 	date_ctxt . step = p_step;


### PR DESCRIPTION
This patch fixes the 2038 problem for current, start and end date in the
`mobilePickDate` command. The issue was the coversion of dates to signed
32 bit integers. On iOS we can yse doubles directly, while on Android we
can cast as long.

Marked as WIP as I still need to test the patch on iOS and Android