### PR TITLE
[Dictionary] grab to hilitePattern

### DIFF
--- a/docs/dictionary/command/grab.lcdoc
+++ b/docs/dictionary/command/grab.lcdoc
@@ -32,9 +32,9 @@ Use the <grab> <command> within a <mouseDown> <handler> to drag an
 it. 
 
 You can only grab a control when the mouse pointer is within the
-control's rectangle at the time the mouse is clicked. If the <mouse
-pointer> is outside the <control> when the <grab> <command> is
-<execute|executed>, nothing happens.
+control's rectangle at the time the mouse is clicked. If the 
+<mouse pointer> is outside the <control> when the <grab> <command> 
+is <execute|executed>, nothing happens.
 
 Although the <grab> <command> returns to the calling handler
 immediately, the target control will remain grabbed until the user

--- a/docs/dictionary/command/hide.lcdoc
+++ b/docs/dictionary/command/hide.lcdoc
@@ -73,7 +73,8 @@ References: disable (command), answer effect (command), show (command),
 hide menubar (command), visual effect (command), object (glossary), 
 command (glossary), property (glossary), black (keyword), stack (object), 
 showPict (property), imageSource (property), visible (property), 
-showInvisibles (property)
+showInvisibles (property), dontUseQT (property), 
+dontUseQTEffects (property)
 
 Tags: ui
 

--- a/docs/dictionary/constant/hand.lcdoc
+++ b/docs/dictionary/constant/hand.lcdoc
@@ -24,8 +24,9 @@ Use the <hand> constant to set the cursor to a pointing hand shape.
 
 The following two statements are equivalent:
 
-set the cursor to hand
-set the cursor to 8
+    set the cursor to hand
+    
+    set the cursor to 28
 
 However, the first is easier to read and understand in LiveCode.
 

--- a/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
+++ b/docs/dictionary/keyword/gRevProfileReadOnly.lcdoc
@@ -24,8 +24,8 @@ if gRevProfileReadOnly is false then switchToLargeFonts
 Description:
 Set the <gRevProfileReadOnly> <variable> to false when configuring a
 <property profile|profile>, so that changes you make to an
-<object|object's> <properties> are saved in the current <property
-profile|profile>. 
+<object|object's> <properties> are saved in the current 
+<property profile|profile>. 
 
 Each object can have one or more profiles, which include settings for
 each property in the object's properties <property>. The

--- a/docs/dictionary/object/group.lcdoc
+++ b/docs/dictionary/object/group.lcdoc
@@ -42,7 +42,7 @@ lowest-layered group on the current card.
 References: property (glossary), radio button (glossary),
 menu bar (glossary), object type (glossary), card (keyword),
 control (glossary), templateGroup (keyword), scrollbar (object),
-control (object), showName (property)
+showName (property)
 
 Tags: objects
 

--- a/docs/dictionary/property/HCAddressing.lcdoc
+++ b/docs/dictionary/property/HCAddressing.lcdoc
@@ -32,9 +32,9 @@ When you open a HyperCard stack and convert it to a LiveCode stack, the
 new stack's <HCAddressing> <property> is set to true.
 
 If the <HCAddressing> <property> is set to true,
-<expression|expressions> in the <stack's> <script|scripts> that refer to
-<field|fields> without specifying <card> or <background> are assumed to
-refer to <grouped control|grouped controls>, and
+<expression|expressions> in the <stack|stack's> <script|scripts> that 
+refer to <field|fields> without specifying <card> or <background> are 
+assumed to refer to <grouped control|grouped controls>, and
 <expression|expressions> that refer to other control types are assumed
 to refer to <card control|card controls>. For example, the number of
 fields reports the number of grouped fields, while button 5 refers to

--- a/docs/dictionary/property/hidden.lcdoc
+++ b/docs/dictionary/property/hidden.lcdoc
@@ -41,14 +41,14 @@ unchanged however, allowing for the normal data parsing.
 For example, take the following content of text in a field and their
 associated <hidden> property settings:
 
-This is the text of line 1 -- hidden property 'false'
-This is the text of line 2 -- hidden property 'true'
-This is the text of line 3 -- hidden property 'false'
+    This is the text of line 1 -- hidden property 'false'
+    This is the text of line 2 -- hidden property 'true'
+    This is the text of line 3 -- hidden property 'false'
 
 The user sees the following:
 
-This is the text of line 1
-This is the text of line 3
+    This is the text of line 1
+    This is the text of line 3
 
 Executing 'put line 2 of field' results in 'This is the text of line 2'.
 

--- a/docs/dictionary/property/hilite.lcdoc
+++ b/docs/dictionary/property/hilite.lcdoc
@@ -51,13 +51,13 @@ the <hilitePattern>, if the <button(object)|button's> <hiliteFill>
 <property> is true).
 
 References: hilite (command), property (glossary),
-hiliteBorder (glossary), highlight (glossary), topPattern (glossary),
-style (glossary), threeD (glossary), checkbox (glossary),
-hilitePattern (glossary), hiliteFill (glossary), topColor (glossary),
-radio button (glossary), bottomColor (glossary), button (keyword),
-button (object), showHilite (property), hilitedIcon (property),
-hiliteFill (property), hilitedButtonName (property),
-hiliteColor (property), hiliteBorder (property), bottomPattern (property)
+highlight (glossary), checkbox (glossary),
+hilitePattern (glossary), radio button (glossary), button (keyword),
+button (object), bottomColor (property), showHilite (property), 
+hiliteBorder (property), hilitedIcon (property), hiliteFill (property), 
+hilitedButtonName (property), hiliteColor (property), 
+hiliteBorder (property), bottomPattern (property), style (property), 
+threeD (property), topColor (property), topPattern (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/hiliteBorder.lcdoc
+++ b/docs/dictionary/property/hiliteBorder.lcdoc
@@ -37,19 +37,19 @@ and left edges (reversing the normal effect), when the <button(keyword)>
 is <highlight|highlighted>.
 
 If the <lookAndFeel> <property> is "Macintosh", the <hiliteBorder>
-<property> has no effect on <button(keyword)> styles other than <radio
-button|radio buttons> and <checkbox|checkboxes>.
+<property> has no effect on <button(keyword)> styles other than 
+<radio button|radio buttons> and <checkbox|checkboxes>.
 
 If the button's <threeD> <property> is false, the <hiliteBorder>
 <property> has no effect.
 
 References: hilite (command), property (glossary), highlight (glossary),
-style (glossary), topColor (glossary), appearance (glossary),
+appearance (glossary),
 checkbox (glossary), radio button (glossary), effective (keyword),
 button (keyword), button (object), hilite (property),
 topPattern (property), bottomColor (property), topColor (property),
 armed (property), bottomPattern (property), lookAndFeel (property),
-threeD (property)
+threeD (property), topColor (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/hiliteColor.lcdoc
+++ b/docs/dictionary/property/hiliteColor.lcdoc
@@ -119,18 +119,19 @@ object's hiliteColor was empty, the setting of the global hiliteColor
 property was used instead.
 
 References: global (command), group (command), object (glossary),
-selection (glossary), backgroundPattern (glossary), property (glossary),
-select (glossary), tabbed button (glossary), highlight (glossary),
-menuMode (glossary), backgroundColor (glossary), object type (glossary),
-style (glossary), color reference (glossary), integer (glossary),
-color palette (glossary), button menu (glossary), keyword (glossary),
-hexadecimal (glossary), EPS (glossary), owner (glossary),
-lookAndFeel (glossary), markerDrawn (glossary), effective (keyword),
+selection (glossary), property (glossary), select (glossary), 
+tabbed button (glossary), highlight (glossary), object type (glossary), 
+color reference (glossary), integer (glossary), color palette (glossary), 
+button menu (glossary), keyword (glossary), hexadecimal (glossary), 
+EPS (glossary), owner (glossary), effective (keyword),
 field (keyword), button (keyword), menu (keyword), card (keyword),
 player (keyword), scrollbar (keyword), graphic (keyword), image (keyword),
 button (object), image (object), field (object), stack (object),
 graphic (object), hiliteFill (property), topColor (property),
-armFill (property), markerLineSize (property)
+armFill (property), markerLineSize (property), 
+backgroundPattern (property), menuMode (property), 
+backgroundColor (property), style (property), lookAndFeel (property),
+markerDrawn (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/hiliteFill.lcdoc
+++ b/docs/dictionary/property/hiliteFill.lcdoc
@@ -35,9 +35,8 @@ The <hiliteFill> <property> affects only the background of a
 change. 
 
 References: property (glossary), highlight (glossary),
-hilitePattern (glossary), hiliteColor (glossary), button (keyword),
-button (object), hilitePattern (property), hilite (property),
-hiliteColor (property)
+button (keyword), button (object), hilitePattern (property), 
+hilite (property), hiliteColor (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/hilitePattern.lcdoc
+++ b/docs/dictionary/property/hilitePattern.lcdoc
@@ -108,16 +108,15 @@ the color specified by <hiliteColor>.
 References: global (command), group (command), stacks (function),
 object (glossary), owner (glossary), current stack (glossary),
 tabbed button (glossary), property (glossary), highlight (glossary),
-width (glossary), button menu (glossary), Windows (glossary),
-height (glossary), backgroundPattern (glossary), lookAndFeel (glossary),
-menuMode (glossary), backgroundColor (glossary), select (glossary),
+button menu (glossary), Windows (glossary), select (glossary),
 Mac OS (glossary), Unix (glossary), object type (glossary),
 selection (glossary), EPS (glossary), field (keyword), image (keyword),
 button (keyword), menu (keyword), card (keyword), graphic (keyword),
 scrollbar (keyword), control (keyword), player (keyword), button (object),
-stack (object), control (object), bottomPattern (property),
+stack (object), bottomPattern (property),
 hiliteFill (property), pixels (property), hiliteColor (property),
-markerLineSize (property)
+markerLineSize (property), height (property), backgroundPattern (property),
+lookAndFeel (property), menuMode (property), backgroundColor (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/hilitedButtonName.lcdoc
+++ b/docs/dictionary/property/hilitedButtonName.lcdoc
@@ -49,8 +49,8 @@ ways to the same <button(object)>. When any of them changes, all of them
 change. 
 
 References: hilite (command), group (command), property (glossary),
-highlight (glossary), hilitedButtonID (glossary), radio button (glossary),
-radioBehavior (glossary), button (keyword), button (object),
+highlight (glossary), radio button (glossary),
+button (keyword), button (object),
 family (property), hilite (property), hilitedButtonID (property),
 name (property), hilitedButton (property), autoHilite (property),
 radioBehavior (property)

--- a/docs/dictionary/property/hilitedLine.lcdoc
+++ b/docs/dictionary/property/hilitedLine.lcdoc
@@ -46,7 +46,7 @@ integer (glossary), list field (glossary), chunk expression (glossary),
 field (keyword), line (keyword), lines (keyword), selected (property),
 listBehavior (property), toggleHilites (property),
 threeDHilite (property), noncontiguousHilites (property),
-multipleLines (property)
+multipleHilites (property)
 
 Tags: ui
 


### PR DESCRIPTION
grab (command): Fixed broken link.
gRevProfileOnly (keyword): Fixed broken link.
group (object): Removed non-existent reference
hand (constant): Fixed equivalent code examples to display as code and to be equivalent.
HCAddressing (property): Fixed broken link.
hidden (property): Formatted example for clarity.
hide (command): Added missing references.
hilite (property): Corrected multiple reference types.
hiliteBorder (property): Fixed broken link. Corrected reference types.
hiliteColor (property): Corrected multiple reference types.
hilitedButtonName (property): Removed non-existent entries.
hilitedLine (property): Changed reference due to synonym issues.
hiliteFill (property): Removed non-existent entry.
hilitePattern (property): Changed types of multiple references, deleted others.