### PR TITLE
long to mobileGetLocationHistoryLimit

### DIFF
--- a/docs/dictionary/command/mobileBusyIndicatorStop.lcdoc
+++ b/docs/dictionary/command/mobileBusyIndicatorStop.lcdoc
@@ -25,8 +25,7 @@ busy indicator from the screen.
 
 The <mobileBusyIndicatorStop> command does not do anything if a busy
 indicator is not running. You can start an activity indicator by calling
-<mobileBusyIndicatorStart.> 
+<mobileBusyIndicatorStart>. 
 
-References: mobileBusyIndicatorStart. (command),
-mobileBusyIndicatorStart (command)
+References: mobileBusyIndicatorStart (command)
 

--- a/docs/dictionary/command/mobileCancelLocalNotification.lcdoc
+++ b/docs/dictionary/command/mobileCancelLocalNotification.lcdoc
@@ -22,15 +22,15 @@ notification:
 
 Description:
 Use the <mobileCancelLocalNotification> <command> to cancel a particular
-Local Notification with the operating system from within a <stack on iOS
-or Android>.
+Local Notification with the operating system from within a <stack> on iOS
+or Android.
 
 This command cancels a Local Notification with the iOS or Android
 operating sytem.
 
 References: mobileCreateLocalNotification (command),
 mobileCancelAllLocalNotifications (command), command (glossary),
-stack on iOS or Android (object)
+stack (object)
 
 Tags: networking
 

--- a/docs/dictionary/function/md5Digest.lcdoc
+++ b/docs/dictionary/function/md5Digest.lcdoc
@@ -34,7 +34,7 @@ Compute a message digest of <message> using the MD5 cryptographic
 hash function.
 
 > *Warning:* Serious flaws have been found in the MD5 hash algorithm
-> that make in unsuitable to use for security-critical purposes.
+> that make it unsuitable to use for security-critical purposes.
 > Unless you need backwards compatibility with existing systems, use
 > one of the other algorithms available with the <messageDigest> <function>
 

--- a/docs/dictionary/function/mobileCanSendMail.lcdoc
+++ b/docs/dictionary/function/mobileCanSendMail.lcdoc
@@ -4,7 +4,7 @@ Synonyms: iphonecansendmail
 
 Type: function
 
-Syntax: mobileCanSendMail ()
+Syntax: mobileCanSendMail()
 
 Summary:
 Determines if a devices can be used to send emails.
@@ -16,11 +16,11 @@ OS: ios, android
 Platforms: mobile
 
 Example:
-answer mobileCanSendMail () with "okay"
+answer mobileCanSendMail() with "okay"
 
 Example:
-if mobileCanSendMail () is false then
-answer "This device does not support e-mail" with "Okay"
+if mobileCanSendMail() is false then
+    answer "This device does not support e-mail" with "Okay"
 end if
 
 Returns (enum):

--- a/docs/dictionary/function/mobileCurrentHeading.lcdoc
+++ b/docs/dictionary/function/mobileCurrentHeading.lcdoc
@@ -22,18 +22,20 @@ Example:
 put mobileCurrentHeading() into theHeading
 
 Returns:
-If heading tracking has been enabled the <mobileCurrentHeading> funtion
-returns an array with the following keys: accuracy - The maximum
-deviation (measured in degrees) between the reported heading and true
-geomagnetic heading. The lower the value, the more accurate the reading.
-magnetic heading - The heading (measured in degrees) relative to
+If heading tracking has been enabled the <mobileCurrentHeading> function
+returns an array with the following keys: 
+- "accuracy": The maximum deviation (measured in degrees) between the 
+reported heading and true geomagnetic heading. The lower the value, 
+the more accurate the reading.
+- "magnetic heading": The heading (measured in degrees) relative to
 magnetic north. true heading - The heading (measured in degrees)
 relative to true north. If the true heading could not be calculated
 (usually due to heading tracking not being enabled, or lack of
-calibration), this key will not be present. heading - The true heading
-if available, otherwise the magnetic heading. x, y, z - The geomagnetic
-data (measured in microteslas) for each of the x, y and z axes.
-timestamp - The time at which the measurement was taken, in seconds
+calibration), this key will not be present. 
+- "heading": The true heading if available, otherwise the magnetic 
+heading. x, y, z - The geomagnetic data (measured in microteslas) for 
+each of the x, y and z axes. 
+- "timestamp": The time at which the measurement was taken, in seconds
 since 1970.
 
 Description:

--- a/docs/dictionary/function/mobileCurrentLocation.lcdoc
+++ b/docs/dictionary/function/mobileCurrentLocation.lcdoc
@@ -33,7 +33,7 @@ function returns an array with the following keys
 - "vertical accuracy": the maximum error in meters of the altitude
   value. 
 - "altitude": the distance in meters of the height of the device
-  relative to sea:level. Positive values extend upward of sea:level,
+  relative to sea level. Positive values extend upward of sea:level,
   negative values downward.
 - "timestamp": the time at which the measurement was taken, in seconds
   since 1970.

--- a/docs/dictionary/function/mobileGetLocationHistoryLimit.lcdoc
+++ b/docs/dictionary/function/mobileGetLocationHistoryLimit.lcdoc
@@ -64,6 +64,6 @@ References: mobileSetLocationHistoryLimit (command),
 mobileStopTrackingSensor (command), mobileStartTrackingSensor (command),
 mobileGetLocationHistory (function), mobileSensorAvailable (function),
 mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function), array (function),
+mobileLocationAuthorizationStatus (function), array (glossary),
 function (glossary), locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/keyword/long.lcdoc
+++ b/docs/dictionary/keyword/long.lcdoc
@@ -72,7 +72,7 @@ propertyNames (function), time (function), folders (function),
 files (function), dateFormat (function), date (function),
 keyword (glossary), property (glossary), command (glossary),
 object type (glossary), expression (glossary), object (glossary),
-card (keyword), short (keyword), abbreviated (keyword), ID (property)
+card (keyword), short (keyword), abbreviated (keyword), ID (property),
 name (property), owner (property), useSystemDate (property)
 
 Tags: file system

--- a/docs/dictionary/message/menuKey.lcdoc
+++ b/docs/dictionary/message/menuKey.lcdoc
@@ -23,11 +23,11 @@ Description:
 Handle the <menuKey> message to perform an action when the menu key is
 pressed. 
 
-The <menuKey> message is sent to the current card of the <default stack>
+The <menuKey> message is sent to the current card of the <defaultStack>
 when the hardware menu button is pressed.
 
 References: backKey (message), searchKey (message),
-default stack (property)
+defaultStack (property)
 
 Tags: ui
 

--- a/docs/dictionary/message/menuPick.lcdoc
+++ b/docs/dictionary/message/menuPick.lcdoc
@@ -40,9 +40,9 @@ Handle the <menuPick> <message> to do something when the user chooses a
 >*Note:* If the specification of a menu or submenu includes a tag, that
 > tag will replace the menu label in the <pChosenItem> parameter
 
-The <menuPick> <message> is sent when the user clicks a tab in a <tabbed
-button>, when the user chooses a <menu item> from the <menu> associated
-with a <button(keyword)>, or when a <button(object)|button's>
+The <menuPick> <message> is sent when the user clicks a tab in a 
+<tabbed button>, when the user chooses a <menu item> from the <menu> 
+associated with a <button(keyword)>, or when a <button(object)|button's>
 <menuHistory> <property> is set by a <handler>.
 
 The <menuPick> <message> is sent every time a <menu item> is chosen,

--- a/docs/dictionary/property/lookAndFeel.lcdoc
+++ b/docs/dictionary/property/lookAndFeel.lcdoc
@@ -52,9 +52,9 @@ being used on. On Windows XP, <Mac OS> and <OS X|OS X systems>, the
 
 The "Appearance Manager" option can be used only on Windows XP, Mac OS
 and OS X systems. If you set the <lookAndFeel> to "Appearance Manager"
-on a <Unix> <system>, it is reset to "Motif". Similarly, tf you set the
+on a <Unix> <system>, it is reset to "Motif". Similarly, if you set the
 <lookAndFeel> to "Appearance Manager" on a pre-Windows XP <system>, it
-is reset to "Wondows 95".
+is reset to "Windows 95".
 
 On Mac OS systems, the native Appearance Manager drawing routines are
 much slower than the emulated Platinum routines. Setting the

--- a/docs/dictionary/property/magnify.lcdoc
+++ b/docs/dictionary/property/magnify.lcdoc
@@ -22,7 +22,7 @@ Value (bool):
 The <magnify> of an <image> is true or false.
 
 Description:
-Use the <magnify> <property> to edit an <image> <pixel> -by- <pixel>.
+Use the <magnify> <property> to edit an <image> <pixel>-by-<pixel>.
 
 When you set the <magnify> of an <image> to true, a <palette> appears
 displaying a close-up view of the center of the <image>. At the same

--- a/docs/dictionary/property/margins.lcdoc
+++ b/docs/dictionary/property/margins.lcdoc
@@ -51,16 +51,16 @@ top, left, bottom, and right margins are set to each one respectively:
 * item 4 is equal to the bottomMargin
 
 
-If the lookAndFeel is set to "Motif", <control(object)|controls> require
+If the lookAndFeel is set to "Motif", <control|controls> require
 two <pixels> of margin space for the border that shows when the
-<control(keyword)> is <active (focused)(glossary)>. To avoid interfering
-with this border on <Unix|Unix systems>, set the <margins> <property> of
-<group(glossary)|groups> to at least 2 if the <group(command)> contains
-<control(object)|controls> whose <traversalOn> <property> is set to
-true. 
+<control> is <active control|active (focused)>. To 
+avoid interfering with this border on <Unix|Unix systems>, set the 
+<margins> <property> of <group(glossary)|groups> to at least 2 if the 
+<group(command)> contains <control|controls> whose <traversalOn> 
+<property> is set to true. 
 
->*Important:*  The <margins> of an <object(glossary)> include the 2-
-> <pixel> space required for the focus border, even if the <lookAndFeel>
+>*Important:*  The <margins> of an <object(glossary)> include the 
+> 2-<pixel> space required for the focus border, even if the <lookAndFeel>
 > is not "Motif". This means that 2 is the smallest usable margin,
 > rather than zero. For example, if the <margins> of a <field(keyword)>
 > is set to zero, a few <pixels> at the edge of the

--- a/docs/dictionary/property/markerDrawn.lcdoc
+++ b/docs/dictionary/property/markerDrawn.lcdoc
@@ -32,20 +32,21 @@ Irregular polygon graphics can be drawn with a marker at each vertex,
 whose shape is defined by the markerPoints <property>. The <markerDrawn>
 <property> specifies whether these markers are visible or not.
 
-The borderPattern and <borderColor> <properties> determine the
+The <borderPattern> and <borderColor> <properties> determine the
 appearance of the markers' interior. The <hilitePattern> and
 <hiliteColor> determine the appearance of the borders.
 
 If the style <property> of the <graphic> is not polygon or curve, the
-setting of its markerPattern <property> has no effect.
+setting of its <hilitePattern> <property> has no effect.
 
-If the markerPoints <property> is empty, the setting of the
+If the <markerPoints> <property> is empty, the setting of the
 <markerDrawn> <property> has no effect.
 
 References: vertex (glossary), property (glossary), polygon (keyword),
 graphic (keyword), graphic (object), borderColor (property),
-hilitePattern (property), properties (property), hiliteColor (property),
-markerFilled (property), markerLineSize (property)
+borderPattern (property), hilitePattern (property), properties (property), 
+hiliteColor (property), markerFilled (property), markerLineSize (property),
+markerPoints (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/mnemonic.lcdoc
+++ b/docs/dictionary/property/mnemonic.lcdoc
@@ -31,7 +31,7 @@ clicking a button on <Windows|Windows systems>.
 The <mnemonic> is any number between 1 and the number of <characters> in
 the <button(object)|button's> name. The <character> at that position is
 underlined, and pressing the <Alt key> with that <character> sends a
-<mouseUp> message to the <button(keyword)>. If the <number> is zero, the
+<mouseUp> message to the <button(keyword)>. If the number is zero, the
 <button(keyword)> does not have an <Alt key> equivalent.
 
 This property has no effect on Mac OS or Unix systems.


### PR DESCRIPTION
long (keyword) - Added comma to make the following reference function properly.
lookAndFeel (property) - Fixed spelling errors.
magnify (property) - Removed needless spacing.
margins (property) - Fixed broken links.
markerDrawn (property) - Added references.
md5digest (function) - Fixed spelling error.
menuKey (message) - Fixed broken link.
menuPick (message) - Fixed broken link.
mnemonic (property) - Removed link formatting where it made no sense in context.
mobileBusyIndicatorStop (command) - Fixed broken link.
mobileCancelLocalNotification (command) - Fixed broken link.
mobileCanSendMail (function) - Formatting corrections.
mobileCurrentHeading (function) - Formatted return information for readability
mobileCurrentLocation (function) - Punctuation correction.
mobileGetLocationHistoryLimit (function) - Corrected reference type.