### PR TITLE
[[ Bug 22003 ]] Fix memory leaks when fetching revScriptDescription

### DIFF
--- a/docs/notes/bugfix-22003.md
+++ b/docs/notes/bugfix-22003.md
@@ -1,0 +1,1 @@
+# Fix memory leaks occurring through the use of autocomplete in the IDE


### PR DESCRIPTION
This patch fixes memory leaks which can occur when fetching the
revScriptDescription (internal) object property. The leaks were
caused by assigning an value-ref with a +1 retain count to an
auto-class rather than using Give.