### PR TITLE
[[ Bug 22013 ]] Fix memory leak when using LCB's send/post/execute

### DIFF
--- a/docs/notes/bugfix-22013.md
+++ b/docs/notes/bugfix-22013.md
@@ -1,0 +1,1 @@
+# Fix memory leak when using send/post/execute script from LCB

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -469,7 +469,11 @@ bool MCEngineConvertToScriptParameters(MCExecContext& ctxt, MCProperListRef p_ar
         
 		MCParameter *t_param;
 		t_param = new (nothrow) MCParameter;
+        
+        /* setvalueref_argument retains its argument so set then release the
+         * value */
 		t_param -> setvalueref_argument(t_value);
+        MCValueRelease(t_value);
         
 		if (t_last_param == nil)
 			&t_params = t_param;


### PR DESCRIPTION
This patch fixes a memory leak which can occur when using LCB's send, post
and execute script commands with an argument list. The leak was caused
by failing to release the argument values after setting the MCParameter
instance argument values (which retain their argument).