### PR TITLE
[[ Engine ]] Add 'layerClipRect' property to controls

### DIFF
--- a/docs/dictionary/property/layerClipRect.lcdoc
+++ b/docs/dictionary/property/layerClipRect.lcdoc
@@ -1,0 +1,38 @@
+Name: layerClipRect
+
+Type: property
+
+Syntax: set the layerClipRect of <control> to <rectangle>
+
+Summary:
+Specifies the visible area of a control
+
+Introduced: 9.5
+
+OS: mac, windows, linux, ios, android
+
+Platforms: desktop, server, mobile
+
+Example:
+// restrict visible region of image to a square in the top-left of the card
+set the layerClipRect of image "myImage" to 0,0,50,50
+
+Example:
+// Hide 10 pixels from the border of image "myImage"
+local tRect
+put the rect of image "myImage" into tRect
+add 10 to item 1 of tRect
+add 10 to item 2 of tRect
+subtract 10 from item 3 of tRect
+subtract 10 from item 4 of tRect
+set the layerClipRect of image "myImage" to tRect
+
+Parameters:
+<rectangle>:
+A rectangle in card coordinates.
+
+Description:
+Use the <layerClipRect> property to clip an object's display to a rectangle.
+The clipping rectangle only changes what part of the object is rendered,
+it has no effect on interaction; in particular, mouse events will still
+occur as they would without it being set.

--- a/docs/notes/feature-layercliprect.md
+++ b/docs/notes/feature-layercliprect.md
@@ -1,0 +1,8 @@
+# New layerClipRect control property
+
+A new property 'layerClipRect' has been added to all controls.
+
+Use the layerClipRect property to clip an object's display to a rectangle.
+The clipping rectangle only changes what part of the object is rendered,
+it has no effect on interaction; in particular, mouse events will still
+occur as they would without it being set.

--- a/engine/src/control.cpp
+++ b/engine/src/control.cpp
@@ -64,6 +64,7 @@ MCPropertyInfo MCControl::kProperties[] =
     DEFINE_RW_OBJ_CUSTOM_PROPERTY(P_MARGINS, InterfaceMargins, MCControl, Margins)
 	DEFINE_RW_OBJ_PROPERTY(P_TOOL_TIP, String, MCControl, ToolTip)
 	DEFINE_RW_OBJ_PROPERTY(P_UNICODE_TOOL_TIP, BinaryString, MCControl, UnicodeToolTip)
+    DEFINE_RW_OBJ_PROPERTY(P_LAYER_CLIP_RECT, OptionalRectangle, MCControl, LayerClipRect)
 	DEFINE_RW_OBJ_NON_EFFECTIVE_ENUM_PROPERTY(P_LAYER_MODE, InterfaceLayerMode, MCControl, LayerMode)
 	DEFINE_RO_OBJ_EFFECTIVE_ENUM_PROPERTY(P_LAYER_MODE, InterfaceLayerMode, MCControl, LayerMode)
     
@@ -100,6 +101,8 @@ MCControl::MCControl()
 	layer_resetattrs();
 	// MW-2011-09-21: [[ Layers ]] The layer starts off as static.
 	m_layer_mode_hint = kMCLayerModeHintStatic;
+    m_layer_has_clip_rect = false;
+    m_layer_clip_rect = kMCEmptyRectangle;
 }
 
 MCControl::MCControl(const MCControl &cref) : MCObject(cref)
@@ -122,6 +125,8 @@ MCControl::MCControl(const MCControl &cref) : MCObject(cref)
 	layer_resetattrs();
 	// MW-2011-09-21: [[ Layers ]] The layer takes its layer hint from the source.
 	m_layer_mode_hint = cref . m_layer_mode_hint;
+    m_layer_has_clip_rect = cref.m_layer_has_clip_rect;
+    m_layer_clip_rect = cref.m_layer_clip_rect;
 }
 
 MCControl::~MCControl()
@@ -817,6 +822,13 @@ void MCControl::redraw(MCDC *dc, const MCRectangle &dirty)
 		
 		dc -> setopacity(255);
 		dc -> setfunction(GXcopy);
+        
+        /* Apply the layerClipRect property, if set. */
+        if (m_layer_has_clip_rect)
+        {
+            trect = MCU_intersect_rect(trect, m_layer_clip_rect);
+        }
+        
 		dc->cliprect(trect);
         
 		// MW-2011-09-06: [[ Redraw ] Make sure we draw the control normally (not

--- a/engine/src/exec-interface-control.cpp
+++ b/engine/src/exec-interface-control.cpp
@@ -337,6 +337,50 @@ void MCControl::GetEffectiveLayerMode(MCExecContext& ctxt, intenum_t& r_mode)
 	r_mode = (intenum_t)layer_geteffectivemode();
 }
 
+void MCControl::GetLayerClipRect(MCExecContext& ctxt, MCRectangle*& r_layer_clip_rect)
+{
+    if (m_layer_has_clip_rect)
+    {
+        *r_layer_clip_rect = m_layer_clip_rect;
+    }
+    else
+    {
+        r_layer_clip_rect = nullptr;
+    }
+}
+
+void MCControl::SetLayerClipRect(MCExecContext& ctxt, MCRectangle* p_layer_clip_rect)
+{
+    bool t_old_has_layer_clip_rect = m_layer_has_clip_rect;
+    MCRectangle t_old_layer_clip_rect = m_layer_clip_rect;
+    
+    bool t_redraw = false;
+    if (p_layer_clip_rect != nullptr)
+    {
+        m_layer_clip_rect = *p_layer_clip_rect;
+        m_layer_has_clip_rect = true;
+        
+        if (!t_old_has_layer_clip_rect ||
+                MCU_equal_rect(m_layer_clip_rect, t_old_layer_clip_rect))
+        {
+            t_redraw = true;
+        }
+    }
+    else
+    {
+        m_layer_has_clip_rect = false;
+        if (t_old_has_layer_clip_rect)
+        {
+            t_redraw = true;
+        }
+    }
+    
+    if (t_redraw)
+    {
+        Redraw();
+    }
+}
+
 void MCControl::SetMargins(MCExecContext& ctxt, const MCInterfaceMargins& p_margins)
 {
     if (p_margins . type == kMCInterfaceMarginsTypeSingle)

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -1114,6 +1114,7 @@ const LT factor_table[] =
         {"labelwidth", TT_PROPERTY, P_LABEL_WIDTH},
         {"last", TT_CHUNK, CT_LAST},
         {"layer", TT_PROPERTY, P_LAYER},
+        {"layercliprect", TT_PROPERTY, P_LAYER_CLIP_RECT},
 		// MW-2011-08-25: [[ TileCache ]] The layerMode property token.
 		{"layermode", TT_PROPERTY, P_LAYER_MODE},
         {"layers", TT_CLASS, CT_LAYER},

--- a/engine/src/mccontrol.h
+++ b/engine/src/mccontrol.h
@@ -65,6 +65,7 @@ protected:
 
 	// MW-2011-08-24: [[ Layers ]] The layer id of the control.
 	uint32_t m_layer_id;
+    MCRectangle m_layer_clip_rect;
 	
 	// MW-2011-09-21: [[ Layers ]] Whether something about the control has
 	//   changed requiring a recompute the layer attributes.
@@ -90,6 +91,8 @@ protected:
 	// MW-2011-09-21: [[ Layers ]] Whether the layer is a sprite or scenery
 	//   layer.
 	bool m_layer_is_sprite : 1;
+    
+    bool m_layer_has_clip_rect : 1;
 
 	static int2 defaultmargin;
 	static int2 xoffset;
@@ -263,6 +266,12 @@ public:
 	// MW-2011-09-21: [[ Layers ]] Returns whether the layer is opaque or not.
 	bool layer_isopaque(void) { return m_layer_is_opaque; }
 
+    bool layer_has_clip_rect(void) { return m_layer_has_clip_rect; }
+    
+    // Note: The returned value only has meaning if layer_has_clip_rect() returns
+    // true.
+    MCRectangle layer_get_clip_rect(void) { return m_layer_clip_rect; }
+    
 	// MW-2011-09-21: [[ Layers ]] Make sure the layerMode attr's are accurate.
 	MCLayerModeHint layer_computeattrs(bool commit);
 	// MW-2011-09-21: [[ Layers ]] Reset the attributes to defaults.
@@ -359,8 +368,10 @@ public:
 	void SetToolTip(MCExecContext& ctxt, MCStringRef p_tooltip);
 	void GetUnicodeToolTip(MCExecContext& ctxt, MCDataRef& r_tooltip);
 	void SetUnicodeToolTip(MCExecContext& ctxt, MCDataRef p_tooltip);
+    void GetLayerClipRect(MCExecContext& ctxt, MCRectangle*& r_layer_clip_rect);
+    void SetLayerClipRect(MCExecContext& ctxt, MCRectangle* p_layer_clip_rect);
 	void GetLayerMode(MCExecContext& ctxt, intenum_t& r_mode);
-	void SetLayerMode(MCExecContext& ctxt, intenum_t p_mode);
+    void SetLayerMode(MCExecContext& ctxt, intenum_t p_mode);
 	void GetEffectiveLayerMode(MCExecContext& ctxt, intenum_t& r_mode);
     virtual void SetMargins(MCExecContext& ctxt, const MCInterfaceMargins& p_margins);
     void GetMargins(MCExecContext& ctxt, MCInterfaceMargins& r_margins);

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -1755,6 +1755,8 @@ enum Properties {
     
     P_REV_LIBRARY_MAPPING,
     
+    P_LAYER_CLIP_RECT,
+    
     __P_LAST,
 };
 

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1123,6 +1123,12 @@ void MCCard::render_control(MCTileCacheRef p_tiler, MCControl *p_control, const 
     // IM-2013-10-14: [[ FullscreenMode ]] Constrain each layer to the visible area
     t_layer_clip = MCU_intersect_rect(t_layer_clip, p_visible_rect);
     
+    /* If the layer has a layerClipRect, then apply it here. */
+    if (p_control->layer_has_clip_rect())
+    {
+        t_layer_clip = MCU_intersect_rect(t_layer_clip, p_control->layer_get_clip_rect());
+    }
+    
     // IM-2013-08-21: [[ ResIndependence ]] Use device coords for tilecache operation
     // IM-2013-09-30: [[ FullscreenMode ]] Use stack transform to get device coords
     t_layer . region = MCRectangle32GetTransformedBounds(t_layer_region, p_transform);


### PR DESCRIPTION
This patch adds a new property 'layerClipRect' to all controls.

The property defines a clipping rectangle in card co-ordinates which
is applied both when the control is rendered normally, and also to
the accelerated rendering layer-clip when accelerated rendering is
turned on.

The property means that the restriction of only top-level objects
being able to have dynamic layers in accelerated rendering mode
is not quite such a problem as it is now possible to have a group
clipping like affect applied to top-level objects.

*NOTE* This PR merges branch https://github.com/runrevmark/livecode/tree/accelrender-layer_clip_rect into PR https://github.com/livecode/livecode/pull/7006