### PR TITLE
[[ Bug 22007 ]] Fix memory leaks when using menus on macOS

### DIFF
--- a/docs/notes/bugfix-22007.md
+++ b/docs/notes/bugfix-22007.md
@@ -1,0 +1,1 @@
+# Fix memory leaks when using menus on macOS


### PR DESCRIPTION
This patch fixes potential leaks of NSMenuItem instances when setting
or updating the menubar on macOS. This is caused by failing to release
the previous instances of the items which need to be cached as the items
are moved into the system-managed menus.

Additionally, this patch resolves false-positives being reported by the
leaks tool caused by MCPlatformMenu and associated delegate pointers
being 'hidden' from the leaks tool when held only by the Cocoa NSMenu
instances. The problem has been resolved by storing the set of submenus
'owned' by an MCPlatformMenu instance in the MCPlatformMenu instance
itself.