### PR TITLE
[[ Bug 21960 ]] Ensure private handler lookups are cached

### DIFF
--- a/docs/notes/bugfix-21960.md
+++ b/docs/notes/bugfix-21960.md
@@ -1,0 +1,1 @@
+# Ensure private handler lookups are always cached

--- a/engine/src/exec-keywords.cpp
+++ b/engine/src/exec-keywords.cpp
@@ -105,38 +105,40 @@ static Exec_stat MCKeywordsExecuteStatements(MCExecContext& ctxt, MCStatement *p
     return stat;
 }
 
-void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandler *handler, MCParameter *params, MCNameRef name, uint2 line, uint2 pos, bool global_handler, bool is_function)
+void MCKeywordsExecResolveCommandOrFunction(MCExecContext& ctxt, MCNameRef p_name, bool is_function, MCHandler*& r_handler)
+{
+    // MW-2008-01-28: [[ Inherited parentScripts ]]
+    // If we are in parentScript context, then the object we search for
+    // private handlers in is the parentScript's object, rather than the
+    // ep's.
+    MCParentScriptUse *t_parentscript;
+    t_parentscript = ctxt . GetParentScript();
+    
+    MCObject *t_object;
+    if (t_parentscript == NULL)
+        t_object = ctxt . GetObject();
+    else
+        t_object = t_parentscript -> GetParent() -> GetObject();
+    
+    // MW-2008-10-28: [[ ParentScripts ]] Private handlers are resolved
+    //   relative to the object containing the handler we are executing.
+    MCHandler *t_resolved_handler;
+    t_resolved_handler = t_object -> findhandler(is_function ? HT_FUNCTION : HT_MESSAGE, p_name);
+    if (t_resolved_handler == NULL ||
+        !t_resolved_handler -> isprivate())
+    {
+        t_resolved_handler = nullptr;
+    }
+    r_handler = t_resolved_handler;
+}
+
+void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, MCHandler *handler, MCParameter *params, MCNameRef name, uint2 line, uint2 pos, bool global_handler, bool is_function)
 {    
 	if (MCscreen->abortkey())
 	{
 		ctxt . LegacyThrow(EE_HANDLER_ABORT);
 		return;
 	}
-    
-	if (!resolved)
-	{
-		// MW-2008-01-28: [[ Inherited parentScripts ]]
-		// If we are in parentScript context, then the object we search for
-		// private handlers in is the parentScript's object, rather than the
-		// ep's.
-		MCParentScriptUse *t_parentscript;
-		t_parentscript = ctxt . GetParentScript();
-        
-		MCObject *t_object;
-		if (t_parentscript == NULL)
-			t_object = ctxt . GetObject();
-        else
-            t_object = t_parentscript -> GetParent() -> GetObject();
-        
-        // MW-2008-10-28: [[ ParentScripts ]] Private handlers are resolved
-        //   relative to the object containing the handler we are executing.
-        MCHandler *t_resolved_handler;
-		t_resolved_handler = t_object -> findhandler(is_function ? HT_FUNCTION : HT_MESSAGE, name);
-		if (t_resolved_handler != NULL && t_resolved_handler -> isprivate())
-			handler = t_resolved_handler;
-        
-        resolved = true;
-    }
 	
     if (is_function)
         MCexitall = False;
@@ -156,7 +158,6 @@ void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandl
         {
             tptr -> clear_argument();
             MCExecValue t_value;
-            //HERE
             if (!ctxt . TryToEvaluateParameter(tptr, line, pos, is_function ? EE_FUNCTION_BADSOURCE : EE_STATEMENT_BADPARAM, t_value))
                 return;
             tptr->give_exec_argument(t_value);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -1801,7 +1801,8 @@ void MCKeywordsExecNext(MCExecContext& ctxt);
 void MCKeywordsExecPass(MCExecContext& ctxt);
 void MCKeywordsExecPassAll(MCExecContext& ctxt);
 void MCKeywordsExecThrow(MCExecContext& ctxt, MCStringRef string);
-void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, bool resolved, MCHandler *handler, MCParameter *params, MCNameRef name, uint2 line, uint2 pos, bool platform_message, bool is_function);
+void MCKeywordsExecResolveCommandOrFunction(MCExecContext& ctxt, MCNameRef p_name, bool is_function, MCHandler*& r_handler);
+void MCKeywordsExecCommandOrFunction(MCExecContext& ctxt, MCHandler *handler, MCParameter *params, MCNameRef name, uint2 line, uint2 pos, bool platform_message, bool is_function);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/express.cpp
+++ b/engine/src/express.cpp
@@ -480,7 +480,13 @@ Parse_stat MCFuncref::parse(MCScriptPoint &sp, Boolean the)
 
 void MCFuncref::eval_ctxt(MCExecContext& ctxt, MCExecValue& r_value)
 {
-    MCKeywordsExecCommandOrFunction(ctxt, resolved, handler, params, *name, line, pos, global_handler, true);
+    if (!resolved)
+    {
+        MCKeywordsExecResolveCommandOrFunction(ctxt, *name, true, handler);
+        resolved = true;
+    }
+    
+    MCKeywordsExecCommandOrFunction(ctxt, handler, params, *name, line, pos, global_handler, true);
     
     Exec_stat stat = ctxt . GetExecStat();
     

--- a/engine/src/statemnt.cpp
+++ b/engine/src/statemnt.cpp
@@ -373,7 +373,13 @@ Parse_stat MCComref::parse(MCScriptPoint &sp)
 
 void MCComref::exec_ctxt(MCExecContext& ctxt)
 {
-    MCKeywordsExecCommandOrFunction(ctxt, resolved, handler, params, name, line, pos, global_handler, false);
+    if (!resolved)
+    {
+        MCKeywordsExecResolveCommandOrFunction(ctxt, name, false, handler);
+        resolved = true;
+    }
+    
+    MCKeywordsExecCommandOrFunction(ctxt, handler, params, name, line, pos, global_handler, false);
     
     if (MCresultmode == kMCExecResultModeReturn)
     {


### PR DESCRIPTION
This patch ensures that private handler calls only lookup the handler
the first time their MCComref or MCFuncref syntax node is executed.

To achieve this the handler lookup code has been moved from
MCKeywordsExecCommandOrFunction to MCKeywordsResolveCommandOrFunction.
The latter is now called directly from the MCComref or MCFuncref
execution methods as the cache is present in those nodes.