### PR TITLE
[[ Bug 21995 ]] Fix memory leaks when using sockets

### DIFF
--- a/docs/notes/bugfix-21995.md
+++ b/docs/notes/bugfix-21995.md
@@ -1,0 +1,1 @@
+# Fix memory leaks when using sockets

--- a/engine/src/opensslsocket.cpp
+++ b/engine/src/opensslsocket.cpp
@@ -551,7 +551,7 @@ static void free_ntoa_message_callback_info(MCNToAMessageCallbackInfo *t_info)
 		MCValueRelease(t_info->message);
 		MCValueRelease(t_info->name);
 		MCValueRelease(t_info->list);
-		MCMemoryDelete(t_info);
+		MCMemoryDestroy(t_info);
 	}
 }
 
@@ -600,7 +600,7 @@ bool MCS_ntoa(MCStringRef p_hostname, MCObject *p_target, MCNameRef p_message, M
 	else
 	{
 		MCNToAMessageCallbackInfo *t_info = NULL;
-		t_success = MCMemoryNew(t_info);
+		t_success = MCMemoryCreate(t_info);
 		if (t_success)
 		{
 			t_info->message = MCValueRetain(p_message);
@@ -1472,6 +1472,8 @@ MCSocket::~MCSocket()
 	deletewrites();
 
 	delete rbuffer;
+    
+    delete[] error;
 	
 	// MM-2014-06-13: [[ Bug 12567 ]] Added support for specifying an end host name to verify against.
 	MCValueRelease(endhostname);

--- a/engine/src/socket_resolve.cpp
+++ b/engine/src/socket_resolve.cpp
@@ -393,7 +393,7 @@ bool MCS_name_to_sockaddr(MCStringRef p_name_in, struct sockaddr_in *r_addr, MCH
             return false;
     }
     else
-        t_name = MCValueRetain(p_name_in);
+        t_name = p_name_in;
 
     // get port & id if set
     MCAutoStringRef t_host;
@@ -468,7 +468,7 @@ bool MCS_name_to_host_and_port(MCStringRef p_name, MCStringRef &r_host, MCNumber
         }
     }
     else
-        t_host = MCValueRetain(p_name);
+        t_host = p_name;
 
     if (!MCStringIsEmpty(*t_host))
         MCValueAssign(r_host, *t_host);


### PR DESCRIPTION
This patch fixes two kinds of memory leak which can occur when
using sockets.

The first leak occurs if a socket suffered an error during its
use and has a non-nil error string attached. Failure to delete
the error member in the MCSocket destructor caused it to leak,
this has been corrected.

The second leak occurs during name->address resolution and is
of a weak object handle. The MCNToAMessageCallbackInfo struct ceased to
be POD when the change to using object handles was made. This has
been fixed by using MCMemoryCreate and MCMemoryDestroy to allocate
and deallocate the structs.

The third leak occurs when parsing the socket connection string when
it is composed of just a host name. In this case the input string
was being over-retained due to using assignment to an auto class
*and* MCValueRetain.