### PR TITLE
[[ Bug 21928 ]] Fix memory leak when using menu buttons

### DIFF
--- a/docs/notes/bugfix-21928.md
+++ b/docs/notes/bugfix-21928.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using menu buttons

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -2860,11 +2860,19 @@ void MCButton::freemenu(Boolean force)
 		else
 		{
 			if (!MCStringIsEmpty(menustring) || force)
-			{
-				closemenu(False, True);
+            {
+                closemenu(False, True);
+                
+                /* In this case the button owns the menu so after removing
+                 * any references to it that might exist in the environment
+                 * it must be explicitly deleted. */
 				MCdispatcher->removepanel(menu);
 				MCstacks->deleteaccelerator(this, NULL);
 				menu->removeneed(this);
+                
+                /* Schedule deletion of the menu stack. */
+                menu->scheduledelete();
+                
 				menu = nil;
 			}
 		}

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -613,6 +613,7 @@ MCStack::~MCStack()
 		MCstaticdefaultstackptr = MCtopstackptr;
 	if (MCdefaultstackptr.IsBoundTo(this))
 		MCdefaultstackptr = MCstaticdefaultstackptr;
+    delete[] needs; /* Allocated with new[] */
 	if (stackfiles != NULL)
 	{
 		while (nstackfiles--)


### PR DESCRIPTION
This patch fixes a memory leak when using menu buttons caused by
failing to delete the internal stack created to enable them to
function. The leak came about when object deletion was being
abstracted, and the code was being refactored to use object handles.
The button's menu pointer was changed to an object handle and
the explicit deletion which was there previously removed. As
object handles are weak references, this meant that they were
never being deleted.

The leak has been fixed by ensuring that scheduledelete() is
called on the button menu stack after it has been removed from
the (menu related) environment in MCButton::freemenu. Additionally
deletion of the MCStack 'needs' member has been added to the
MCStack destructor.