### PR TITLE
[[ Prebuilt ]] Exclude armv6 binaries when fetching Android prebuilt libraries

### DIFF
--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -2,7 +2,7 @@
 
 # Libraries to fetch
 PLATFORMS=( mac linux win32 android ios emscripten )
-ARCHS_android=( armv6 armv7 arm64 x86 x86_64 )
+ARCHS_android=( armv7 arm64 x86 x86_64 )
 ARCHS_mac=( Universal )
 ARCHS_ios=( Universal )
 ARCHS_win32=( x86 x86_64 )

--- a/prebuilt/fetch.gyp
+++ b/prebuilt/fetch.gyp
@@ -311,7 +311,7 @@
 					
 					'outputs':
 					[
-						'lib/android/armv6',
+						'lib/android/<(target_arch)',
 					],
 					
 					'action':


### PR DESCRIPTION
As we no longer produce armv6 prebuilt libraries for android, attempting
to fetch them will fail when we update the existing set of prebuilt
libraries, or add new ones.