### PR TITLE
[[ PlayAAR ]] LCB files can now specify play AARs they depend on.

### DIFF
--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -537,6 +537,13 @@ function pathToJar pRoot
    return pRoot & slash & "bin" & slash & executableName("jar")
 end pathToJar
 
+function pathToPlayServices  pRoot
+   if pRoot is empty then
+      put sAndroidRoot into pRoot
+   end if
+   return pRoot & slash & "extras/google/m2repository/com/google/android/gms"
+end pathToPlayServices
+
 ////////////////////////////////////////////////////////////////////////////////
 
 private command configureJavaRootWindows

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -350,6 +350,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       revSBUpdateSettingsForExtensions "android", pSettings
       revSBResolveCopyFilesList tBaseFolder, "android", pSettings, tResolvedFileData
       
+      addPlayServiceAARsToSettings pSettings
       expandAARsAndComputeSettings tBuildFolder, pSettings
       
       repeat for each element tFile in tResolvedFileData
@@ -1161,6 +1162,31 @@ private command appendToStringList pValue, @xList
    end if
 end appendToStringList
 
+private command addPlayServiceAARsToSettings  @xSettingsA
+   local tPlayServicesPath
+   put pathToPlayServices() into tPlayServicesPath
+   
+   repeat for each line tPlayService in xSettingsA["android,play dependencies"]
+      local tPlayVersion
+      set the itemDel to "-"
+      put the last item of tPlayService into tPlayVersion
+      delete the last item of tPlayService
+      set the itemDel to comma
+      
+      local tPlayServiceAARPath
+      put tPlayServicesPath & slash & \
+            "play-services-" & tPlayService & slash & \
+            tPlayVersion & slash & \
+            "play-services-" & tPlayService & "-" & tPlayVersion & ".aar" \
+            into tPlayServiceAARPath
+      if there is not a file tPlayServiceAARPath then
+         throw "unable to locate play service dependency" && tPlayService && "version" && tPlayVersion
+      end if
+      
+      appendToStringList tPlayServiceAARPath, xSettingsA["aarFiles"]
+   end repeat
+end addPlayServiceAARsToSettings
+
 private command expandAARsAndComputeSettings tBuildFolder, @xSettingsA
    local tCount, tDefaultFolder
    put the folder into tDefaultFolder
@@ -1581,6 +1607,11 @@ private function pathToJar pRoot
    dispatch function "pathToJar" to stack kDeployLibrary with pRoot
    return the result
 end pathToJar
+
+private function pathToPlayServices pRoot
+   dispatch function "pathToPlayServices" to stack kDeployLibrary with pRoot
+   return the result
+end pathToPlayServices
 
 ################################################################################
 

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2491,6 +2491,12 @@ command revSBUpdateForDependencies pPlatform, pArchs, pSDK, @xSettings
                xSettings["android,device capabilities"][tFeature]
       end repeat
       
+      local tPlayVersion
+      put tAndroidMetadataA["play"]["version"]into tPlayVersion
+      repeat for each item tPlayDep in tAndroidMetadataA["play"]["deps"]
+         appendToStringList tPlayDep & "-" & tPlayVersion, xSettings["android,play dependencies"]
+      end repeat
+      
       revSBUpdateExtensionCodeInclusions tExtension, pPlatform, pArchs, pSDK, xSettings
       revSBUpdatePerExtensionSettings tExtension, pPlatform, xSettings
    end repeat


### PR DESCRIPTION
LCB files can no include android.play.deps and android.play.version
to list andy play AARs they depend on. The standalone builder
will look for those AARs in the Android SDK and include them in
the package. This also elminates confilcts when multiple LCB
files include the same play AAR.