### PR TITLE
[[ Bug 22004 ]] Fix memory leak when configuring syntax highlighting

### DIFF
--- a/docs/notes/bugfix-22004.md
+++ b/docs/notes/bugfix-22004.md
@@ -1,0 +1,1 @@
+# Fix memory leak when configuring syntax hightlighting in the script editor

--- a/engine/src/ide.cpp
+++ b/engine/src/ide.cpp
@@ -534,8 +534,8 @@ void MCIdeScriptConfigure::exec_ctxt(MCExecContext &ctxt)
                 MCNewAutoNameRef t_attr_key;
                 MCAutoStringRef t_attr_value;
 
-                MCStringFormat(t_attr_key_string, "%s attributes", s_script_keywords[t_keyword]);
-                MCNameCreate(t_attr_key_string, &t_attr_key);
+                /* UNCHECKED */ MCStringFormat(t_attr_key_string, "%s attributes", s_script_keywords[t_keyword]);
+                /* UNCHECKED */ MCNameCreateAndRelease(t_attr_key_string, &t_attr_key);
 
                 if (ctxt . CopyOptElementAsString(*t_settings, *t_attr_key, false, &t_attr_value))
                 {


### PR DESCRIPTION
This patch fixes a memory leak in the internal 'ide script configure'
command, caused by a failure to release a string used to create a name
value. The issue has been fixed by using the AndRelease form of
MCNameCreate.