### PR TITLE
[Bugfix 21936] Clarify that paintings without images will be lost

### DIFF
--- a/docs/dictionary/command/request-appleEvent.lcdoc
+++ b/docs/dictionary/command/request-appleEvent.lcdoc
@@ -70,9 +70,10 @@ specify which pieces you want to get.
   data. 
 
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/techpubs/mac/IAC/IAC-2.html.
+For more information about Apple events, refer to the section entitled 
+"Apple Events Sent by the Mac OS" in the technical documentation section 
+located on [Apple's website]
+(https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-1117769).
 
 References: send to program (command), handler (glossary),
 Apple Event (glossary), variable (glossary), command (glossary),

--- a/docs/dictionary/keyword/brush.lcdoc
+++ b/docs/dictionary/keyword/brush.lcdoc
@@ -26,9 +26,11 @@ This <tool> is used to brush the <brushColor> (or <brushPattern>) onto
 an <image>.
 
 If you try to paint with the brush on a card that has no images, an
-image the size of the card is created to hold the painting. If the
-current card already has one or more images, painting outside the image
-has no effect.
+image the size of the card is temporarily created to hold the painting
+that will disappear after changing card; an image must first be created 
+in order to keep a painting. 
+If the current card already has one or more images, painting outside 
+the image has no effect.
 
 References: choose (command), tool (function), keyword (glossary),
 property (glossary), paint tool (glossary), image (keyword),

--- a/docs/dictionary/keyword/pencil.lcdoc
+++ b/docs/dictionary/keyword/pencil.lcdoc
@@ -24,9 +24,11 @@ windows) or an arrow (anywhere else). This tool is used to draw the
 penColor onto an <image>.
 
 If you try to paint with the pencil on a card that has no images, an
-image the size of the card is created to hold the painting. If the
-current card already has one or more images, painting outside the image
-has no effect.
+image the size of the card is temporarily created to hold the painting
+that will disppear after changing card; an image must first be created 
+in order to keep a painting. 
+If the current card already has one or more images, painting outside the 
+image has no effect.
 
 References: choose (command), keyword (glossary), paint tool (glossary),
 image (keyword), penColor (property)

--- a/docs/dictionary/message/appleEvent.lcdoc
+++ b/docs/dictionary/message/appleEvent.lcdoc
@@ -47,9 +47,10 @@ or one that you want to handle specially.
 Use the request appleEvent <command> to obtain the data associated with
 an <Apple event>.
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/documentation/mac/IAC/IAC-2.html.
+For more information about Apple events, refer to the section entitled
+"Apple Events Sent by the Mac OS" in the technical documentation 
+located on [Apple's website]
+(https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-1117769)
 
 References: send to program (command), flushEvents (function),
 application (glossary), current card (glossary), Apple Event (glossary),

--- a/docs/notes/bugfix-21936.md
+++ b/docs/notes/bugfix-21936.md
@@ -1,0 +1,1 @@
+# Added to documentation on brush and pencil about how paintings made without existing images will not be kept.


### PR DESCRIPTION
Added information to the brush and pencil entries explaining that if a painting is made before an image is created, the image created afterwards to hold the painting isn't kept.