### PR TITLE
[[ Bug 21987 ]] Fix pasteboard leak on macOS

### DIFF
--- a/docs/notes/bugfix-21987.md
+++ b/docs/notes/bugfix-21987.md
@@ -1,0 +1,1 @@
+# Fix pasteboard leak on macOS

--- a/engine/src/mac-clipboard.h
+++ b/engine/src/mac-clipboard.h
@@ -115,7 +115,7 @@ public:
 	virtual MCDataRef DecodeTransferredHTML(MCDataRef p_html) const;
     
     // Constructor. The NSPasteboard being wrapped is required.
-    MCMacRawClipboard(NSPasteboard* p_pasteboard);
+    MCMacRawClipboard(NSPasteboard* p_pasteboard, bool p_release_globally = false);
     
     // Converts a LiveCode-style RawClipboardData key into an OSX UTI
     static MCStringRef CopyAsUTI(MCStringRef p_key);
@@ -130,6 +130,10 @@ private:
     
     // The array that we are pushing onto the clipboard
     NSMutableArray* m_items;
+    
+    // If true, the NSPasteboard must be released with releaseGlobally rather
+    // than release.
+    bool m_release_globally;
     
     // Indicates whether any changes have been made to the clipboard
     bool m_dirty;

--- a/engine/src/mac-clipboard.mm
+++ b/engine/src/mac-clipboard.mm
@@ -59,8 +59,9 @@ MCRawClipboard* MCRawClipboard::CreateSystemClipboard()
 
 MCRawClipboard* MCRawClipboard::CreateSystemSelectionClipboard()
 {
-    // Create a pasteboard internal to LiveCode
-    return new MCMacRawClipboard([NSPasteboard pasteboardWithUniqueName]);
+    // Create a pasteboard internal to LiveCode. Pasteboards created in this
+    // manner must be released using 'releaseGlobally'.
+    return new MCMacRawClipboard([NSPasteboard pasteboardWithUniqueName], true);
 }
 
 MCRawClipboard* MCRawClipboard::CreateSystemDragboard()
@@ -69,11 +70,13 @@ MCRawClipboard* MCRawClipboard::CreateSystemDragboard()
 }
 
 
-MCMacRawClipboard::MCMacRawClipboard(NSPasteboard* p_pasteboard) :
+MCMacRawClipboard::MCMacRawClipboard(NSPasteboard* p_pasteboard,
+                                     bool p_release_globally) :
   MCRawClipboard(),
   m_pasteboard(p_pasteboard),
   m_last_changecount(0),
   m_items(nil),
+  m_release_globally(p_release_globally),
   m_dirty(false),
   m_external_data(false)
 {
@@ -83,6 +86,14 @@ MCMacRawClipboard::MCMacRawClipboard(NSPasteboard* p_pasteboard) :
 MCMacRawClipboard::~MCMacRawClipboard()
 {
     [m_items release];
+    
+    /* If the pasteboard requires global release, then do this before releasing
+     * it in the usual way. */
+    if (m_release_globally)
+    {
+        [m_pasteboard releaseGlobally];
+    }
+    
     [m_pasteboard release];
 }
 


### PR DESCRIPTION
This patch fixes a leak of an NSPasteboard on macOS due to not
using the 'releaseGlobally' method to release the engine's
selection clipboard before it is released in the normal manner
using 'release'. To fix the issue, the constructor of MCMacRawClipboard
now takes an (optional) second boolean parameter which indicates
whether it needs global release. This is then used by the factory
function for the system selection clipboard.