### PR TITLE
[TreeView Widget] Set hilited item to empty fix

### DIFF
--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -2090,7 +2090,7 @@ private handler setSelectedElement(in pElement as String)
 			unfoldFullPath(element 1 to -2 of tPath)
 		end if
 		selectPath(tPath)
-	else
+	else if mSelectedElement is not nothing then
 		unselectPath(mSelectedElement)
 	end if
 end handler


### PR DESCRIPTION
Correct regression where setting the hilighted item to empty when 
nothing is selected caused the widget to throw an error (type mismatch).

PR #6764 