### PR TITLE
[[ Bug 12419 ]] Ensure Android ScrollViews don't cancel touch events

### DIFF
--- a/docs/notes/bugfix-12419.md
+++ b/docs/notes/bugfix-12419.md
@@ -1,0 +1,1 @@
+# Fix touch messages not being sent to controls under an mobile scroller control on Android

--- a/engine/src/java/com/runrev/android/nativecontrol/ScrollerControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ScrollerControl.java
@@ -80,6 +80,12 @@ class ScrollerControl extends NativeControl
                     ScrollerControl.this.updateScroll(m_dispatching ? m_new_left : m_left, t);
                 super.onScrollChanged(l, t, oldl, oldt);
             }
+            
+            @Override
+            public boolean onInterceptTouchEvent (MotionEvent ev)
+            {
+                return true;
+            }
         };
         m_hscroll = new HorizontalScrollView(p_context) {
             @Override
@@ -88,6 +94,12 @@ class ScrollerControl extends NativeControl
                 if (l != oldl)
                     ScrollerControl.this.updateScroll(l, m_dispatching ? m_new_top : m_top);
                 super.onScrollChanged(l, t, oldl, oldt);
+            }
+            
+            @Override
+            public boolean onInterceptTouchEvent (MotionEvent ev)
+            {
+                return true;
             }
         };
         


### PR DESCRIPTION
This patch implements the `onInterceptTouchEvent` method in the vertical and
horizontal scroll views so that they do not cancel the touch events. Without
this patch the cancellation of the touch events causes a touch down to be unpaired
with an up or release event. Not that iOS Scrollers have a `canCancelTouches`
property but android scrollers do not.