### PR TITLE
[Dictionary] kill to lock menus

### DIFF
--- a/docs/dictionary/command/kill.lcdoc
+++ b/docs/dictionary/command/kill.lcdoc
@@ -42,7 +42,7 @@ Use the <kill> command to send a signal to a <process> (on <Unix|Unix
 systems>), or to terminate a <process> with extreme prejudice.
 
 On Mac OS systems, the <kill> <command> sends a "Quit Application"
-<Apple event> to the specified application.
+<Apple Event|Apple event> to the specified application.
 
 On Unix systems, the <kill> command sends the specified signal to the
 <process>. If no signal is specified, the <kill> command sends SIGTERM.

--- a/docs/dictionary/command/launch-document.lcdoc
+++ b/docs/dictionary/command/launch-document.lcdoc
@@ -29,7 +29,14 @@ filename:
 The result:
 If launching the document fails, an error message will be placed into
 the result, otherwise the result will be empty. If non-empty, the
-message will be one of the following:.
+message will be one of the following:
+-  "can't open file" - the file was not found or is not accessible
+-  "no association" - no application was found to open the document
+-  "request failed" - an attempt was made to launch the appropriate
+application but it was unable to fulfill the request
+-  "no memory" - the system ran out of resources or memory while trying to
+fulfill the request
+
 
 Description:
 <launch document> allows you to open the file  without specifying an
@@ -44,16 +51,6 @@ clicking the file in Windows Explorer and Mac OS X Finder.
 If you want to launch a document with a specific application, use the
 <launch> <command> instead, which allows an optional documentName
 parameter for this purpose.
-
-"can't open file" - the file was not found or is not accessible
-
-"no association" - no application was found to open the document
-
-"request failed" - an attempt was made to launch the appropriate
-application but it was unable to fulfill the request
-
-"no memory" - the system ran out of resources or memory while trying to
-fulfill the request
 
 References: launch (command), launch url (command),
 command (glossary)

--- a/docs/dictionary/command/launch.lcdoc
+++ b/docs/dictionary/command/launch.lcdoc
@@ -52,8 +52,8 @@ foreground.
 If no <documentPath> is specified, the following two statements are
 equivalent: 
 
-launch application
-open process application for neither
+    launch application
+    open process application for neither
 
 >*Note:*  On OS X systems, you can use the <launch> command to start up
 > an application, but not a Unix process. To work with a Unix process,
@@ -62,7 +62,7 @@ open process application for neither
 >*Tip:*  On Windows systems, you can also start up an application by
 > using the shell function with the Windows "start" command:
 
-get shell("start MyProgram.exe")
+    get shell("start MyProgram.exe")
 
 References: launch url (command), kill (command),
 launch document (command), shell (function), command (glossary),

--- a/docs/dictionary/command/libURLSetCustomHTTPHeaders.lcdoc
+++ b/docs/dictionary/command/libURLSetCustomHTTPHeaders.lcdoc
@@ -38,13 +38,13 @@ Whenever LiveCode contacts a web server (with the load <command>, the
 Usually, the <headersList> will include multiple lines. A typical
 <headersList> might look like the following example:
 
-GET /catsdata/coldat.dat HTTP/1.1
-Connection:Close
-User-Agent: My Fancy Browser
-Host:www.cats-training.com
-Accept:image/gif, image/x-xbitmap, image/jpeg, image/png, */*
-Accept-Encoding: gzip
-Accept-Charset: iso-8859-1,*,utf-8
+    GET /catsdata/coldat.dat HTTP/1.1
+    Connection:Close
+    User-Agent: My Fancy Browser
+    Host:www.cats-training.com
+    Accept:image/gif, image/x-xbitmap, image/jpeg, image/png, */*
+    Accept-Encoding: gzip
+    Accept-Charset: iso-8859-1,*,utf-8
 
 The <libURLSetCustomHTTPHeaders> setting takes effect for the next
 <HTTP> transaction. After the transaction, the headers are set back to

--- a/docs/dictionary/command/libURLftpUpload.lcdoc
+++ b/docs/dictionary/command/libURLftpUpload.lcdoc
@@ -5,7 +5,7 @@ Type: command
 Syntax: libURLftpUpload <value>, <uploadURL> [, <callbackMessage>]
 
 Summary:
-<upload|Uploads> data to an Internet <server> asynchronously via <FTP>.
+<upload|Uploads> data to an Internet <server> asynchronously via <ftp|FTP>.
 
 Associations: internet library
 

--- a/docs/dictionary/command/libURLftpUploadFile.lcdoc
+++ b/docs/dictionary/command/libURLftpUploadFile.lcdoc
@@ -6,7 +6,7 @@ Syntax: libURLftpUploadFile <filePath>, <uploadURL> [, <callbackMessage>]
 
 Summary:
 <upload|Uploads> a file to an Internet <server> asynchronously via
-<FTP>. 
+<ftp|FTP>. 
 
 Associations: internet library
 
@@ -42,7 +42,7 @@ Use the <libURLftpUploadFile> <command> to put a <file> on a <server>.
 
 The <libURLftpUploadFile> <command> transfers the data directly from the
 <file> to the <server>. Unlike <libURLftpUpload> (or the <put> <command>
-used with an <FTP> <URL>), the data does not all need to be in memory at
+used with an <ftp|FTP> <URL>), the data does not all need to be in memory at
 once, so this <command> is a better choice for large <files>.
 
 The <libURLftpUploadFile> <command> transfers the file in <binary> mode.

--- a/docs/dictionary/command/load-extension.lcdoc
+++ b/docs/dictionary/command/load-extension.lcdoc
@@ -60,7 +60,7 @@ name of the main module.
 
 References: unload extension (command), create widget (command),
 loadedExtensions (function), result (function),
-LiveCode Builder extension (glossary)
+LiveCode Builder extension (glossary), command (glossary)
 
 Changes:
 The ability to load multiple modules in a single <load extension>

--- a/docs/dictionary/command/load.lcdoc
+++ b/docs/dictionary/command/load.lcdoc
@@ -93,8 +93,8 @@ remove it from the <cache>.
 > the engine implementation.
 
 > *Note:* When specifying URLs for iOS or Android, you must use the
-> appropriate form that conforms to [RFC
-> 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
+> appropriate form that conforms to 
+> [RFC 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
 > <URLEncode> any username and password fields appropriately for FTP
 > URLs.
 
@@ -116,7 +116,8 @@ application (glossary), standalone application (glossary),
 load (glossary), cache (glossary), command (glossary),
 main stack (glossary), expression (glossary), keyword (glossary), 
 download (glossary), message (glossary), parameter (glossary), 
-handler (glossary), URL (keyword), file (keyword), 
+handler (glossary), Standalone Application Settings (glossary),
+URL (keyword), file (keyword), 
 Internet library (library), library (library), startup (message), 
 openBackground (message), preOpenStack (message), openStack (message), 
 preOpenCard (message), script (property)

--- a/docs/dictionary/command/lock-menus.lcdoc
+++ b/docs/dictionary/command/lock-menus.lcdoc
@@ -34,7 +34,7 @@ visible to the user.
 
 References: unlock menus (command), lock screen (command),
 menus (function), property (glossary), command (glossary),
-menu bar (glossary), control (object), lockMenus (property)
+menu bar (glossary), control (glossary), lockMenus (property)
 
 Tags: menus
 

--- a/docs/dictionary/function/libUrlFormData.lcdoc
+++ b/docs/dictionary/function/libUrlFormData.lcdoc
@@ -54,10 +54,10 @@ second part, and so on.
 References: post (command), libURLSetExpect100 (command),
 libURLMultipartFormAddPart (function), libURLMultipartFormData (function),
 application (glossary), standalone application (glossary),
-openBackground (glossary), function (glossary), openStack (glossary),
-main stack (glossary), keyword (glossary), group (glossary),
-startup (glossary), Standalone Application Settings (glossary),
-preOpenStack (glossary), message (glossary), preOpenCard (glossary),
-handler (glossary), LiveCode custom library (glossary),
-Internet library (library), library (library)
+function (glossary), main stack (glossary), keyword (glossary), 
+group (glossary), Standalone Application Settings (glossary),
+message (glossary), handler (glossary), LiveCode custom library (glossary),
+Internet library (library), library (library), openBackground (message),
+openStack (message), startup (message), preOpenStack (message),
+preOpenCard (message)
 

--- a/docs/dictionary/property/layer.lcdoc
+++ b/docs/dictionary/property/layer.lcdoc
@@ -57,8 +57,8 @@ equal to the number of <control(object)|controls>.
 
 The <layer> of <control(object)|controls> also determines the tab order.
 When you press the Tab key, the next <control(keyword)> whose
-<traversalOn> <property> is true becomes the <active (focused)
-control(glossary)>. For example, to set the tab order of
+<traversalOn> <property> is true becomes the <active control|active 
+(focused) control>. For example, to set the tab order of
 <field(object)|fields> in a data entry form, set the <layer> of each
 <field(keyword)> so that they are in order.
 

--- a/docs/dictionary/property/layerMode.lcdoc
+++ b/docs/dictionary/property/layerMode.lcdoc
@@ -51,32 +51,38 @@ If you specify the effective keyword, getting the <layerMode> returns
 how the engine is actually treating the layer, rather than what you
 requested it to be. There can be a difference for a number of reasons:
 
-1) You are not using a compositor (set using <compositorType>) -
-effective layerMode is set to 'static'. 2) You have a static <layerMode>
+1. You are not using a compositor (set using <compositorType>) -
+effective layerMode is set to 'static'. 
+2. You have a static <layerMode>
 object with a non-copy/blendSrcOver ink set - effective layerMode is set
-to 'dynamic'. 3) You have a scrolling <layerMode> on a non-group or an
+to 'dynamic'. 
+3. You have a scrolling <layerMode> on a non-group or an
 adorned group - effective layerMode is set to 'dynamic'.
 
-Scrolling
+**Scrolling**
+
 The scrolling layerMode is pertinent to groups. It means that the engine
 caches the content of the group unclipped, and then renders the cached
 copies clipped; instead of caching the visible portion of the group.
 This results in fast updates when setting the scroll properties of a
 group. 
 
-Static vs Dynamic
+**Static vs Dynamic**
+
 There are various contexts where setting the <layerMode> can have a big
 impact on the performance of an application, in particular games or
 interfaces with moving/changing elements. In these cases, the
 <layerMode> should be set to 'dynamic'.
 
 A PLATFORM GAME EXAMPLE
+
 Take a platform game as an example. The main character, any animated
 elements and scrolling platform components should all have a <layerMode>
 of 'dynamic'. However, the background image should have a <layerMode> of
 'static'. 
 
 NON-GAME DRAG EXAMPLE
+
 Consider a drag-drop interface where a user can 'pick' something up and
 drop it elsewhere. While the object is being dragged across the stack
 the <layerMode> can be set to 'dynamic' (particularly important if it

--- a/docs/dictionary/property/listBehavior.lcdoc
+++ b/docs/dictionary/property/listBehavior.lcdoc
@@ -58,13 +58,12 @@ However, you can set the <hilitedLine> of the field even if the
 > field to false has no effect.
 
 References: property (glossary), highlight (glossary),
-dontWrap property (glossary), lock (glossary), message (glossary),
-autoHilite (glossary), listBehavior (glossary), line (glossary),
+lock (glossary), message (glossary), line (glossary),
 list field (glossary), field (glossary), field (keyword),
 selection (keyword), mouseDown (message), mouseRelease (message),
 mouseUp (message), field (object), noncontiguousHilites (property),
 dontWrap (property), autoHilite (property), lockText (property),
-multipleLines (property), threeDHilite (property),
+multipleHilites (property), threeDHilite (property),
 toggleHilites (property), hilitedLine (property)
 
 Tags: ui

--- a/docs/glossary/l/library.lcdoc
+++ b/docs/glossary/l/library.lcdoc
@@ -6,14 +6,14 @@ Type: library
 
 Description:
 A repository of code that is available to be used by other routines.
-LiveCode includes several <custom libraries> you can include in your
-applications. 
+LiveCode includes several <LiveCode custom library|custom libraries> 
+you can include in your applications. 
 
 You can make the <script> of any <stack> into a library with the 
 <start using> <command>, or make any <object|object's> <script> into a library
 using the <insert script> <command>.
 
 References: start using (command), insert script (command),
-command (glossary), custom libraries (glossary), script (glossary),
+command (glossary), LiveCode custom library (glossary), script (glossary),
 stack (glossary), object (glossary)
 


### PR DESCRIPTION
kill (command) - Fixed broken link.
launch (command) - Added indents to code examples to display correctly.
launch document (command) - Moved misplaced text.
layer (property) - Fixed broken link.
layerMode (property) - General formatting changes. Fixed broken link.
library (glossary) - Fixed broken link and reference
libUrlFormData (function) - Corrected type for multiple references.
libURLftpUpload (command) - Fixed broken link.
libURLftpUploadFile (command) - Fixed broken link.
libURLSetCustomHTTPHeaders (command) - Indented headers list example for readability.
listBehaviour (property) - Removed non-existent entries, corrected one reference that was using a synonym.
load (command) - Added missing reference.
load extension (command) - Added missing reference.
lock menus (command) - Corrected type of reference.