### PR TITLE
[[ Bug 21984 ]] Fix android accelrendering startup issue

### DIFF
--- a/docs/notes/bugfix-21984.md
+++ b/docs/notes/bugfix-21984.md
@@ -1,0 +1,1 @@
+# Render screen at startup on Android when accelerated rendering on without event queue trigger

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -2779,8 +2779,12 @@ static void doSurfaceChangedCallback(void *p_is_init)
 	// We can now re-enable screen updates.
 	MCRedrawEnableScreenUpdates();
 
-	// Force a redraw of the current window without re-rendering
-    static_cast<MCScreenDC *>(MCscreen) -> refresh_current_window();
+	// Force a redraw of the current window. If this is an initializing change,
+	// re-render the whole screen.
+	if (t_is_init)
+		MCRedrawUpdateScreen();
+	else
+		static_cast<MCScreenDC *>(MCscreen) -> refresh_current_window();
 }
 
 JNIEXPORT void JNICALL Java_com_runrev_android_OpenGLView_doSurfaceChanged(JNIEnv *env, jobject object, jobject p_view)


### PR DESCRIPTION
This patch fixes an issue with accelerated rendering on startup
whereby only a redraw of the current window was being triggered.
If the surfaceChanged callback is triggered with no previously
allocated open gl view then force a full rendering of the window.