### PR TITLE
[[ Bug 21956 ]] Fix memory leak in repeat for each string chunk

### DIFF
--- a/docs/notes/bugfix-21956.md
+++ b/docs/notes/bugfix-21956.md
@@ -1,0 +1,1 @@
+# Fix memory leak in repeat for each chunk when the chunk is of string type

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -560,7 +560,10 @@ void MCKeywordsExecRepeatFor(MCExecContext& ctxt, MCStatement *statements, MCExp
                     done = true;
                 }
                 else
+                {
+                    t_unit.Reset();
                     tci -> CopyString(&t_unit);
+                }
             }
             break;
         }


### PR DESCRIPTION
This patch fixes a memory leak which occurs when using repeat for each
when the chunk is of string type. The leak was caused by failing to
reset an autoclass before doing implicit assignment to it.