### PR TITLE
[[ NO MERGE - CI ]] Hacks to run tests through leak checking on macOS

### DIFF
--- a/libfoundation/src/foundation-value.cpp
+++ b/libfoundation/src/foundation-value.cpp
@@ -539,6 +539,8 @@ bool __MCValueCreate(MCValueTypeCode p_type_code, size_t p_size, __MCValue*& r_v
 {
 	void *t_value;
 	
+#if 0
+    
     // MW-2014-03-21: [[ Faster ]] If we are pooling this typecode, and the
     //   pool isn't empty grab the ptr from there.
     if (p_type_code <= kMCValueTypeCodeList && s_value_pools[p_type_code] . count > 0)
@@ -565,6 +567,7 @@ bool __MCValueCreate(MCValueTypeCode p_type_code, size_t p_size, __MCValue*& r_v
         MCMemoryClear(t_value, p_size);
 	}
     else
+#endif
     {
         // The minimum size of a valueref has to be sizeof(MCValuePoolLink).
         // This is to ensure we have enough space to chain in the free list.
@@ -665,6 +668,8 @@ void __MCValueDestroy(__MCValue *self)
 	self -> flags = UINT32_MAX;
 #endif
 
+#if 0
+    
     // MW-2014-03-21: [[ Faster ]] If we are pooling this typecode, and the
     //   pool isn't full, add it to the pool.
     if (t_code <= kMCValueTypeCodeList && s_value_pools[t_code] . count < 32)
@@ -695,6 +700,8 @@ void __MCValueDestroy(__MCValue *self)
 
 		return;
     }
+    
+#endif
 	
 	MCMemoryDelete(self);
 }

--- a/libfoundation/src/system-library-posix.hpp
+++ b/libfoundation/src/system-library-posix.hpp
@@ -42,7 +42,7 @@ public:
     {
         if (m_handle == nullptr)
             return;
-        dlclose(m_handle);
+        //dlclose(m_handle);
     }
     
     bool IsDefined(void) const

--- a/tests/_testrunner.livecodescript
+++ b/tests/_testrunner.livecodescript
@@ -121,22 +121,38 @@ private command runTestCommand pInfo, pScriptFile, pCommand
 
    put "invoke" && pScriptFile && pCommand after tCommandLine
 
-   -- Invoke the test in a subprocess.  This ensures that we can detect
-   -- if a crash occurs
-   local tTestOutput, tTestExitStatus
-   put shell(tCommandLine) into tTestOutput
-   put the result into tTestExitStatus
-   
-   -- The output from the subprocesses will be native encoded utf-8.
-   put textDecode(tTestOutput, "utf8") into tTestOutput
+   local tAttemptCount
+   put 0 into tAttemptCount
+   repeat while tAttemptCount < 3
+      -- Invoke the test in a subprocess.  This ensures that we can detect
+      -- if a crash occurs
+      local tTestOutput, tTestExitStatus
+      put shell("MallocStackLogging=1 MallocScribble=1 leaks -quiet --atExit -- " & tCommandLine) into tTestOutput
+      put the result into tTestExitStatus
+      
+      -- The output from the subprocesses will be native encoded utf-8.
+      put textDecode(tTestOutput, "utf8") into tTestOutput
 
-   -- Check the exit status.  If it suggests failure, add a "not ok" stanza
-   -- to the tail of the TAP output
-   if tTestExitStatus is not empty then
-      put return after tTestOutput
-      put "not ok # Subprocess exited with status" && \
-            tTestExitStatus & return after tTestOutput
-   end if
+      put "#" && tCommandLine & return before tTestOutput
+
+      -- Check the exit status.  If it suggests failure, add a "not ok" stanza
+      -- to the tail of the TAP output
+      if tTestExitStatus is not empty then
+         if the number of lines in tTestOutput > 5000 and \
+               (tTestOutput contains "NSMethodSignature" or \
+                  tTestOutput contains "block_invoke") then
+            add 1 to tAttemptCount
+            next repeat
+         end if
+
+         put return after tTestOutput
+         put "not ok # Subprocess exited with status" && \
+               tTestExitStatus & return after tTestOutput
+         exit repeat
+      else
+         exit repeat
+      end if
+   end repeat
 
    TestRunnerProcessOutput pScriptFile, pCommand, tTestOutput
    return the result


### PR DESCRIPTION
This patch contains some hacks which enables running the test
suite through the macOS leaks tool.

The use of 'value pools' in libfoundation is disabled so that
the stacktrace information generated by the leak checker is useful
(that being said, this is only useful when using the Xcode memory
graph features - for just detecting whether there are leaks or not,
it makes no difference at all).

The closing of shared library handles which have been opened with
dlopen has been disabled so that leaks can be traced in externals
and thirdparty loaded library (again this is probably only germaine
when needing stacktraces to analyze, i.e. through Xcode).

Finally the testrunner has been modified to run each individual test
through leaks, with a leaks failure causing a test failure. There is
some attempt at mitigation of false-positives caused by some
pseudo-non-determinism in the leaks '--atExit' option. Sometimes
a test which does not leak will come back with 1000's of leaks all
over the place; presumably because something system related has
caused disruption of the at-exit leak checking process.