### PR TITLE
[[ Bug 22017 ]] Fix memory leak when updating listBehavior fields

### DIFF
--- a/docs/notes/bugfix-22017.md
+++ b/docs/notes/bugfix-22017.md
@@ -1,0 +1,1 @@
+# Fix memory leak when updating listBehavior fields in some cases

--- a/engine/src/field.h
+++ b/engine/src/field.h
@@ -457,7 +457,7 @@ public:
     
 	Exec_stat seltext(findex_t si, findex_t ei, Boolean focus, Boolean update = False);
 	uint2 hilitedline();
-	void hilitedlines(vector_t<uint32_t> &r_lines);
+    void hilitedlines(MCAutoArray<uint32_t>& r_lines);
 	Exec_stat sethilitedlines(const uint32_t *p_lines, uint32_t p_line_count, Boolean forcescroll = True);
 	void hiliteline(int2 x, int2 y);
 

--- a/engine/src/fieldf.cpp
+++ b/engine/src/fieldf.cpp
@@ -337,9 +337,8 @@ void MCField::resetparagraphs()
 	findex_t si = 0;
 	findex_t ei = 0;
 
-    vector_t<uint32_t> t_lines;
-    t_lines . elements = nil;
-    t_lines . count = 0;
+    MCAutoArray<uint32_t> t_lines;
+    
 	// MW-2005-05-13: [[Fix bug 2766]] We always need to retrieve the hilitedLines
 	//   to prevent phantom selections w.r.t. focused paragraph.
 	if (flags & F_LIST_BEHAVIOR)
@@ -347,13 +346,6 @@ void MCField::resetparagraphs()
 
 	if (MCactivefield == this && focusedparagraph != NULL)
 	{
-		// TS-2005-01-06: Fix for bug 2381
-		//   A) get old hilites lines
-		//   B) clear current hilites line, useless now, but may actually do something
-		//      in the future
-		if (flags & F_LIST_BEHAVIOR)
-            hilitedlines(t_lines);
-        
 		selectedmark(False, si, ei, True);
 		if (flags & F_LIST_BEHAVIOR)
 			sethilitedlines(NULL, 0);
@@ -373,9 +365,9 @@ void MCField::resetparagraphs()
 	// MW-2005-01-28: Correct small integration error, != instead of ==
 	if ((flags & F_LIST_BEHAVIOR) != 0)
 	{
-		if (t_lines . elements != nil)
+		if (t_lines.Ptr() != nil)
         {
-			sethilitedlines(t_lines . elements, t_lines . count, False);
+			sethilitedlines(t_lines.Ptr(), t_lines.Size(), False);
         }
 	}
 	else if (ei != 0)

--- a/engine/src/fields.cpp
+++ b/engine/src/fields.cpp
@@ -996,16 +996,12 @@ uint2 MCField::hilitedline()
 	return line;
 }
 
-void MCField::hilitedlines(vector_t<uint32_t> &r_lines)
+void MCField::hilitedlines(MCAutoArray<uint32_t>& r_lines)
 {
-    if (r_lines.elements != nil)
-        delete r_lines.elements;
-    if (r_lines.count != 0)
-        r_lines.count = 0;;
 	if (!opened || !(flags & F_LIST_BEHAVIOR))
 		return;
+    
 	uinteger_t line = 0;
-    MCAutoArray<uint32_t> t_lines;
 
 	MCParagraph *pgptr = paragraphs;
 	do
@@ -1013,13 +1009,11 @@ void MCField::hilitedlines(vector_t<uint32_t> &r_lines)
 		line++;
 		if (pgptr->gethilite())
 		{
-            /* UNCHECKED */ t_lines . Push(line);
+            /* UNCHECKED */ r_lines . Push(line);
 		}
 		pgptr = pgptr->next();
 	}
 	while (pgptr != paragraphs);
-    
-    t_lines . Take(r_lines . elements, r_lines . count);
 }
 
 Exec_stat MCField::sethilitedlines(const uint32_t *p_lines, uint32_t p_line_count, Boolean forcescroll)

--- a/tests/lcs/core/field/listBehavior.livecodescript
+++ b/tests/lcs/core/field/listBehavior.livecodescript
@@ -1,0 +1,50 @@
+script "CoreFieldListBehavior"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+on TestListBehaviorHilitedLines
+	/* the hilitedLines of a field only work if the field is open so open
+	 * this stack */
+	go this stack
+
+	reset the templateField
+	create field "Test"
+	set the dontWrap of field "Test" to true
+	set the autoHilite of field "Test" to true
+	set the listBehavior of field "Test" to true
+	set the nonContiguousHilites of field "Test" to true
+	set the multipleHilites of field "Test" to true
+	set the text of field "Test" to format("first\nsecond\nthird\nfourth\nfifth")
+
+	TestAssert "hilitedLines start empty", the hilitedLines of field "Test" is empty
+
+	set the hilitedLines of field "Test" to "2,4"
+	TestAssert "hilitedLines roundtrip", the hilitedLines of field "Test" is "2,4"
+
+	set the width of field "Test" to the width of field "Test" * 2
+	set the hilitedLines of field "Test" to "2,4"
+	TestAssert "hilitedLines survive field resize", the hilitedLines of field "Test" is "2,4"
+
+	set the hilitedLines of field "Test" to "2,4"
+	focus on field "Test"
+	focus on nothing
+	TestAssert "hilitedLines survive focus out", the hilitedLines of field "Test" is "2,4"
+
+	set the hilitedLines of field "Test" to "2,4"
+	focus on field "Test"
+	TestAssert "hilitedLines survive focus in", the hilitedLines of field "Test" is "2,4"
+end TestListBehaviorHilitedLines


### PR DESCRIPTION
This patch fixes a memory leak which can occur when updating listBehavior
fields in some cases. The leak was caused by failing to release the saved
set of previously hilited lines after re-applying them. It has been fixed
by passing a reference to an appropriate auto-class around, rather than
bare pointers.