### PR TITLE
[Bugfix 20022] Change external link to Apple Event documentation.

### DIFF
--- a/docs/dictionary/command/request-appleEvent.lcdoc
+++ b/docs/dictionary/command/request-appleEvent.lcdoc
@@ -70,9 +70,10 @@ specify which pieces you want to get.
   data. 
 
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/techpubs/mac/IAC/IAC-2.html.
+For more information about Apple events, refer to the section entitled 
+"Apple Events Sent by the Mac OS" in the technical documentation section 
+located on [Apple's website]
+(https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-1117769).
 
 References: send to program (command), handler (glossary),
 Apple Event (glossary), variable (glossary), command (glossary),

--- a/docs/dictionary/message/appleEvent.lcdoc
+++ b/docs/dictionary/message/appleEvent.lcdoc
@@ -47,9 +47,10 @@ or one that you want to handle specially.
 Use the request appleEvent <command> to obtain the data associated with
 an <Apple event>.
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/documentation/mac/IAC/IAC-2.html.
+For more information about Apple events, refer to the section entitled
+"Apple Events Sent by the Mac OS" in the technical documentation 
+located on [Apple's website]
+(https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-1117769)
 
 References: send to program (command), flushEvents (function),
 application (glossary), current card (glossary), Apple Event (glossary),

--- a/docs/notes/bugfix-20022.md
+++ b/docs/notes/bugfix-20022.md
@@ -1,0 +1,1 @@
+# Updated an external link to Apple Event documentation in dictionary entries regarding Apple Events.


### PR DESCRIPTION
Updated an external link to Apple Event documentation in dictionary entries regarding Apple Events.