### PR TITLE
[[ Bug 21999 ]] Fix memory leak when converting strings to numbers

### DIFF
--- a/docs/notes/bugfix-21999.md
+++ b/docs/notes/bugfix-21999.md
@@ -1,0 +1,1 @@
+# Fix memory leak when converting strings to numbers

--- a/engine/src/exec.cpp
+++ b/engine/src/exec.cpp
@@ -3548,11 +3548,13 @@ void MCExecTypeConvertAndReleaseAlways(MCExecContext& ctxt, MCExecValueType p_fr
         else if (p_from_type == kMCExecValueTypeStringRef)
         {
             MCExecTypeConvertStringToNumber(ctxt, *(MCStringRef*)p_from_value, p_to_type, p_to_value);
+            MCValueRelease(*(MCStringRef*)p_from_value);
             return;
         }
         else if (p_from_type == kMCExecValueTypeNameRef)
         {
             MCExecTypeConvertStringToNumber(ctxt, MCNameGetString(*(MCNameRef*)p_from_value), p_to_type, p_to_value);
+            MCValueRelease(*(MCNameRef*)p_from_value);
             return;
         }
     }


### PR DESCRIPTION
This patch fixes a memory leak which occurs when converting a string or
name value to a number value. The leak was caused due to failing to release
the source string (or name) value in the optimized code paths for that case
in MCExecTypeConvertAndReleaseAlways.