### PR TITLE
[Dictionary] export snapshot to go

### DIFF
--- a/docs/dictionary/command/export-snapshot.lcdoc
+++ b/docs/dictionary/command/export-snapshot.lcdoc
@@ -146,8 +146,9 @@ snapshot to specified dimensions, was added in version 6.0.
 References: export (command), import snapshot (command), select (command),
 screenRect (function), PPM (glossary), command (glossary),
 container (glossary), PBM (glossary), alpha channel (glossary),
-file (keyword), image (keyword), cursor (property), rectangle (property),
-windowID (property), object reference (glossary)
+file (keyword), image (keyword), cursor (property), 
+defaultFolder (property), rectangle (property), windowID (property), 
+object reference (glossary)
 
 Tags: file system, multimedia
 

--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -61,9 +61,9 @@ mode (enum):
 -   palette
 -   modal dialog box
 -   modeless dialog box 
--   sheet dialog box - appears in <defaultStack>
--   drawer - appears in <defaultStack>, centered at left side if there's
-    room 
+-   sheet dialog box - appears in <defaultStack (property)>
+-   drawer - appears in <defaultStack (property)>, centered at left 
+    side if there's room 
 
 
 window:

--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -61,8 +61,8 @@ mode (enum):
 -   palette
 -   modal dialog box
 -   modeless dialog box 
--   sheet dialog box - appears in <defaultStack (property)>
--   drawer - appears in <defaultStack (property)>, centered at left 
+-   sheet dialog box - appears in <defaultStack(property)>
+-   drawer - appears in <defaultStack(property)>, centered at left 
     side if there's room 
 
 

--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -57,12 +57,12 @@ command opens the main stack of the specified stack file.
 
 mode (enum):
 
--   editable window: 
--   palette: 
--   modal dialog box: 
--   modeless dialog box: 
--   sheet dialog box: appears in <defaultStack>
--   drawer: appears in <defaultStack>, centered at left side if there's
+-   editable window
+-   palette
+-   modal dialog box
+-   modeless dialog box 
+-   sheet dialog box - appears in <defaultStack>
+-   drawer - appears in <defaultStack>, centered at left side if there's
     room 
 
 

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -46,7 +46,7 @@ Description:
 <targetFolder>, with one file per line.  If no <targetFolder> is
 specified, list the files in the <current folder>.
 
-The list only includes folders at the top level of the <target folder>.
+The list only includes folders at the top level of the <targetFolder>.
 The <folders> <function> does not recursively enter and examine
 folders deeper in the filesystem.  To examine the contents of a
 <subfolder|subfolders>, either pass its path as the <targetFolder>, or

--- a/docs/dictionary/function/fontNames.lcdoc
+++ b/docs/dictionary/function/fontNames.lcdoc
@@ -80,7 +80,7 @@ The fontNames (printer) form was introduced in version 2.0.
 Changes:
 The fontNames () form was introduced to iOS in version 4.5.3.
 
-References: revFontLoad (command), function (control structure),
+References: function (control structure),
 fontStyles (function), font (glossary), return (glossary), line (keyword)
 
 Tags: ui

--- a/docs/dictionary/function/getResources.lcdoc
+++ b/docs/dictionary/function/getResources.lcdoc
@@ -35,29 +35,26 @@ resources of all resource types.
 
 Returns (enum):
 The <getResources> <function> <return|returns> a list of
-<resource|resources>, one per <line>. Each <line> consists of four
-<items> :
+<resource|resources>, one per <line>. Each <line> consists of 
+the following items <items> :
+ - the resource ID
+ - the resource name
+ - the resource size in bytes
+ - the 4-character resource type
+ - one or more resource flag characters. The possible resource flags
+   are as follows:
+     - S       System heap
+     - U       Purgeable
+     - L       Locked
+     - P       Protected
+     - R       Preload
+     - C       Compressed resource
 
-        - the resource ID
-        - the resource name
-        - the resource size in bytes
-
-S       System heap
-U       Purgeable
-L       Locked
-P       Protected
-R       Preload
-C       Compressed resource
 If a flag is set to true, its character is included in the last item. If
 the flag is set to false, its character is not included. If none of
 these flags is set for a resource, the last item of that resource's line
 is empty. If the file does not contain any resources, the <getResources>
 <function> <return|returns> empty
-
--   the 4: character resource type
--   one or more resource flag characters. The possible resource flags
-    are as follows:
-
 
 The result:
 If the <filePath> does not exist, the <result> is set to

--- a/docs/dictionary/keyword/fifth.lcdoc
+++ b/docs/dictionary/keyword/fifth.lcdoc
@@ -20,8 +20,8 @@ Example:
 select fifth line of field "Address Info"
 
 Description:
-Use the <fifth> <keyword> in an <object reference> or <chunk
-expression>. 
+Use the <fifth> <keyword> in an <object reference> or 
+<chunk expression>. 
 
 The <fifth> <keyword> can be used to specify any <object(glossary)>
 whose <number> <property> is 5. It can also be used to designate the

--- a/docs/dictionary/keyword/from.lcdoc
+++ b/docs/dictionary/keyword/from.lcdoc
@@ -30,14 +30,14 @@ Description:
 Use the <from> <keyword> to complete a <command> that requires it.
 
 The <from> <keyword> is used with the <convert>, <drag>, <import>,
-<import snapshot>, <move>, print card, <read from file>, 
+<import snapshot>, <move>, <print|print card>, <read from file>, 
 <read from process>, <read from socket>, <remove>, <remove script>, 
 <request>, and <subtract> <command|commands>.
 
 References: read from file (command), import snapshot (command),
-convert (command), move (command), remove script (command),
-remove (command), request (command), drag (command),
-read from process (command), subtract (command),
+convert (command), move (command), print (command), 
+remove script (command), remove (command), request (command), 
+drag (command), read from process (command), subtract (command),
 read from socket (command), import (command), command (glossary),
 keyword (glossary), to (keyword)
 

--- a/docs/dictionary/property/focusColor.lcdoc
+++ b/docs/dictionary/property/focusColor.lcdoc
@@ -93,7 +93,7 @@ color reference (glossary), insertion point (glossary),
 object type (glossary), EPS (glossary), effective (keyword),
 card (keyword), button (keyword), player (keyword), graphic (keyword),
 scrollbar (keyword), field (keyword), image (keyword), audioClip (object),
-button (object), control (object), stack (object), videoClip (object),
+button (object), stack (object), videoClip (object),
 style (property), owner (property), traversalOn (property),
 showFocusBorder (property), focusColor (property)
 

--- a/docs/dictionary/property/foregroundPattern.lcdoc
+++ b/docs/dictionary/property/foregroundPattern.lcdoc
@@ -46,12 +46,12 @@ text or the pattern that fills an <object(glossary)>.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
-> <height> and <width> must be a power of 2. To be used on <Windows> and
-> <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
-> be used as a fully cross-platform pattern, both an image's dimensions
-> should be one of 8, 16, 32, 64, or 128.
+>*Cross-platform note:*  To be used as a pattern on 
+> <Mac OS|Mac OS systems>, an <image> must be 128x128 <pixels> or less, 
+> and both its <height> and <width> must be a power of 2. To be used on
+> <Windows> and <Unix|Unix systems>, <height> and <width> must be 
+> divisible by 8. To be used as a fully cross-platform pattern, both an 
+> image's dimensions should be one of 8, 16, 32, 64, or 128.
 
 The <foregroundPattern> of <control(object)|controls> is drawn starting
 at the <control(object)|control's> upper right corner: if the

--- a/docs/dictionary/property/fullDragData.lcdoc
+++ b/docs/dictionary/property/fullDragData.lcdoc
@@ -7,7 +7,7 @@ Syntax: set the fullDragData[<key>] to <data>
 Syntax: set the fullDragData to empty
 
 Summary:
-provides access to the contents of the <drag-and-drop clipboard>.
+Provides access to the contents of the <drag-and-drop> <clipboard>.
 
 Introduced: 8.0
 
@@ -64,7 +64,8 @@ will cause the rest to be automatically generated and added.
 If you require lower-level access to the drag-and-drop clipboard, see
 the <rawDragData> <property>.
 
-References: dragData (property), rawDragData (property)
+References: dragData (property), rawDragData (property), 
+clipboard (glossary), drag and drop (glossary)
 
 Tags: ui, drag-and-drop
 

--- a/docs/dictionary/property/fullscreen.lcdoc
+++ b/docs/dictionary/property/fullscreen.lcdoc
@@ -43,7 +43,8 @@ the <stack> is restored to the value it had immediately before the
 
 When a <stack> is full screen, all <decorations> are removed, however
 the <decorations> property still reports the <decorations> that the
-<stack> had prior to being made full screen. The <operty)ions.
+<stack> had prior to being made full screen. The decorations are
+restored when a stack is made non-full screen.
 
 Description:
 Use the <fullscreen> property to change a <stack|stack's> size to make


### PR DESCRIPTION
export snapshot (command) - Added missing reference
fifth (keyword) - Fixed broken link
focusColor (property) - Removed non-existent reference
folders (function) - Fixed typo
fontNames (function) - Removed non-existent reference
foregroundPattern (property) - Fixed broken link
from (keyword) - Added missing reference
fullDragData (property) - Fixed broken links
fullscreen (property) - Recovered text from 7.x entry; have presumed that it was still meant to be there based on what remained of it.
getResources (function) - Rearranged returns details to be legible.
go (command) - Links to defaultStack wouldn’t display; tried several things that *might* work.