### PR TITLE
[[ Bug 21997 ]] Fix memory leak in MCStringSplitByDelimiter

### DIFF
--- a/docs/notes/bugfix-21997.md
+++ b/docs/notes/bugfix-21997.md
@@ -1,0 +1,2 @@
+# Fix memory leaks when splitting strings in specific cases
+


### PR DESCRIPTION
This patch fixes a memory leak of the split values in the internal
function MCStringSplitByDelimiter.

The leak occurs because the split values are stored in an
MCAutoArray<MCValueRef> and then copied into a properlist, without
releasing the original values.

The leak has been fixed by switching to use an MCAutoStringRefArray
class and its TakeAsProperList method.