### PR TITLE
[[ Bug 21988 ]] Fix memory leaks in clipboard functions

### DIFF
--- a/docs/notes/bugfix-21988.md
+++ b/docs/notes/bugfix-21988.md
@@ -1,0 +1,1 @@
+# Fix memory leaks when using clipboard functions


### PR DESCRIPTION
This patch fixes several similar memory leaks that can occur
when using the clipboard functions. The leaks are either
caused by passing a MCDataRef with a +1 retain count to the
constructor of an MCAutoDataRef, or a similar case with
an MCRawClipboardItem.