### PR TITLE
[[ Bug 22020 ]] Fix memory leak when dbsqlite connection fails

### DIFF
--- a/docs/notes/bugfix-22020.md
+++ b/docs/notes/bugfix-22020.md
@@ -1,0 +1,1 @@
+# Fix memory leak when dbsqlite connection fails


### PR DESCRIPTION
This patch fixes a memory leak when opening a dbsqlite connection
fails.

See the corresponding patch in the thirdparty submodule for
details - https://github.com/livecode/livecode-thirdparty/pull/129.