### PR TITLE
[[ Bug ]] Fix crash on creation of browser widget

### DIFF
--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -52,7 +52,8 @@ void MCBrowserRefCounted::Destroy()
 
 MCBrowserBase::MCBrowserBase(void)
     : m_event_handler(nil),
-      m_javascript_handler(nil)
+      m_javascript_handler(nil),
+      m_progress_handler(nil)
 {
 }
 


### PR DESCRIPTION
This patch fixes a crash which occurs when creating an instance
of the browser widget. The crash was caused by a failure to
initialize the m_progress_handler member variable of the MCBrowserBase
class to nullptr in its constructor.