### PR TITLE
[[ Bug 21986 ]] Fix benign leak of backdrop window on macOS

### DIFF
--- a/docs/notes/bugfix-21986.md
+++ b/docs/notes/bugfix-21986.md
@@ -1,0 +1,1 @@
+# Fix benign leak of backdrop window on engine shutdown on macOS

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -135,6 +135,8 @@ Boolean MCScreenDC::open()
 Boolean MCScreenDC::close(Boolean force)
 {
 	MCPlatformReleaseMenu(icon_menu);
+    
+    MCPlatformReleaseWindow(backdrop_window);
 	
 	// COCOA-TODO: Is this still needed?
 	if (ncolors != 0)


### PR DESCRIPTION
This patch fixes the failure to release the backdrop window on
engine shutdown on macOS. The leak is benign as it cannot affect
user code, however it does clutter up memory leak logs.