### PR TITLE
[[ Bug 22000 ]] Fix memory leak when parsing save with format

### DIFF
--- a/docs/notes/bugfix-22000.md
+++ b/docs/notes/bugfix-22000.md
@@ -1,0 +1,1 @@
+# Fix memory leak when parsing save with format

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1112,6 +1112,7 @@ MCSave::~MCSave()
 {
 	delete target;
 	delete filename;
+    delete format;
 }
 
 Parse_stat MCSave::parse(MCScriptPoint &sp)


### PR DESCRIPTION
This patch fixes a memory leak which occurs when parsing the
'with format' form of the save command. The leak was caused
by a failure to delete the 'format' expression in the MCSave
command's syntax node destructor.