### PR TITLE
[[ Bug 22012 ]] Fix memory leak when using LCB's log command

### DIFF
--- a/docs/notes/bugfix-22012.md
+++ b/docs/notes/bugfix-22012.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using LCB's log command on desktop platforms

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -695,10 +695,10 @@ static void MCEventQueueDestroyEvent(MCEvent *p_event)
     {
         MCStackHandle(MCEventQueueGetEventStack(p_event)).ExternalRelease();
     }
-#ifdef _MOBILE
     else if (p_event -> type == kMCEventTypeCustom)
+    {
         p_event -> custom . event -> Destroy();
-#endif
+    }
     
     MCMemoryDelete(p_event);
 }


### PR DESCRIPTION
This patch fixes a memory leak which occurs when using the log
command in LCB. The leak was caused by a failure to destroy the
internal MCEngineLogChangedEvent instance after being processed.