### PR TITLE
[[ Bug 21959 ]] Fix memory leak when using clipboard functions

### DIFF
--- a/docs/notes/bugfix-21959.md
+++ b/docs/notes/bugfix-21959.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using clipboard functionality

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -883,7 +883,8 @@ bool MCClipboard::CopyAsFileList(MCStringRef& r_file_list) const
             
             // Get the data for this representation and decode it
             MCAutoStringRef t_url;
-            MCAutoDataRef t_encoded_url(t_rep->CopyData());
+            MCAutoDataRef t_encoded_url;
+            t_encoded_url.Give(t_rep->CopyData());
 			if (*t_encoded_url == NULL)
 				return false;
             t_url.Reset(m_clipboard->DecodeTransferredFileList(*t_encoded_url));
@@ -912,7 +913,8 @@ bool MCClipboard::CopyAsFileList(MCStringRef& r_file_list) const
             return false;
         
 		// Decode the list of files
-        MCAutoDataRef t_data(t_rep->CopyData());
+        MCAutoDataRef t_data;
+        t_data.Give(t_rep->CopyData());
 		if (*t_data == NULL)
 			return false;
 		t_output = m_clipboard->DecodeTransferredFileList(*t_data);
@@ -1197,7 +1199,8 @@ int MCClipboard::GetLegacyOrdering() const
         const MCRawClipboardItemRep* t_rep = t_item->FetchRepresentationAtIndex(i);
         
         // Is this an image representation?
-        MCAutoStringRef t_type(t_rep->CopyTypeString());
+        MCAutoStringRef t_type;
+        t_type.Give(t_rep->CopyTypeString());
         if (MCTypeMatches(*t_type, m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypePNG))
             || MCTypeMatches(*t_type, m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeGIF))
             || MCTypeMatches(*t_type, m_clipboard->GetKnownTypeString(kMCRawClipboardKnownTypeJPEG)))
@@ -1485,7 +1488,8 @@ bool MCClipboard::CopyAsEncodedText(const MCRawClipboardItem* p_item, MCRawClipb
         return false;
     
     // Get the data for this representation and decode it
-    MCAutoDataRef t_encoded(t_rep->CopyData());
+    MCAutoDataRef t_encoded;
+    t_encoded.Give(t_rep->CopyData());
 
 	// IM-2016-11-21: [[ Bug 18652 ]] Check for null return from CopyData()
 	if (!t_encoded.IsSet())

--- a/engine/src/exec-pasteboard.cpp
+++ b/engine/src/exec-pasteboard.cpp
@@ -568,7 +568,13 @@ void MCPasteboardEvalRawClipboardOrDragKeys(MCExecContext& ctxt, const MCClipboa
 	uindex_t t_type_count = t_item->GetRepresentationCount();
 	for (uindex_t i = 0; t_success && i < t_type_count; i++)
 	{
-		MCAutoStringRef t_type(t_item->FetchRepresentationAtIndex(i)->CopyTypeString());
+        MCAutoStringRef t_type;
+        t_type.Give(t_item->FetchRepresentationAtIndex(i)->CopyTypeString());
+        if (!t_type.IsSet())
+        {
+            continue;
+        }
+        
 		t_success = MCListAppend(*t_list, *t_type);
 	}
 	

--- a/engine/src/lnx-clipboard.cpp
+++ b/engine/src/lnx-clipboard.cpp
@@ -481,7 +481,8 @@ MCDataRef MCLinuxRawClipboard::CopyTargets() const
         
         // Add it to the data. Note that GDK expects 32-bit atoms to be in the
         // form of gulong, even when sizeof(gulong) > sizeof(uint32_t).
-        MCAutoStringRef t_type(t_rep->CopyTypeString());
+        MCAutoStringRef t_type;
+        t_type.Give(t_rep->CopyTypeString());
         gulong t_atom = gulong(CopyAtomForType(*t_type));
         MCDataAppendBytes(*t_data, (const byte_t*)&t_atom, sizeof(t_atom));
     }
@@ -626,8 +627,10 @@ bool MCLinuxRawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
     MCLinuxRawClipboardItemRep* t_rep = NULL;
     for (uindex_t i = 0; i < GetRepresentationCount(); i++)
     {
-        MCAutoStringRef t_type(m_reps[i]->CopyTypeString());
-        if (MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareExact))
+        MCAutoStringRef t_type;
+        t_type.Give(m_reps[i]->CopyTypeString());
+        if (t_type.IsSet() &&
+            MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareExact))
         {
             // This is the rep we're looking for. Updates it.
             t_rep = m_reps[i];

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -409,8 +409,10 @@ bool MCMacRawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_by
         if (!FetchRepresentationAtIndex(i))
             return false;
         
-        MCAutoStringRef t_type(m_rep_cache[i]->CopyTypeString());
-        if (MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareExact))
+        MCAutoStringRef t_type;
+        t_type.Give(m_rep_cache[i]->CopyTypeString());
+        if (t_type.IsSet() &&
+            MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareExact))
         {
             // This is the rep we're looking for
             t_rep = m_rep_cache[i];
@@ -629,7 +631,8 @@ MCDataRef MCMacRawClipboardItemRep::CopyData() const
     else if ([m_item isKindOfClass:[NSPasteboardItem class]])
     {
         // Get the type string for this representation (as lookup is by type)
-        MCAutoStringRef t_type_string(CopyTypeString());
+        MCAutoStringRef t_type_string;
+        t_type_string.Give(CopyTypeString());
         if (*t_type_string == NULL)
             return NULL;
         

--- a/engine/src/raw-clipboard.cpp
+++ b/engine/src/raw-clipboard.cpp
@@ -40,8 +40,10 @@ bool MCRawClipboardItem::HasRepresentation(MCStringRef p_type) const
     // Loop over the representations of this item and test each one
     for (uindex_t i = 0; i < GetRepresentationCount(); i++)
     {
-        MCAutoStringRef t_type(FetchRepresentationAtIndex(i)->CopyTypeString());
-        if (MCStringIsEqualTo(p_type, *t_type, kMCStringOptionCompareExact))
+        MCAutoStringRef t_type;
+        t_type.Give(FetchRepresentationAtIndex(i)->CopyTypeString());
+        if (t_type.IsSet() &&
+            MCStringIsEqualTo(p_type, *t_type, kMCStringOptionCompareExact))
             return true;
     }
     
@@ -57,8 +59,10 @@ const MCRawClipboardItemRep* MCRawClipboardItem::FetchRepresentationByType(MCStr
     // Loop over the representations of this item and test each one
     for (uindex_t i = 0; i < GetRepresentationCount(); i++)
     {
-        MCAutoStringRef t_type(FetchRepresentationAtIndex(i)->CopyTypeString());
-        if (MCStringIsEqualTo(p_type, *t_type, kMCStringOptionCompareExact))
+        MCAutoStringRef t_type;
+        t_type.Give(FetchRepresentationAtIndex(i)->CopyTypeString());
+        if (t_type.IsSet() &&
+            MCStringIsEqualTo(p_type, *t_type, kMCStringOptionCompareExact))
             return FetchRepresentationAtIndex(i);
     }
     

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -854,8 +854,10 @@ bool MCWin32RawClipboardItem::AddRepresentation(MCStringRef p_type, MCDataRef p_
 	MCWin32RawClipboardItemRep* t_rep = NULL;
 	for (uindex_t i = 0; i < GetRepresentationCount(); i++)
 	{
-		MCAutoStringRef t_type(m_reps[i]->CopyTypeString());
-		if (MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareCaseless))
+        MCAutoStringRef t_type;
+        t_type.Give(m_reps[i]->CopyTypeString());
+		if (t_type.IsSet() &&
+            MCStringIsEqualTo(*t_type, p_type, kMCStringOptionCompareCaseless))
 		{
 			// This is the rep we're looking for. Update it.
 			t_rep = m_reps[i];


### PR DESCRIPTION
This patch corrects memory leaks in the clipboard functions where
they result in calling CopyData() or CopyTypeString(). Due to the
signatures of the methods being non-standard (i.e. returning a
+1 retain count rather than the standard bool return value and
out argument pattern) there are several places where the return
value has been passed to an auto class constructor. As the latter
retain their argument, this causes an over-retain.

The problem has been fixed by ensuring the return values of the
relevant methods are given to the autoclass using Give() rather
than passing to the constructor.