### PR TITLE
[[ Bug 22042 ]] Update SQLite to v3.28.0

### DIFF
--- a/docs/notes/bugfix-22042.md
+++ b/docs/notes/bugfix-22042.md
@@ -1,0 +1,1 @@
+# Updated SQLite to version 3.28.0


### PR DESCRIPTION
This patch adds a release note for the update of SQLite in the
thirdparty submodule.