### PR TITLE
[[ Bug ]] Fix failing LCB varargs test on Linux

### DIFF
--- a/tests/lcb/vm/foreign-invoke.lcb
+++ b/tests/lcb/vm/foreign-invoke.lcb
@@ -26,33 +26,46 @@ foreign handler sprintf(in pTarget as Pointer, in pFormat as ZStringNative, ...)
 foreign handler MCStringCreateWithCString(in pCString as Pointer, out rString as String) returns CBool binds to "<builtin>"
 
 public handler TestForeignInvoke_Varargs()
-   variable tString1 as String
-   variable tString2 as String
+   variable tOutputBuffer as Pointer
    unsafe
-      variable tOutputBuffer as Pointer
       put malloc(4096) into tOutputBuffer
+   end unsafe
 
+   variable tString1 as String
+   unsafe
       sprintf(tOutputBuffer, "no formats")
       MCStringCreateWithCString(tOutputBuffer, tString1)
+   end unsafe
+   test "sprintf works with no variadic arguments" when tString1 is "no formats"
 
+   variable tString2 as String
+   unsafe
       variable tInt as SInt16
       variable tLong as SInt32
       variable tLongLong as SInt64
       variable tFloat as CFloat
       variable tDouble as CDouble
-      variable tNothing as optional Pointer
       put 1000 into tInt
       put 1000000000 into tLong
       put tLong * 1000000 into tLongLong
       put 3.5 into tFloat
       put 7.5 into tDouble
-      sprintf(tOutputBuffer, "%d %ld %lld %.1f %.1lf %p", tInt, tLong, tLongLong, tFloat, tDouble, tNothing)
+      sprintf(tOutputBuffer, "%d %ld %lld %.1f %.1lf", tInt, tLong, tLongLong, tFloat, tDouble)
       MCStringCreateWithCString(tOutputBuffer, tString2)
+   end unsafe
+   test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5"
 
+   variable tString3 as String
+   unsafe
+      variable tNothing as optional Pointer
+      sprintf(tOutputBuffer, "nullptr %p", tNothing)
+      MCStringCreateWithCString(tOutputBuffer, tString3)
+   end unsafe
+   test "sprintf works with nullptr variadic argument" when tString3 begins with "nullptr "
+
+   unsafe
       free(tOutputBuffer)
    end unsafe
-   test "sprintf works with no variadic arguments" when tString1 is "no formats"
-   test "sprintf works with variadic arguments" when tString2 is "1000 1000000000 1000000000000000 3.5 7.5 0x0"
 end handler
 
 --------


### PR DESCRIPTION
This patch fixes the LCB varargs tests on Linux. The test was failing
due to the assumption that the %p printf format would render a nullptr
as 0x0 as it does on macOS - this was an incorrect assumption.

To resolve this, the varargs tests have been restructured, with the
nullptr test being separated out. Rather than check for a specific
output string, it just checks it begins with the known string (the
issue was a crash, so the only thing which needs to be checked is
that the crash doesn't happen!).