### PR TITLE
[[ Bug 22016 ]] Fix memory leak when setting widget properties

### DIFF
--- a/docs/notes/bugfix-22016.md
+++ b/docs/notes/bugfix-22016.md
@@ -1,0 +1,1 @@
+# Fix memory leak when setting widget properties in some cases

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -647,14 +647,9 @@ bool MCWidget::setcustomprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNameRe
         return MCObject::setcustomprop(ctxt, p_set_name, p_prop_name, p_path, p_value);
     
     MCAutoValueRef t_value;
-    if (MCExecTypeIsValueRef(p_value . type))
-        t_value = p_value . valueref_value;
-    else
-    {
-        MCExecTypeConvertToValueRefAndReleaseAlways(ctxt, p_value.type, &p_value.valueref_value, Out(t_value));
-        if (ctxt . HasError())
-            return false;
-    }
+    MCExecTypeConvertToValueRefAndReleaseAlways(ctxt, p_value.type, &p_value.valueref_value, Out(t_value));
+    if (ctxt . HasError())
+        return false;
     
     MCTypeInfoRef t_get_type, t_set_type;
     if (p_path != nil)


### PR DESCRIPTION
This patch fixes a memory leak which can occur when setting a
widget property. The leak occurs when the incoming value is
already a value-ref, in which case the MCWidget::setcustomprop
method retains it, rather than taking the existing reference
that it has been given.