### PR TITLE
[[ AccelRender ]] Add container layer modes

### DIFF
--- a/docs/dictionary/property/layerMode.lcdoc
+++ b/docs/dictionary/property/layerMode.lcdoc
@@ -40,6 +40,10 @@ A string specifying the mode of the object.
 -   scrolling: Applies to groups only and is used where the group
     contains contents to scroll. The group must be unadorned or the
     layerMode is set to 'dynamic' (no borders, no scrollbars).
+-   container: Applies to groups only and is used where the group
+    is intended only to organise or restrict the visible area of
+    its contents. The group must be unadorned or the
+    layerMode is set to 'dynamic' (no borders, no scrollbars).
 
 
 Description:
@@ -58,6 +62,8 @@ object with a non-copy/blendSrcOver ink set - effective layerMode is set
 to 'dynamic'. 
 3. You have a scrolling <layerMode> on a non-group or an
 adorned group - effective layerMode is set to 'dynamic'.
+4. You have a container <layerMode> on a non-group or an
+adorned or opaque group - effective layerMode is set to 'static'.
 
 **Scrolling**
 
@@ -66,6 +72,16 @@ caches the content of the group unclipped, and then renders the cached
 copies clipped; instead of caching the visible portion of the group.
 This results in fast updates when setting the scroll properties of a
 group. 
+
+**Container**
+The container layerMode is pertinent to groups. When a group has its
+layerMode set to 'container', and all its ancestor groups (if any) have
+their layerMode set to 'container', the engine ignores the group for the
+purposes of accelerated rendering, allowing objects within the group to
+have 'static', 'dynamic' or 'scrolling' layerModes; e.g. an image with
+'dynamic' layerMode inside a group will behave the same as if it were a
+top-level object with 'dynamic' layerMode *except* it will be clipped by
+the rect of its owning group.
 
 **Static vs Dynamic**
 

--- a/docs/notes/feature-container_layermode
+++ b/docs/notes/feature-container_layermode
@@ -1,0 +1,13 @@
+# New container layer mode
+
+Container layer mode support has been added to the accelerated
+rendering architecture.
+
+The container layer mode only has an effect on unadorned groups
+whose ancestors are also container layer mode unadorned groups.
+
+A container layer mode group provides a container for static and
+dynamic layers, allowing nested groups to also benefit from
+being cached for fast re-rendering.
+
+For more information, see the **layerMode** entry in the dictionary.

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -2557,8 +2557,7 @@ void MCCard::erasefocus(MCObject *p_object)
 
 MCObjptr *MCCard::newcontrol(MCControl *cptr, Boolean needredraw)
 {
-	if (opened)
-		cptr->setparent(this);
+	cptr->setparent(this);
 
 	MCObjptr *newptr = new (nothrow) MCObjptr;
 	newptr->setparent(this);

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -241,7 +241,9 @@ public:
 	void layer_setviewport(int32_t x, int32_t y, int32_t width, int32_t height);
 
 	// MW-2011-08-26: [[ TileCache ]] Render all layers into the stack's tilecache.
-	void render(void);
+    void render(void);
+    void render_control(MCTileCacheRef p_tiler, MCControl *p_control, const MCRectangle& p_visible_rect, const MCGAffineTransform& p_transform, bool p_parent_is_container);
+    void render_control_reset_ids(MCControl *p_control);
 
 	// IM-2013-09-13: [[ RefactorGraphics ]] add tilecache_ prefix to render methods to make their purpose clearer
 	// MW-2011-09-23: [[ TileCache ]] Render the card's bg layer.

--- a/engine/src/card.h
+++ b/engine/src/card.h
@@ -234,9 +234,9 @@ public:
 	// MW-2011-08-19: [[ Layers ]] Dirty the given rect of the viewport.
 	void layer_dirtyrect(const MCRectangle& dirty_rect);
 	// MW-2011-08-19: [[ Layers ]] A layer has been added to the card.
-	void layer_added(MCControl *control, MCObjptr *previous, MCObjptr *next);
+	void layer_added(MCControl *control, MCControl *previous, MCControl *next);
 	// MW-2011-08-19: [[ Layers ]] A layer has been removed from the card.
-	void layer_removed(MCControl *control, MCObjptr *previous, MCObjptr *next);
+	void layer_removed(MCControl *control, MCControl *previous, MCControl *next);
 	// MW-2011-08-19: [[ Layers ]] The viewport displayed in the stack has changed.
 	void layer_setviewport(int32_t x, int32_t y, int32_t width, int32_t height);
 
@@ -353,5 +353,13 @@ public:
     virtual void SetTextStyle(MCExecContext& ctxt, const MCInterfaceTextStyle& p_style);
     virtual void SetTheme(MCExecContext& ctxt, intenum_t p_theme);
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+// navigate controls by layer
+MCControl *MCControlPreviousByLayer(MCControl *p_control);
+MCControl *MCControlNextByLayer(MCControl *p_control);
+
+////////////////////////////////////////////////////////////////////////////////
 
 #endif

--- a/engine/src/exec-interface-control.cpp
+++ b/engine/src/exec-interface-control.cpp
@@ -321,14 +321,6 @@ void MCControl::SetLayerMode(MCExecContext& ctxt, intenum_t p_mode)
 
 	MCLayerModeHint t_mode = (MCLayerModeHint)p_mode;
 
-#if !NOT_YET_IMPLEMENTED
-	if (t_mode == kMCLayerModeHintContainer)
-	{
-		ctxt . LegacyThrow(EE_CONTROL_BADLAYERMODE);
-		return;
-	}
-#endif
-
 	// If the layer mode hint has changed, update and mark the attrs
 	// for recompute. If the hint hasn't changed, then there's no need
 	// to redraw.

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -257,7 +257,9 @@ public:
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is a sprite or not.
 	bool layer_issprite(void) { return m_layer_is_sprite; }
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is scrolling or not.
-	bool layer_isscrolling(void) { return m_layer_mode == kMCLayerModeHintScrolling; }
+    bool layer_isscrolling(void) { return m_layer_mode == kMCLayerModeHintScrolling; }
+    // MW-2011-09-21: [[ Layers ]] Returns whether the layer is a container or not.
+    bool layer_iscontainer(void) { return m_layer_mode == kMCLayerModeHintContainer; }
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is opaque or not.
 	bool layer_isopaque(void) { return m_layer_is_opaque; }
 

--- a/engine/src/tilecache.cpp
+++ b/engine/src/tilecache.cpp
@@ -1489,6 +1489,7 @@ void MCTileCacheEndFrame(MCTileCacheRef self)
 #ifdef _DEBUG
     MCLog("Frame - %d sprite tiles, %d scenery tiles, %d active tiles, %d instructions, %d bytes",
     			self -> sprite_render_list . length, self -> scenery_render_list . length, self -> active_tile_count, self -> display_list_frontier, self -> cache_size);
+    MCLog("      - %d tile count, %d sprite count, %d scenery count", self->tile_count, self->sprite_count, self->scenery_renderers_frontier);
 #endif
 }
 


### PR DESCRIPTION
This patch adds container layer mode support to the accelerated
rendering architecture.

The container layer mode only has an effect on unadorned groups
whose ancestors are also container layer mode unadorned groups.

A container layer mode group provides a container for static and
dynamic layers, allowing nested groups to also benefit from
being cached for fast re-rendering.