### PR TITLE
[[ Bug 22047 ]] Allow nothing as variadic argument to foreign handler

### DIFF
--- a/docs/lcb/notes/22047.md
+++ b/docs/lcb/notes/22047.md
@@ -1,0 +1,1 @@
+# [22047] Allow nothing to be passed as a variadic argument to a foreign handler

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -503,7 +503,7 @@ MCScriptExecuteContext::InvokeForeignVarArgument(MCScriptForeignInvocation& p_in
     MCTypeInfoRef t_actual_type = t_resolved_type.type;
     
     // Fetch the promoted type of arg type (sub ints promote to int, and float
-    // promotes to double).
+    // promotes to double) - but only if the actual type is foreign.
     const MCForeignTypeDescriptor *t_desc = nullptr;
     if (MCTypeInfoIsForeign(t_actual_type))
     {
@@ -511,16 +511,19 @@ MCScriptExecuteContext::InvokeForeignVarArgument(MCScriptForeignInvocation& p_in
     }
     
     MCTypeInfoRef t_arg_type = t_actual_type;
-    if (t_desc->promote != nullptr)
+    if (t_desc != nullptr)
     {
-        MCResolvedTypeInfo t_resolved_arg_type;
-        if (!ResolveTypeInfo(t_desc->promotedtype,
-                             t_resolved_arg_type))
+        if (t_desc->promote != nullptr)
         {
-            return false;
+            MCResolvedTypeInfo t_resolved_arg_type;
+            if (!ResolveTypeInfo(t_desc->promotedtype,
+                                 t_resolved_arg_type))
+            {
+                return false;
+            }
+            
+            t_arg_type = t_resolved_arg_type.type;
         }
-        
-        t_arg_type = t_resolved_arg_type.type;
     }
     
     // Compute the slot attributes - using the (potentially) promoted type.

--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -40,18 +40,19 @@ public handler TestForeignInvoke_Varargs()
       variable tLongLong as SInt64
       variable tFloat as CFloat
       variable tDouble as CDouble
+      variable tNothing as optional Pointer
       put 1000 into tInt
       put 1000000000 into tLong
       put tLong * 1000000 into tLongLong
       put 3.5 into tFloat
       put 7.5 into tDouble
-      sprintf(tOutputBuffer, "%d %ld %lld %.1f %.1lf", tInt, tLong, tLongLong, tFloat, tDouble)
+      sprintf(tOutputBuffer, "%d %ld %lld %.1f %.1lf %p", tInt, tLong, tLongLong, tFloat, tDouble, tNothing)
       MCStringCreateWithCString(tOutputBuffer, tString2)
 
       free(tOutputBuffer)
    end unsafe
    test "sprintf works with no variadic arguments" when tString1 is "no formats"
-   test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5"
+   test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5 0x0"
 end handler
 
 --------


### PR DESCRIPTION
This patch ensures that the value nothing can be passed as a variadic
argument to a foreign handler - this enables the calling of variadic
foreign handlers which might take a nullptr as one of its variadic
arguments.