### PR TITLE
[[ Bug 22002 ]] Fix memory leak when setting numberFormat

### DIFF
--- a/docs/notes/bugfix-22002.md
+++ b/docs/notes/bugfix-22002.md
@@ -1,0 +1,2 @@
+# Fix memory leak when setting numberFormat properties
+

--- a/engine/src/util.cpp
+++ b/engine/src/util.cpp
@@ -266,9 +266,9 @@ void MCU_setnumberformat(MCStringRef d, uint2 &fw,
                          uint2 &trailing, uint2 &force)
 {
 	fw = MCStringGetLength(d);
-    char *temp_d;
-    /* UNCHECKED */ MCStringConvertToCString(d, temp_d);
-	const char *sptr = temp_d;
+    MCAutoPointer<char> temp_d;
+    /* UNCHECKED */ MCStringConvertToCString(d, &temp_d);
+	const char *sptr = *temp_d;
 	const char *eptr = sptr;
 	while (eptr - sptr < fw && *eptr != '.')
 		eptr++;


### PR DESCRIPTION
This patch fixes a memory leak which occurs as a result of setting
the numberFormat property (either local or scrollbar). The leak was
caused by failing to free the temporary c-string which is used to
parse the number format details. It has been fixed by using an
MCAutoPointer auto-class.