### PR TITLE
[[ Bug 22006 ]] Fix memory leaks when using player on macOS

### DIFF
--- a/docs/notes/bugfix-22006.md
+++ b/docs/notes/bugfix-22006.md
@@ -1,0 +1,1 @@
+# Fix memory leaks when using player on macOS


### PR DESCRIPTION
This patch fixes some memory leaks which can occur when using the
player control on macOS. The leaks appear to be caused by a combination
of failing to break the link between the AVPlayerLayer and AVPlayer when
the view is deallocated and key-value observers which are attached
temporarily to enable status information to be gathered not being
removed properly.