### PR TITLE
[[ Bug 21945 ]] Fix MCWidget::hittest for invisible/disabled widgets

### DIFF
--- a/docs/notes/bugfix-21945.md
+++ b/docs/notes/bugfix-21945.md
@@ -1,0 +1,1 @@
+# Fix touch events being sent to and controlAtLoc returning hidden and disabled widgets

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -327,6 +327,10 @@ Boolean MCWidget::doubleup(uint2 p_which)
 
 MCObject* MCWidget::hittest(int32_t x, int32_t y)
 {
+    if (!(flags & F_VISIBLE || showinvisible()) ||
+        (flags & F_DISABLED && getstack()->gettool(this) == T_BROWSE))
+        return nil;
+    
     if (m_widget != nil)
         return MCwidgeteventmanager->event_hittest(this, x, y);
     return nil;

--- a/tests/lcs/core/interface/controlatloc.livecodescript
+++ b/tests/lcs/core/interface/controlatloc.livecodescript
@@ -1,0 +1,57 @@
+script "CoreControlAtLoc"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+
+on TestControlAtLoc
+	TestSkipIfNot "lcb"
+	
+	create stack "Test"
+	set the defaultStack to "Test"
+	
+	local tControl, tLoc
+	repeat for each item tType in "button,field,scrollbar,image,player,graphic,widget,group"
+		switch tType
+		case "graphic"
+			do format("create %s", tType)
+			set the opaque of it to true
+			set the style of it to "rectangle"
+			break
+		case "group"
+			do format("create %s", tType)
+			set the opaque of it to true
+			set the rect of it to 0,0,100,100
+			break
+		case "widget"
+			TestLoadExtension "com.livecode.widget.clock"
+			create widget "TestWidget" as "com.livecode.widget.clock"
+			break
+		default
+			do format("create %s", tType)
+		end switch
+		put it into tControl
+		TestDiagnostic tControl
+
+		put the loc of tControl into tLoc
+		TestDiagnostic tLoc
+		TestDiagnostic "hit" && controlAtLoc(tLoc)
+		TestAssert format("visible %s controlAtLoc", tType), the long id of controlAtLoc(tLoc) is tControl
+		set the visible of tControl to false
+		TestAssert format("invisible %s controlAtLoc", tType), controlAtLoc(tLoc) is empty
+		delete tControl
+	end repeat
+end TestControlAtLoc


### PR DESCRIPTION
This patch adds the same guard to `MCWidget::hittest` as seen in the `MCControl`
and `MCGroup` implementation where the hit test should return nil if the target
is not visible or the target is disabled and the current tool is browse.

This issue was causing `controlAtLoc` to return hidden widgets on all platforms
and touch events on mobile to be sent to hidden widgets.