### PR TITLE
[[ Bug 22015 ]] Fix memory leak when bridging foreign values

### DIFF
--- a/docs/notes/bugfix-22015.md
+++ b/docs/notes/bugfix-22015.md
@@ -1,0 +1,1 @@
+# Fix memory leak when bridging foreign values to LCS

--- a/engine/src/exec-extension.cpp
+++ b/engine/src/exec-extension.cpp
@@ -770,8 +770,8 @@ bool MCExtensionConvertToScriptType(MCExecContext& ctxt, MCValueRef& x_value)
                 MCValueRelease(t_imported);
                 return false;
             }
-
-            MCValueAssign(x_value, t_imported);
+            
+            MCValueAssignAndRelease(x_value, t_imported);
         }
         return true;
 


### PR DESCRIPTION
This patch fixes a memory leak when LCB's foreign values are
returned to LCS (either via library handlers, or widget
properties) and the foreign value successfully converts to an
LCS script value type. The leak was caused by a failure to
release the 'imported' foreign value instance correctly.