### PR TITLE
[[ Bug 22024 ]] Fix LCB's 'is among the elements of' operator

### DIFF
--- a/docs/notes/bugfix-22024.md
+++ b/docs/notes/bugfix-22024.md
@@ -1,0 +1,1 @@
+# Fix LCB's 'is among the elements of' when searching for array elements

--- a/libfoundation/src/foundation-array.cpp
+++ b/libfoundation/src/foundation-array.cpp
@@ -728,7 +728,8 @@ bool __MCArrayIsEqualTo(__MCArray *self, __MCArray *other_self)
 			return false;
 
 		// Otherwise, they are only equal if the values are the same.
-		if (t_contents -> key_values[i] . value != t_other_contents -> key_values[t_slot] . value)
+		if (!MCValueIsEqualTo((MCValueRef)t_contents -> key_values[i] . value,
+                              (MCValueRef)t_other_contents -> key_values[t_slot] . value))
 			return false;
 
 		// We've compared one more key, so used count goes down.

--- a/tests/lcb/stdlib/array.lcb
+++ b/tests/lcb/stdlib/array.lcb
@@ -26,4 +26,18 @@ public handler TestSubscriptPrecedence()
 	test "subscript (_ ends with)" when tArray["bar"] ends with "o"
 end handler
 
+public handler TestIsAmongTheElementsOf()
+	/* Non-const variants of in element searches are required to ensure
+	 * it isn't just pointer equality which is occurring (LCB uniques all 
+	 * constants so the same constant has the same pointer). */
+
+	variable tArray
+	put {"a": "x", "b": 1, "c": true, "d": { "e": [2] } } into tArray
+	test "element is among the elements of" when "x" is among the elements of tArray
+	test "element is among the elements of (non-const)" when ("x" & "") is among the elements of tArray
+	test "array element is among the elements of" when { "e": [2] } is among the elements of tArray
+	test "array element is among the elements of (non-const)" when { "e": [1 + 1] } is among the elements of tArray
+	test "array element is not among the elements of" when not { "e": [1] } is among the elements of tArray
+end handler
+
 end module


### PR DESCRIPTION
This patch fixes an issue with LCB's 'is among the elements of'
operator which causes it to return the wrong result when searching
for an array in another array.

The issue was caused by the internal __MCArrayIsEqualTo method
only using pointer equivalence to check for element equality
rather than MCValueIsEqualTo.

Additionally an explicit test for 'is among the elements of' has
been added to the array test file.