### PR TITLE
[[ Bug 22001 ]] Fix memory leak when using import eps

### DIFF
--- a/docs/notes/bugfix-22001.md
+++ b/docs/notes/bugfix-22001.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using import eps command


### PR DESCRIPTION
This patch fixes a memory leak which occurred when using the
import eps command. The leak was caused by a failure to close
an open IO_handle. The problem has been fixed by restructuring
the command implementation to ensure that the handle is always
closed if it was successfully opened.