### PR TITLE
[[ Bug 22019 ]] Fix several memory leaks in the field object

### DIFF
--- a/docs/notes/bugfix-22019.md
+++ b/docs/notes/bugfix-22019.md
@@ -1,0 +1,1 @@
+# Fix several memory leaks occurring in use of specific field features

--- a/engine/src/exec-interface-field-chunk.cpp
+++ b/engine/src/exec-interface-field-chunk.cpp
@@ -294,13 +294,21 @@ template <>
 struct PodFieldPropType<MCInterfaceFieldTabAlignments>
 {
     typedef MCInterfaceFieldTabAlignments value_type;
-    typedef MCInterfaceFieldTabAlignments stack_type;
+    struct stack_type
+    {
+        MCInterfaceFieldTabAlignments alignments;
+        ~stack_type()
+        {
+            if (alignments.m_alignments != nil)
+                MCMemoryDeallocate(alignments.m_alignments);
+        }
+    };
     typedef MCInterfaceFieldTabAlignments return_type;
     typedef const MCInterfaceFieldTabAlignments& arg_type;
     
-    template<typename X> static void getter(MCExecContext& ctxt, X *sptr, void (X::*p_getter)(MCExecContext& ctxt, return_type&), return_type& r_value)
+    template<typename X> static void getter(MCExecContext& ctxt, X *sptr, void (X::*p_getter)(MCExecContext& ctxt, return_type&), stack_type& r_value)
     {
-        (sptr ->* p_getter)(ctxt, r_value);
+        (sptr ->* p_getter)(ctxt, r_value.alignments);
     }
     
     template<typename X> static void setter(MCExecContext &ctxt, X *sptr, void (X::*p_setter)(MCExecContext& ctxt, arg_type), arg_type p_value)
@@ -308,21 +316,21 @@ struct PodFieldPropType<MCInterfaceFieldTabAlignments>
         (sptr ->* p_setter)(ctxt, p_value);
     }
     
-    static void init(MCInterfaceFieldTabAlignments& self)
+    static void init(stack_type& self)
     {
-        self . m_count = 0;
-        self . m_alignments = 0;
+        self.alignments.m_count = 0;
+        self.alignments.m_alignments = 0;
     }
     
     static void input(value_type p_value, stack_type& r_value)
     {
-        r_value = p_value;
+        r_value.alignments = p_value;
     }
     
     static bool equal(const stack_type& a, const stack_type& b)
     {
-        return (a . m_count == b . m_count
-                && MCMemoryCompare(a . m_alignments, b . m_alignments, a . m_count * sizeof(intenum_t)) == 0);
+        return (a.alignments.m_count == b.alignments.m_count
+                && MCMemoryCompare(a.alignments.m_alignments, b.alignments.m_alignments, a.alignments.m_count * sizeof(intenum_t)) == 0);
     }
     
     //static void assign(stack_type& x, stack_type y)
@@ -330,9 +338,10 @@ struct PodFieldPropType<MCInterfaceFieldTabAlignments>
     //    x = y;
     //}
     
-    static void output(stack_type p_value, return_type& r_value)
+    static void output(stack_type& p_value, return_type& r_value)
     {
-        r_value = p_value;
+        r_value = p_value.alignments;
+        p_value.alignments.m_alignments = nil;
     }
     
     static bool need_layout()
@@ -340,9 +349,9 @@ struct PodFieldPropType<MCInterfaceFieldTabAlignments>
         return true;
     }
     
-    static bool is_set(const MCInterfaceFieldTabAlignments& p_alignments)
+    static bool is_set(stack_type& p_alignments)
     {
-        return p_alignments.m_alignments != nil;
+        return p_alignments.alignments.m_alignments != nil;
     }
 };
 

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -375,6 +375,8 @@ MCField::~MCField()
 		delete vscrollbar;
 
 	delete[] tabs; /* Allocated with new[] */
+    
+    MCMemoryDeallocate(alignments);
 
 	MCValueRelease(label);
 }

--- a/engine/src/fieldhtml.cpp
+++ b/engine/src/fieldhtml.cpp
@@ -2200,6 +2200,7 @@ MCParagraph *MCField::importhtmltext(MCValueRef p_text)
                                 import_html_parse_paragraph_attrs(t_tag, t_style);
                                 import_html_begin(ctxt, &t_style);
                                 delete t_style . tabs;
+                                delete t_style.tab_alignments;
                                 MCValueRelease(t_style . metadata);
                             }
                         }

--- a/engine/src/fieldstyledtext.cpp
+++ b/engine/src/fieldstyledtext.cpp
@@ -391,8 +391,10 @@ bool MCField::exportasstyledtext(MCParagraph* p_paragraphs, int32_t p_start_inde
 			t_flags |= kMCFieldExportLines;
 		doexport(t_flags, p_paragraphs, p_start_index, p_finish_index, export_styled_text, &t_context);
 
-		if (MCArrayCopy(t_context . paragraphs_array, r_array))
+		if (MCArrayCopyAndRelease(t_context . paragraphs_array, r_array))
 			return true;
+        
+        MCValueRelease(t_context.paragraphs_array);
 	}
 
 	return false;

--- a/tests/lcs/core/field/line-properties.livecodescript
+++ b/tests/lcs/core/field/line-properties.livecodescript
@@ -1,0 +1,193 @@
+script "CoreFieldLineProperties"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+local sTests
+
+on TestSetup
+	_AddTest true, "textAlign", "center", "right"
+	_AddTest false, "listStyle", "square", "circle"
+	_AddTest false, "listDepth", "5", "10"
+	_AddTest true, "vGrid", "true", "false"
+	_AddTest true, "hGrid", "true", "false"
+	_AddTest true, "dontWrap", "true", "false"
+	_AddTest false, "borderWidth", "5", "10"
+	_AddTest true, "firstIndent", "5", "10"
+	_AddTest false, "leftIndent", "5", "10"
+	_AddTest false, "rightIndent", "5", "10"
+	_AddTest false, "spaceAbove", "5", "10"
+	_AddTest false, "spaceBelow", "5", "10"
+	_AddTest true, "tabStops", "100", "200"
+	_AddTest true, "tabWidths", "100", "200"
+	_AddTest true, "tabAlign", "center", "right"
+	_AddTest false, "listIndex", "10", "20"
+	_AddTest false, "backgroundColor", "255,0,0", "0,0,255"
+	_AddTest false, "borderColor", "255,0,0", "0,0,255"
+end TestSetup
+
+private command _AddTest pFieldAndLine, pProp, pValue1, pValue2
+	local tTest
+	put pFieldAndLine into tTest["effective"]
+	put pProp into tTest["property"]
+	put pValue1 into tTest["value-1"]
+	put pValue2 into tTest["value-2"]
+	put tTest into sTests[the number of elements in sTests + 1]
+end _AddTest
+
+on TestEqualLineProperties
+	repeat for each element tTest in sTests
+		_TestEqualLineProperty tTest["property"], tTest["value-1"]
+	end repeat
+
+	/* metadata can't be mixed so handle separately */
+	_TestEqualLineProperty "metadata", "foo"
+end TestEqualLineProperties
+
+private command _TestEqualLineProperty pProp, pValue
+	create field "Test"
+
+	repeat with tExtra = 0 to 4
+		local tValid
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			set the text of field "Test" to format("first\nsecond\nthird\nfourth\nfifth")
+			set the pProp of line tStart to tStart + tExtra of field "Test" to pValue
+			if the pProp of line tStart to tStart + tExtra of field "Test" is pValue then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip equal %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+	end repeat
+
+	delete field "Test"
+end _TestEqualLineProperty
+
+on TestEqualEffectiveLineProperties
+	repeat for each element tTest in sTests
+		if not tTest["effective"] then
+			next repeat
+		end if
+		_TestEqualEffectiveLineProperties tTest["property"], tTest["value-1"]
+	end repeat
+end TestEqualEffectiveLineProperties
+
+on _TestEqualEffectiveLineProperties pProp, pValue
+	create field "Test"
+
+	set the pProp of field "Test" to pValue
+	set the text of field "Test" to format("first\nsecond\nthird\nfourth\nfifth")
+	repeat with i = 1 to 5
+		if (i mod 2) is 1 then
+			set the pProp of line i of field "Test" to pValue
+		end if
+	end repeat
+
+	repeat with tExtra = 1 to 4
+		local tValid
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			if the effective pProp of line tStart to tStart + tExtra of field "Test" is pValue then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip effective equal %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			if the pProp of line tStart to tStart + tExtra of field "Test" is "mixed" then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip non-effective equal %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+	end repeat
+
+	delete field "Test"
+end _TestEqualEffectiveLineProperties
+
+on TestMixedLineProperties
+	repeat for each element tTest in sTests
+		_TestMixedLineProperty tTest["property"], tTest["value-1"], tTest["value-2"]
+	end repeat
+end TestMixedLineProperties
+
+private command _TestMixedLineProperty pProp, pValue1, pValue2
+	create field "Test"
+
+	set the text of field "Test" to format("first\nsecond\nthird\nfourth\nfifth")
+	repeat with i = 1 to 5
+		if (i mod 2) is 1 then
+			set the pProp of line i of field "Test" to pValue1
+		else
+			set the pProp of line i of field "Test" to pValue2
+		end if
+	end repeat
+
+	repeat with tExtra = 1 to 4
+		local tValid
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			if the pProp of line tStart to tStart + tExtra of field "Test" is "mixed" then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip mixed %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+	end repeat
+
+	delete field "Test"
+end _TestMixedLineProperty
+
+on TestMixedEffectiveLineProperties
+	repeat for each element tTest in sTests
+		if not tTest["effective"] then
+			next repeat
+		end if
+		_TestMixedEffectiveLineProperties tTest["property"], tTest["value-1"], tTest["value-2"]
+	end repeat
+end TestMixedEffectiveLineProperties
+
+on _TestMixedEffectiveLineProperties pProp, pValue1, pValue2
+	create field "Test"
+
+	set the pProp of field "Test" to pValue2
+	set the text of field "Test" to format("first\nsecond\nthird\nfourth\nfifth")
+	repeat with i = 1 to 5
+		if (i mod 2) is 1 then
+			set the pProp of line i of field "Test" to pValue1
+		end if
+	end repeat
+
+	repeat with tExtra = 1 to 4
+		local tValid
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			if the effective pProp of line tStart to tStart + tExtra of field "Test" is "mixed" then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip effective mixed %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+
+		put 0 into tValid
+		repeat with tStart = 1 to 5 - tExtra
+			if the pProp of line tStart to tStart + tExtra of field "Test" is "mixed" then
+				add 1 to tValid
+			end if
+		end repeat
+		TestAssert format("roundtrip non-effective mixed %s over %d lines", pProp, tExtra + 1), tValid is 5 - tExtra
+	end repeat
+
+	delete field "Test"
+end _TestMixedEffectiveLineProperties

--- a/tests/lcs/core/field/styledText.livecodescript
+++ b/tests/lcs/core/field/styledText.livecodescript
@@ -21,6 +21,36 @@ private function q pString
    return pString
 end q
 
+on TestParagraphTabStopsRoundtrip
+   create stack "Test"
+   set the defaultStack to "Test"
+
+   create field "TestField"
+   
+   // set up styledText array with text and tabAlign
+   local tStyledText
+   put "left" & tab & "center" & tab & "right" into tStyledText[1]["runs"][1]["text"]
+   put "100,200,300" into tStyledText[1]["style"]["tabStops"]
+   
+   set the styledText of field "TestField" to tStyledText
+   TestAssert "styledText supports tabStops", the tabStops of line 1 of field "TestField" is "100,200,300"
+   
+   put the styledText of field "testField" into tStyledText
+   TestAssert "styledText roundtrips tabStops", tStyledText[1]["style"]["tabStops"] is "100,200,300"
+
+   // clear field styles
+   set the text of field "testField" to "left" & tab & "center" & tab & "right"
+   set the tabStops of field "testField" to "10,20,30"
+
+   put the styledText of field "testField" into tStyledText
+   TestAssert "styledText doesn't include inherited tabStops", "tabStops" is not among the keys of tStyledText[1]["style"]
+   
+   put the effective styledText of field "testField" into tStyledText
+   TestAssert "effective styledText does include inherited tabStops", tStyledText[1]["style"]["tabStops"] is "10,20,30"
+   
+   delete stack "Test"
+end TestParagraphTabStopsRoundtrip
+
 on TestParagraphTabAlignRoundtrip
    create stack "Test"
    set the defaultStack to "Test"
@@ -44,7 +74,7 @@ on TestParagraphTabAlignRoundtrip
    set the tabAlign of field "testField" to "right,center,left"
 
    put the styledText of field "testField" into tStyledText
-   TestAssert "styledText doesn't include inherited tabAlign", tabAlign is not among the keys of tStyledText[1]["style"]
+   TestAssert "styledText doesn't include inherited tabAlign", "tabAlign" is not among the keys of tStyledText[1]["style"]
    
    put the effective styledText of field "testField" into tStyledText
    TestAssert "effective styledText does include inherited tabAlign", tStyledText[1]["style"]["tabAlign"] is "right,center,left"


### PR DESCRIPTION
This patch fixes four memory leaks caused by using field features.

The first leak which has been fixed occurred when a field object
had a field-level tabAlign setting. A failure to free the underlying
setting when the field was destroyed caused the leak.

The second leak which has been fixed occurred when fetching the
tabAlign property across multiple paragraphs. A failure to free
intermediate values used to compute whether the setting was mixed
or not caused the leak.

The third leak which has been fixed occurred when importing field
content with htmlText when the htmlText contained tabAlign settings.
A failure to free intermediate values used to compute the final
tabAlign settings caused the leak.

The fourth leak which has been fixed occurred when fetching the
styledText representation of the field or a chunk of the field. An
over-retain of the returned array caused the leak.