### PR TITLE
[[ Bug 22009 ]] Fix memory leak when releasing LCB objects

### DIFF
--- a/docs/notes/bugfix-22009.md
+++ b/docs/notes/bugfix-22009.md
@@ -1,0 +1,1 @@
+# Fix memory leaks when releasing loaded LCB modules and instances

--- a/libfoundation/src/foundation-pickle.cpp
+++ b/libfoundation/src/foundation-pickle.cpp
@@ -978,6 +978,8 @@ static void MCPickleReleaseField(MCPickleFieldType p_kind, void *p_base_ptr, voi
                                 MCPickleRelease(t_info -> cases[t_case] . record, t_variant);
                                 break;
                             }
+                        
+                        free(t_variant);
                     }
                 }
                 free(*(void **)p_field_ptr);

--- a/libscript/src/script-object.cpp
+++ b/libscript/src/script-object.cpp
@@ -253,6 +253,8 @@ void MCScriptDestroyObject(MCScriptObject *self)
             __MCScriptAssert__(false, "invalid kind");
             break;
     }
+    
+    MCMemoryDeallocate(self);
 }
 
 MCScriptObject *MCScriptRetainObject(MCScriptObject *self)


### PR DESCRIPTION
This patch fixes memory leaks which can occur when releasing loaded
LCB modules and module instances. The leaks occur due to a failure
to free the base record of the objects and a failure to release some
parts of the loaded compiled module structure.