### PR TITLE
[[ Bug 21958 ]] Fix buffer overrun when initializing MCrandomseed

### DIFF
--- a/docs/notes/bugfix-21958.md
+++ b/docs/notes/bugfix-21958.md
@@ -1,0 +1,1 @@
+# Fix non-effective buffer overrun on initial seeding of pseudo-random number generator

--- a/engine/src/mcssl.cpp
+++ b/engine/src/mcssl.cpp
@@ -108,7 +108,9 @@ Boolean InitSSLCrypt()
 #ifdef MCSSL
         OPENSSL_init_ssl(0, NULL);
         
-		RAND_seed(&MCrandomseed,I4L);
+        uint32_t t_randomseed_bytes[4];
+		RAND_seed(t_randomseed_bytes, sizeof(t_randomseed_bytes));
+        MCrandomseed = t_randomseed_bytes[0];
 		cryptinited = True;
 		
 		s_ssl_system_root_certs = nil;


### PR DESCRIPTION
This patch fixes a buffer overrun (into other internal global variables)
when seeding the pseudo-random number generator (MCrandomseed) using
SSL. The overrun occurs because the RAND_bytes SSL function has an
undocumented minimum byte generation length of 16 due to using an
SHA1 hash on the source data.