### PR TITLE
[[ Documentation ]] Info about setting up Apple ID in Xcode

### DIFF
--- a/docs/development/build-mac.md
+++ b/docs/development/build-mac.md
@@ -1,6 +1,7 @@
 # Compiling LiveCode for Mac OS X and iOS
 
-![LiveCode Community Logo](http://livecode.com/wp-content/uploads/2015/02/livecode-logo.png)
+![LiveCode Community
+Logo](http://livecode.com/wp-content/uploads/2015/02/livecode-logo.png)
 
 Copyright © 2015-2016 LiveCode Ltd., Edinburgh, UK
 
@@ -13,18 +14,22 @@ You must install Xcode.  This will allow you to build LiveCode for:
 * iPhone OS
 * iPhoneSimulator
 
-You will not be able to compile the OS X desktop version of LiveCode
-unless you install some older OS X SDKs; see the next section for details.
+You will not be able to compile the OS X desktop version of LiveCode unless you
+install some older OS X SDKs; see the next section for details.
 
-You will need to setup your Apple ID (aka developer account) in Xcode by going to _Preferences &rarr; Accounts_. without it the code signing step of the build process will fail. 
+You will need to setup your Apple ID (a.k.a. developer account) in Xcode by
+going to _Preferences &rarr; Accounts_. Without it, the code signing step of the
+build process will fail. 
 
 ### Optional dependencies
 
-By default, LiveCode is compiled for a large number of versions of iPhoneSimulator, and requires quite a lot of Apple SDKs to be installed.
+By default, LiveCode is compiled for a large number of versions of
+iPhoneSimulator, and requires quite a lot of Apple SDKs to be installed.
 
 Create a directory on your hard disk (say, `/Applications/Xcode-Dev/`).
 
-Download and install each of the following versions of Xcode, placing their app bundles into the specified paths:
+Download and install each of the following versions of Xcode, placing their app
+bundles into the specified paths:
 
 | Xcode version | App path                                |
 | ------------- | --------------------------------------- |
@@ -36,25 +41,33 @@ Download and install each of the following versions of Xcode, placing their app 
 Notes:
 1. Required for OS X build
 
-Make sure you run and verify each of the versions of Xcode. Download and install any extra SDKs you need using the "Xcode → Preferences → Downloads" window.
+Make sure you run and verify each of the versions of Xcode. Download and install
+any extra SDKs you need using the "Xcode → Preferences → Downloads" window.
 
-Make `/Applications/Xcode-Dev/Xcode.app` a symlink to the latest version of Xcode available.  For example, run:
+Make `/Applications/Xcode-Dev/Xcode.app` a symlink to the latest version of
+Xcode available.  For example, run:
 ```
     cd /Applications/Xcode-Dev
     ln -s Xcode_V_V_V.app Xcode.app
 ```
-Where `Xcode_V_V_V.app` is the latest version of Xcode that you have installed on your machine.
+Where `Xcode_V_V_V.app` is the latest version of Xcode that you have installed
+on your machine.
 
-Before proceeding to the next step, make sure to run Xcode at least once and get to the starting screen. Not doing this might break your Xcode installation and result in an error complaining that it ***could not find the default platform*** 
+Before proceeding to the next step, make sure to run Xcode at least once and get
+to the starting screen. Not doing this might break your Xcode installation and
+result in an error complaining that it ***could not find the default platform***
 
-After checking out the LiveCode git repository, you need to run a tool to finalize the Xcode setup and to make sure all of the necessary SDKs are installed.  If LiveCode is checked out to `~/git/livecode`, run:
+
+After checking out the LiveCode git repository, you need to run a tool to
+finalize the Xcode setup and to make sure all of the necessary SDKs are
+installed.  If LiveCode is checked out to `~/git/livecode`, run:
 ```
     cd /Applications/Xcode-Dev/
     sh ~/git/livecode/tools/setup_xcode_sdks.sh
 ```
-If you want the setup tool to copy the required SDKs out of the Xcode
-app bundles (so that you can safely delete all but the latest Xcode to
-save disk space), you can run:
+If you want the setup tool to copy the required SDKs out of the Xcode app
+bundles (so that you can safely delete all but the latest Xcode to save disk
+space), you can run:
 ```
     sh ~/git/livecode/tools/setup_xcode_sdks.sh --cache
 ```
@@ -62,40 +75,48 @@ save disk space), you can run:
 
 ### Build environment
 
-If you have installed the `Xcode.app` to a non-standard location, or you wish to switch between multiple versions of Xcode, you will need to set the `XCODEBUILD` environment variable.  For example:
+If you have installed the `Xcode.app` to a non-standard location, or you wish to
+switch between multiple versions of Xcode, you will need to set the `XCODEBUILD`
+environment variable.  For example:
 
-    export XCODEBUILD=/Applications/Xcode-Dev/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+`export XCODEBUILD=/Applications/Xcode-Dev/Xcode.app/Contents/Developer/usr/bin/xcodebuild`
 
 ### Generating Xcode project files
 
 To generate Xcode project files for OS X desktop builds, run:
 
-    make config-mac
+`$ make config-mac` 
 
-This will generate project files in the `build-mac` directory.  You can open and use these in Xcode.
+This will generate project files in the `build-mac` directory.  You can open and
+use these in Xcode.
 
 To generate Xcode project files for iOS, run:
 
-    make config-ios
+`$ make config-ios`
 
-This will generate several build directories with Xcode project files: one for each version of iPhoneOS or iPhoneSimulator.
+This will generate several build directories with Xcode project files: one for
+each version of iPhoneOS or iPhoneSimulator.
 
-If you want to just build for the newest supported version of the iPhoneOS SDK, you can simply run:
+If you want to just build for the newest supported version of the iPhoneOS SDK,
+you can simply run:
 
-    make config-ios-iphoneos
+`$ make config-ios-iphoneos`
 
-To provide detailed configuration options, you can use the `config.sh` script.  For more information, run:
+To provide detailed configuration options, you can use the `config.sh` script.
+For more information, run:
 
-    ./config.sh --help
+`$ ./config.sh --help`
 
 ## Compiling LiveCode
 
-You can open the generated project files in Xcode and compile from there using the normal Xcode build procedure.
+You can open the generated project files in Xcode and compile from there using
+the normal Xcode build procedure.
 
 You can also compile the engine from the command line using make, for example:
 
-    make compile-mac
+`$ make compile-mac`
 
-The same applies for the iPhoneOS and iPhoneSimulator builds.  For example, you can compile for the newest supported version of the iPhoneSimulator SDK using:
+The same applies for the iPhoneOS and iPhoneSimulator builds.  For example, you
+can compile for the newest supported version of the iPhoneSimulator SDK using:
 
-    make compile-ios-iphonesimulator
+`$ make compile-ios-iphonesimulator`

--- a/docs/development/build-mac.md
+++ b/docs/development/build-mac.md
@@ -16,6 +16,8 @@ You must install Xcode.  This will allow you to build LiveCode for:
 You will not be able to compile the OS X desktop version of LiveCode
 unless you install some older OS X SDKs; see the next section for details.
 
+You will need to setup your Apple ID (aka developer account) in Xcode by going to _Preferences &rarr; Accounts_. without it the code signing step of the build process will fail. 
+
 ### Optional dependencies
 
 By default, LiveCode is compiled for a large number of versions of iPhoneSimulator, and requires quite a lot of Apple SDKs to be installed.


### PR DESCRIPTION
Added a paragraph to the _Required dependencies_ section of the documentation outlining the need to setup an account in Xcode before building mac/iOS.