### PR TITLE
[Dictionary] hotspotClicked to keyword

### DIFF
--- a/docs/dictionary/command/import.lcdoc
+++ b/docs/dictionary/command/import.lcdoc
@@ -87,6 +87,7 @@ XPM (glossary), PGM (glossary), XWD (glossary), audio clip (glossary),
 PPM (glossary), XBM (glossary), PNG (glossary), stack file (glossary),
 Windows (glossary), AVI (glossary), file (keyword), image (keyword),
 paint (keyword), EPS (object), stack (object), defaultStack (property),
+dontUseQT (property), dontUseQTEffects (property),
 filename (property), JPEGQuality (property),
 paintCompression (property)
 

--- a/docs/dictionary/command/iphoneSetAudioCategory.lcdoc
+++ b/docs/dictionary/command/iphoneSetAudioCategory.lcdoc
@@ -21,7 +21,7 @@ iphoneSetAudioCategory "play and record"
 
 Parameters:
 category (enum):
-The audio category to use. One of:
+The audio category to use.
 
 -   "ambient": Audio from other applications can mix into the sound of
     the running application. Audio is silenced by locking the screen or

--- a/docs/dictionary/command/iphoneSetRedrawInterval.lcdoc
+++ b/docs/dictionary/command/iphoneSetRedrawInterval.lcdoc
@@ -57,7 +57,7 @@ elements. For example, scrollers, dragging and the move command all
 independently request redraws causing a build up which can lead to
 'judders' and other unwanted drawing issues.
 
->*Warning:* When the this feature, updates do not occur after each
+>*Warning:* When using this feature, updates do not occur after each
 > command. 
 
 >*Warning:* This feature should not be used if your scripts prevent

--- a/docs/dictionary/command/iphoneSetRemoteControlDisplay.lcdoc
+++ b/docs/dictionary/command/iphoneSetRemoteControlDisplay.lcdoc
@@ -50,10 +50,11 @@ both on an external device and also on the device itself when in lock
 screen (via double-tapping on the Home button).
 
 Use the <iphoneSetRemoteControlDisplay> command to configure the
-> information that may be displayed on the remote control device, or on
-> the (locked) home screen controls.
+information that may be displayed on the remote control device, or on
+the (locked) home screen controls.
 >*Note:* There is no guarantee that any of this information will be
 > used, it is up to the remote control device / iOS to decide.
+
 >*Note:* This functionality is only available on iOS 5.x and above.
 
 References: iphoneEnableRemoteControl (command),

--- a/docs/dictionary/control_st/if.lcdoc
+++ b/docs/dictionary/control_st/if.lcdoc
@@ -133,7 +133,8 @@ a <switch> <control structure> instead.
 >*Note:* The <if> <control structure> is implemented internally as a
 > <command> and appears in the <commandNames>.
 
-References: switch (control structure), commandNames (function),
+References: repeat (control structure), switch (control structure), 
+try (control structure), commandNames (function),
 statement (glossary), command (glossary), evaluate (glossary),
 execute (glossary), control structure (glossary), then (keyword),
 else (keyword), else if (keyword), end if (keyword), word (keyword)

--- a/docs/dictionary/function/iphoneDoNotBackupFile.lcdoc
+++ b/docs/dictionary/function/iphoneDoNotBackupFile.lcdoc
@@ -22,7 +22,7 @@ put iphoneDoNotBackupFile(specialFolderPath("documents") & "/appointments.txt") 
 
 Parameters:
 filename:
-The fulle path to the flagged file
+The full path to the flagged file
 
 Returns:
 true - the file has been flagged to prevent backup to the Cloud.

--- a/docs/dictionary/keyword/http.lcdoc
+++ b/docs/dictionary/keyword/http.lcdoc
@@ -32,13 +32,15 @@ If an error occurs during transfer of the data, the error is placed in
 the result <function>. The first <word> returned by the <result>
 <function> is "error", followed (where appropriate) by the text of the
 error message returned by the HTTP <server>, including the server
-response code. >*Important:* If there is an error downloading an <http>
+response code. 
+>*Important:* If there is an error downloading an <http>
 <URL(keyword)>, the <URL(keyword)> <container> does not necessarily
 <evaluate> to empty. Most <HTTP> <server|servers> send an error page
 when the file is not found or another error occurs, and the URL
 <container> will evaluate to the contents of this page. Before using the
 data in a URL <container>, check the <result> to make sure it is empty
 and there was no error. 
+
 >*Important:* If a <blocking> operation
 involving a <URL(keyword)> (using the <put> <command> to <upload> a
 <URL(keyword)>, the <post> <command>, the <delete URL> <command>, or a
@@ -95,9 +97,7 @@ Here are some examples of valid <http> <URL(glossary)|URLs>:
     put "name" into userName
     put "jdoe@example.com" into userPassword
     put "http://" & userName & ":" & URLEncode(userPassword) \
-
-    & "@www.example.net/index.html" into fileURLToGet
-
+          & "@www.example.net/index.html" into fileURLToGet
     get URL fileURLToGet
 
 
@@ -131,16 +131,14 @@ concludes. If the user clicks the button again while the download is
 still going on, the handler simply beeps:
 
     on mouseUp
-
-    global gDownloadInProgress
-    if gDownloadInProgress then
-        beep
-        exit mouseUp
-    end if
-    put true into gDownloadInProgress -- about to start
-    put URL (field "Page to get") into field "Command Result"
-    put false into gDownloadInProgress -- finished
-    
+        global gDownloadInProgress
+        if gDownloadInProgress then
+            beep
+            exit mouseUp
+        end if
+        put true into gDownloadInProgress -- about to start
+        put URL (field "Page to get") into field "Command Result"
+        put false into gDownloadInProgress -- finished
     end mouseUp
 
 

--- a/docs/dictionary/keyword/https.lcdoc
+++ b/docs/dictionary/keyword/https.lcdoc
@@ -39,7 +39,9 @@ response code.
 when the file is not found or another error occurs, and the URL
 <container> will evaluate to the contents of this page. Before using the
 data in a URL <container>, check the <result> to make sure it is empty
-and there was no error. >*Important:* If a <blocking> operation
+and there was no error. 
+
+>*Important:* If a <blocking> operation
 involving a <URL(keyword)> (using the <put> <command> to <upload> a
 <URL(keyword)>, the <post> <command>, the <delete URL> <command>, or a
 <statement> that gets an <ftp> or <HTTP> <URL(keyword)>) is going on, no
@@ -116,16 +118,14 @@ concludes. If the user clicks the button again while the download is
 still going on, the handler simply beeps:
 
     on mouseUp
-
-    global gDownloadInProgress
-    if gDownloadInProgress then
-        beep
-        exit mouseUp
-    end if
-    put true into gDownloadInProgress -- about to start
-    put URL (field "Page to get") into field "Command Result"
-    put false into gDownloadInProgress -- finished
-    
+        global gDownloadInProgress
+        if gDownloadInProgress then
+            beep
+            exit mouseUp
+        end if
+        put true into gDownloadInProgress -- about to start
+        put URL (field "Page to get") into field "Command Result"
+        put false into gDownloadInProgress -- finished
     end mouseUp
 
 

--- a/docs/dictionary/message/hotspotClicked.lcdoc
+++ b/docs/dictionary/message/hotspotClicked.lcdoc
@@ -51,7 +51,8 @@ not include 64 bit support and therefore can not be supported on OS X 64
 bit builds of LiveCode.
 
 References: QuickTime VR (glossary), message (glossary),
-nodeChanged (message), QTDebugStr (message), hotspots (property)
+nodeChanged (message), QTDebugStr (message), hotspots (property),
+dontUseQT (property), dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/message/keyDown.lcdoc
+++ b/docs/dictionary/message/keyDown.lcdoc
@@ -54,7 +54,7 @@ being entered in the <field>.
 
 References: focus (command), keysDown (function), handler (glossary),
 character (glossary), pass (glossary), message (glossary),
-trap (glossary), field (keyword), rawKeyDown message (message),
+trap (glossary), field (keyword), rawKeyDown (message),
 commandKeyDown (message), returnKey (message), enterInField (message),
 controlKeyDown (message), arrowKey (message), backspaceKey (message),
 tabKey (message), functionKey (message), enterKey (message),

--- a/docs/dictionary/property/ink.lcdoc
+++ b/docs/dictionary/property/ink.lcdoc
@@ -27,8 +27,8 @@ inkmode:
 the name of the ink
 
 Value (enum):
-The <ink> of an <object(glossary)> is a <string> designating one of 48
-<transfer mode|transfer modes>.By default, the <ink> of newly created
+The <ink> of an <object(glossary)> is a <string> designating one of 25
+<transfer mode|transfer modes>. By default, the <ink> of newly created
 <object|objects> is "srcCopy"
 
 

--- a/docs/glossary/k/keyword.lcdoc
+++ b/docs/glossary/k/keyword.lcdoc
@@ -6,8 +6,8 @@ Type: glossary
 
 Description:
 A word that is part of the <LiveCode> language, but is not a built-in
-<command>, <function>, <property>, or <message> name, a <control
-structure>, <operator>, or <object(glossary)> type.
+<command>, <function>, <property>, or <message> name, a 
+<control structure>, <operator>, or <object(glossary)> type.
 
 References: property (glossary), LiveCode (glossary), operator (glossary),
 message (glossary), control structure (glossary), function (glossary),


### PR DESCRIPTION
hotspotClicked (message) - Added missing references
http (keyword) - Corrected formatting
https (keyword) - Correct formatting
if (control structure) - Added missing references
import (command) - Added missing references
ink (property) - Changed the stated number of transfer modes to be consistent with the rest of the entry
iphoneDoNotBackupFile (function) - Fixed typo
iphoneSetAudioCategory (command) - Removed redundant text
iphoneSetRedrawInterval (command) - Corrected typo
iphoneSetRemoteControDisplay (command) - Corrected Note formatting
keyDown (message) - Corrected reference
keyword (glossary) - Fixed broken link