### PR TITLE
[[ Bug 21989 ]] Fix benign leak of apple events on startup on macOS

### DIFF
--- a/docs/notes/bugfix-21989.md
+++ b/docs/notes/bugfix-21989.md
@@ -1,0 +1,1 @@
+# Fix benign leak of apple events on startup on macOS

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -144,8 +144,8 @@ NSWindow *MCMacPlatformApplicationPseudoModalFor(void)
     if (self == nil)
         return nil;
     
-    AEDuplicateDesc(event, &m_event);
-    AEDuplicateDesc(reply, &m_reply);
+    m_event = *event;
+    m_reply = *reply;
     
     return self;
 }
@@ -155,11 +155,6 @@ NSWindow *MCMacPlatformApplicationPseudoModalFor(void)
     AEDisposeDesc(&m_event);
     AEDisposeDesc(&m_reply);
     [super dealloc];
-}
-
-- (OSErr)process
-{
-    return AEResumeTheCurrentEvent(&m_event, &m_reply, (AEEventHandlerUPP)kAEUseStandardDispatch, 0);
 }
 
 - (AppleEvent *)getEvent

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -19,7 +19,6 @@ class MCMacPlatformSurface;
 - (id)initWithEvent: (const AppleEvent *)event andReply: (AppleEvent *)reply;
 - (void)dealloc;
 
-- (OSErr)process;
 @end
 
 @compatibility_alias MCPendingAppleEvent com_runrev_livecode_MCPendingAppleEvent;


### PR DESCRIPTION
This patch fixes a benign leak of two AE descriptors on startup
on macOS. The leak was caused by duplicating the descriptors when
it was unnecessary to do so as the system had passed ownership to
the engine. Additionally this patch removes the unused 'process'
method from the MCPendingAppleEvent objective-c class.