### PR TITLE
[[ Bug 21991 ]] Ensure external library modules are unloaded

### DIFF
--- a/docs/notes/bugfix-21991.md
+++ b/docs/notes/bugfix-21991.md
@@ -1,0 +1,1 @@
+# Ensure external library code modules are unloaded when no longer referenced

--- a/engine/src/external.cpp
+++ b/engine/src/external.cpp
@@ -291,7 +291,7 @@ MCExternal *MCExternal::Load(MCStringRef p_filename)
 			s_externals = t_external;
 
 			t_external -> m_references = 0;
-			t_external -> m_module = t_module.Take();
+            t_external -> m_module.Give(t_module.Take());
 			t_external -> m_name = nil;
 			
 			t_success = t_external -> Prepare();


### PR DESCRIPTION
This patch ensures that any native code libraries which are loaded
as externals are correctly released when the last reference to
them (from any loaded stacks) is removed. Previously, incorrect
usage of MCSAutoLibraryRef meant that the library handle would
get an extra +1 retain count each time it was loaded.