### PR TITLE
[[ Bug 21996 ]] Fix memory leak when using filter elements of

### DIFF
--- a/docs/notes/bugfix-21996.md
+++ b/docs/notes/bugfix-21996.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using filter elements of array

--- a/engine/src/patternmatcher.cpp
+++ b/engine/src/patternmatcher.cpp
@@ -121,7 +121,7 @@ bool MCRegexMatcher::match(MCRange p_range)
 
 bool MCRegexMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key)
 {
-    MCStringRef t_string;
+    MCAutoStringRef t_string;
     MCAutoStringRef t_normalized_source;
     if (p_match_key)
         t_string = MCNameGetString(p_key);
@@ -131,11 +131,11 @@ bool MCRegexMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key
         if (!MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element))
             return false;
         
-        if (!ctxt . ConvertToString(t_element, t_string))
+        if (!ctxt . ConvertToString(t_element, &t_string))
             return false;
     }
         
-    MCStringNormalizedCopyNFC(t_string, &t_normalized_source);
+    MCStringNormalizedCopyNFC(*t_string, &t_normalized_source);
     return MCR_exec(m_compiled, *t_normalized_source, MCRangeMake(0, MCStringGetLength(*t_normalized_source)));
 }
 
@@ -293,7 +293,7 @@ bool MCWildcardMatcher::match(MCRange p_source_range)
 
 bool MCWildcardMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_key)
 {
-    MCStringRef t_string;
+    MCAutoStringRef t_string;
     if (p_match_key)
         t_string = MCNameGetString(p_key);
     else
@@ -301,9 +301,9 @@ bool MCWildcardMatcher::match(MCExecContext ctxt, MCNameRef p_key, bool p_match_
         MCValueRef t_element;
         if (!MCArrayFetchValue(m_array_source, m_options == kMCStringOptionCompareCaseless, p_key, t_element))
             return false;
-        if (!ctxt . ConvertToString(t_element, t_string))
+        if (!ctxt . ConvertToString(t_element, &t_string))
             return false;
     }
     
-    return MCStringWildcardMatch(t_string, MCRangeMake(0, MCStringGetLength(t_string)), m_pattern, m_options);
+    return MCStringWildcardMatch(*t_string, MCRangeMake(0, MCStringGetLength(*t_string)), m_pattern, m_options);
 }


### PR DESCRIPTION
This patch fixes a memory leak which occurs when using the elements
form of the filter command.

The leak was caused by failing to release converted element values
after use. It has been fixed by using an auto-class to hold the
string values being matched against in the wildcard and pattern
matching classes.