### PR TITLE
[[ Bug 21990 ]] Fix memory leak when destroying windows on macOS

### DIFF
--- a/docs/notes/bugfix-21990.md
+++ b/docs/notes/bugfix-21990.md
@@ -1,0 +1,1 @@
+# Fix memory leak when destroying a stack's window on macOS

--- a/engine/src/platform-window.cpp
+++ b/engine/src/platform-window.cpp
@@ -74,6 +74,11 @@ MCPlatformWindow::~MCPlatformWindow(void)
 {
     //MCLog("Destroy window %p", this);
 	
+    if (m_cursor != nullptr)
+    {
+        MCPlatformReleaseCursor(m_cursor);
+    }
+    
 	MCRegionDestroy(m_dirty_region);
 	
 	MCPlatformWindowMaskRelease(m_mask);


### PR DESCRIPTION
This patch fixes a leak which can occur when destroying a window
on macOS caused by the failure to release the cursor attached
to the window (should one have been attached at any point).