### PR TITLE
[[ Bug 21993 ]] Tweak __MCName and __MCString layouts

### DIFF
--- a/docs/notes/bugfix-21993.md
+++ b/docs/notes/bugfix-21993.md
@@ -1,0 +1,1 @@
+# Make name and string values more memory efficient

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -257,6 +257,21 @@ struct __MCString: public __MCValue
         MCStringRef string;
         struct
         {
+#ifdef __32_BIT__
+            uindex_t char_count;
+            union
+            {
+                unichar_t *chars;
+                char_t *native_chars;
+            };
+            double numeric_value;
+            uindex_t capacity;
+            /* The padding is here to ensure the size of the struct is 32-bytes
+             * on all platforms. This ensures consistency between Win and UNIX
+             * ABIs which have slightly different rules concerning double
+             * alignment. */
+            uint32_t __padding;
+#else
             uindex_t char_count;
             uindex_t capacity;
             union
@@ -265,6 +280,7 @@ struct __MCString: public __MCValue
                 char_t *native_chars;
             };
             double numeric_value;
+#endif
         };
     };
 };
@@ -307,7 +323,6 @@ struct __MCName: public __MCValue
 	uintptr_t next;
 	uintptr_t key;
 	MCStringRef string;
-    hash_t hash;
 #endif
 };
 

--- a/libfoundation/test/test_memory.cpp
+++ b/libfoundation/test/test_memory.cpp
@@ -65,3 +65,30 @@ TEST(memory, information)
     _memory_malloc_size(48);
     _memory_malloc_size(64);
 }
+
+TEST(memory, sizes)
+{
+#ifdef __32_BIT__
+    EXPECT_EQ(sizeof(__MCNull), 8);
+    EXPECT_EQ(sizeof(__MCBoolean), 8);
+    EXPECT_EQ(sizeof(__MCNumber), 16);
+    EXPECT_EQ(sizeof(__MCName), 24);
+    EXPECT_EQ(sizeof(__MCString), 32);
+    EXPECT_EQ(sizeof(__MCData), 20);
+    EXPECT_EQ(sizeof(__MCArray), 16);
+    EXPECT_EQ(sizeof(__MCList), 16);
+    EXPECT_EQ(sizeof(__MCSet), 16);
+    EXPECT_EQ(sizeof(__MCProperList), 16);
+#else
+    EXPECT_EQ(sizeof(__MCNull), 8);
+    EXPECT_EQ(sizeof(__MCBoolean), 8);
+    EXPECT_EQ(sizeof(__MCNumber), 16);
+    EXPECT_EQ(sizeof(__MCName), 32);
+    EXPECT_EQ(sizeof(__MCString), 32);
+    EXPECT_EQ(sizeof(__MCData), 24);
+    EXPECT_EQ(sizeof(__MCArray), 24);
+    EXPECT_EQ(sizeof(__MCList), 24);
+    EXPECT_EQ(sizeof(__MCSet), 24);
+    EXPECT_EQ(sizeof(__MCProperList), 24);
+#endif
+}


### PR DESCRIPTION
This patch tweaks both the __MCName and __MCString struct layouts
to ensure they are more efficient.

The __MCName struct has had the now unused 'hash' member removed
when compiling for 64-bit architectures as this is stored in
free bits elsewhere in the structure.

The __MCString struct has had its layout changed when compiling
for 32-bit architectures so that the numeric_value double is
8-byte aligned, a padding member to ensure the struct is 32-bytes
in size on all platforms has also been added.

Additionally a low-level memory test has been added which verifies
the sizes of all the core __MCValue derived structs are the
expected (hand calculated and optimized for) values.