### PR TITLE
[[ Canvas ]] Add ability to get density property of canvas images

### DIFF
--- a/docs/lcb/notes/feature-canvas_image_metadata.md
+++ b/docs/lcb/notes/feature-canvas_image_metadata.md
@@ -1,0 +1,11 @@
+# LiveCode Builder Host Library
+## Canvas library
+
+New syntax has been added to enable getting image metadata and density
+information.
+
+The image 'metadata' property returns data associated with the image in the
+form of an array.
+
+The image 'density' property returns an images density in dots per inch (DPI).
+This allows widgets to scale images appropriately for display.

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -2186,8 +2186,8 @@ end syntax
 
 public foreign handler MCCanvasImageGetWidth(in pImage as Image, out rWidth as UInt32) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasImageGetHeight(in pImage as Image, out rHeight as UInt32) returns nothing binds to "<builtin>"
-// TODO - add support for metadata
-//public foreign handler MCCanvasImageGetMetadata(in pImage as Image, out rMetadata as Array) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasImageGetMetadata(in pImage as Image, out rMetadata as Array) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasImageGetDensity(in pImage as Image, out rDensity as CDouble) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasImageGetPixels(in pImage as Image, out rPixels as Data) returns nothing binds to "<builtin>"
 // TODO - add image frame index property?
 
@@ -2245,11 +2245,65 @@ end syntax
 
 //////////
 
-//syntax ImageMetadataProperty is prefix operator with property precedence
-//	"the" "metadata" "of" <mImage: Expression>
-//begin
-//	MCCanvasImageGetMetadata(mImage, output)
-//end syntax
+/**
+Summary:	the metadata associated with an image.
+
+mImage:		An expression which evaluates to an image.
+
+Description:	An array containing metadata associated with an image.
+
+Example:
+	// Load an image from a file
+	variable tImage as Image
+	put image from file "images/logo.png" into tImage
+	
+	// get the image metadata
+	variable tMetadata as Array
+	put the metadata of tImage into tMetadata
+	
+	// get image density in DPI from the image metadata
+	variable tDPI as Number
+	if "density" is among the keys of tMetadata then
+		put tMetadata["density"] into tDPI
+	else
+		put 72 into tDPI
+	end if
+
+Tags: canvas
+*/
+syntax ImageMetadataProperty is prefix operator with property precedence
+	"the" "metadata" "of" <mImage: Expression>
+begin
+	MCCanvasImageGetMetadata(mImage, output)
+end syntax
+
+//////////
+
+/**
+Summary:	The density of an image.
+
+mImage:		An expression which evaluates to an image.
+
+Description:	The image density in DPI (dots per inch)
+
+Example:
+	// Load an image from a file
+	variable tImage as Image
+	put image from file "images/logo.png" into tImage
+	
+	// scale down image based on standard DPI of 72.
+	variable tScale as Number
+	put (72 / the density of tImage) into tScale
+	scale this canvas by [tScale, tScale]
+	draw tImage into rectangle [0,0,the width of tImage,the height of tImage] of this canvas
+
+Tags: canvas
+*/
+syntax ImageDensityProperty is prefix operator with property precedence
+	"the" "density" "of" <mImage: Expression>
+begin
+	MCCanvasImageGetDensity(mImage, output)
+end syntax
 
 //////////
 

--- a/engine/src/image_rep.cpp
+++ b/engine/src/image_rep.cpp
@@ -893,6 +893,42 @@ bool MCImageRepGetFrameDuration(MCImageRep *p_image_rep, uint32_t p_frame, uint3
 	return p_image_rep->GetFrameDuration(p_frame, r_duration);
 }
 
+bool MCImageRepGetMetadata(MCImageRep *p_image_rep, MCArrayRef &r_metadata)
+{
+	MCImageMetadata t_metadata;
+	if (!p_image_rep->GetMetadata(t_metadata))
+		return false;
+	
+	MCAutoArrayRef t_metadata_array;
+	if (!MCArrayCreateMutable(&t_metadata_array))
+		return false;
+	
+	if (t_metadata.has_density)
+	{
+		MCAutoNumberRef t_density;
+		if (!MCNumberCreateWithReal(t_metadata.density, &t_density))
+			return false;
+		if (!MCArrayStoreValue(*t_metadata_array, false, MCNAME("density"), *t_density))
+			return false;
+	}
+	/* TODO - support other metadata fields */
+	
+	return MCArrayCopy(*t_metadata_array, r_metadata);
+}
+
+bool MCImageRepGetDensity(MCImageRep *p_image_rep, double &r_density)
+{
+	MCImageMetadata t_metadata;
+	if (!p_image_rep->GetMetadata(t_metadata) || !t_metadata.has_density)
+	{
+		r_density = 72.0;
+		return true;
+	}
+	
+	r_density = t_metadata.density;
+	return true;
+}
+
 bool MCImageRepLock(MCImageRep *p_image_rep, uint32_t p_index, MCGFloat p_density, MCGImageFrame &r_frame)
 {
 	return p_image_rep->LockImageFrame(p_index, p_density, r_frame);

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -488,6 +488,8 @@ MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepGetMetadataErrorTypeInfo;
+MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepGetDensityErrorTypeInfo;
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
 
 MC_DLLEXPORT_DEF MCTypeInfoRef kMCCanvasGradientInvalidRampErrorTypeInfo;
@@ -1970,6 +1972,20 @@ void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height)
 }
 
 MC_DLLEXPORT_DEF
+void MCCanvasImageGetMetadata(MCCanvasImageRef p_image, MCArrayRef &r_metadata)
+{
+	if (!MCImageRepGetMetadata(MCCanvasImageGetImageRep(p_image), r_metadata))
+		MCCanvasThrowError(kMCCanvasImageRepGetMetadataErrorTypeInfo);
+}
+
+MC_DLLEXPORT_DEF
+void MCCanvasImageGetDensity(MCCanvasImageRef p_image, double &r_density)
+{
+	if (!MCImageRepGetDensity(MCCanvasImageGetImageRep(p_image), r_density))
+		MCCanvasThrowError(kMCCanvasImageRepGetDensityErrorTypeInfo);
+}
+
+MC_DLLEXPORT_DEF
 void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels)
 {
 	MCImageRep *t_image_rep;
@@ -2013,11 +2029,6 @@ void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels)
 	/* UNCHECKED */ MCDataCreateWithBytesAndRelease(t_buffer, t_buffer_size, r_pixels);
 	
 	MCImageRepUnlockRaster(t_image_rep, 0, t_raster);
-}
-
-void MCCanvasImageGetMetadata(MCCanvasImageRef p_image, MCArrayRef &r_metadata)
-{
-	// TODO - implement image metadata
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -6388,6 +6399,14 @@ bool MCCanvasErrorsInitialize()
 	if (!MCNamedErrorTypeInfoCreate(MCNAME("com.livecode.canvas.ImageRepGetGeometryError"), MCNAME("canvas"), MCSTR("Unable to get image geometry."), kMCCanvasImageRepGetGeometryErrorTypeInfo))
 		return false;
 	
+	kMCCanvasImageRepGetMetadataErrorTypeInfo = nil;
+	if (!MCNamedErrorTypeInfoCreate(MCNAME("com.livecode.canvas.ImageRepGetMetadataError"), MCNAME("canvas"), MCSTR("Unable to get image metadata."), kMCCanvasImageRepGetMetadataErrorTypeInfo))
+		return false;
+	
+	kMCCanvasImageRepGetDensityErrorTypeInfo = nil;
+	if (!MCNamedErrorTypeInfoCreate(MCNAME("com.livecode.canvas.ImageRepGetDensityError"), MCNAME("canvas"), MCSTR("Unable to get image density."), kMCCanvasImageRepGetDensityErrorTypeInfo))
+		return false;
+	
 	kMCCanvasImageRepLockErrorTypeInfo = nil;
 	if (!MCNamedErrorTypeInfoCreate(MCNAME("com.livecode.canvas.ImageRepLockError"), MCNAME("canvas"), MCSTR("Unable to lock image pixels."), kMCCanvasImageRepLockErrorTypeInfo))
 		return false;
@@ -6452,6 +6471,8 @@ void MCCanvasErrorsFinalize()
 	MCValueRelease(kMCCanvasImageRepDataErrorTypeInfo);
 	MCValueRelease(kMCCanvasImageRepPixelsErrorTypeInfo);
 	MCValueRelease(kMCCanvasImageRepGetGeometryErrorTypeInfo);
+	MCValueRelease(kMCCanvasImageRepGetMetadataErrorTypeInfo);
+	MCValueRelease(kMCCanvasImageRepGetDensityErrorTypeInfo);
 	MCValueRelease(kMCCanvasImageRepLockErrorTypeInfo);
 	
 	MCValueRelease(kMCCanvasGradientStopRangeErrorTypeInfo);

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -56,7 +56,10 @@ bool MCImageRepCreateWithPath(MCStringRef p_path, MCImageRep *&r_image_rep);
 bool MCImageRepCreateWithData(MCDataRef p_data, MCImageRep *&r_image_rep);
 bool MCImageRepCreateWithPixels(MCDataRef p_pixels, uint32_t p_width, uint32_t p_height, MCGPixelFormat p_format, bool p_premultiplied, MCImageRep *&r_image_rep);
 bool MCImageRepGetGeometry(MCImageRep *p_image_rep, uint32_t &r_width, uint32_t &r_height);
+bool MCImageRepGetMetadata(MCImageRep *p_image_rep, MCArrayRef &r_metadata);
+bool MCImageRepGetDensity(MCImageRep *p_image_rep, double &r_density);
 bool MCImageRepGetFrameDuration(MCImageRep *p_image_rep, uint32_t p_frame, uint32_t &r_duration);
+bool MCImageRepGetMetadata(MCImageRep *p_image_rep, MCArrayRef &r_metadata);
 
 bool MCImageRepLock(MCImageRep *p_image_rep, uint32_t p_index, MCGFloat p_density, MCGImageFrame &r_frame);
 void MCImageRepUnlock(MCImageRep *p_image_rep, uint32_t p_index, MCGImageFrame &p_frame);
@@ -152,6 +155,8 @@ extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepReferencedErrorTypeInfo;
 extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepDataErrorTypeInfo;
 extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepPixelsErrorTypeInfo;
 extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepGetGeometryErrorTypeInfo;
+extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepGetMetadataErrorTypeInfo;
+extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepGetDensityErrorTypeInfo;
 extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasImageRepLockErrorTypeInfo;
 	
 extern MC_DLLEXPORT MCTypeInfoRef kMCCanvasGradientStopRangeErrorTypeInfo;
@@ -308,9 +313,9 @@ extern "C" MC_DLLEXPORT void MCCanvasImageMakeWithResourceFile(MCStringRef p_res
 // Properties
 extern "C" MC_DLLEXPORT void MCCanvasImageGetWidth(MCCanvasImageRef p_image, uint32_t &r_width);
 extern "C" MC_DLLEXPORT void MCCanvasImageGetHeight(MCCanvasImageRef p_image, uint32_t &r_height);
+extern "C" MC_DLLEXPORT void MCCanvasImageGetMetadata(MCCanvasImageRef p_image, MCArrayRef &r_metadata);
+extern "C" MC_DLLEXPORT void MCCanvasImageGetDensity(MCCanvasImageRef p_image, double &r_density);
 extern "C" MC_DLLEXPORT void MCCanvasImageGetPixels(MCCanvasImageRef p_image, MCDataRef &r_pixels);
-// TODO - Add support for image metadata
-//void MCCanvasImageGetMetadata(const MCCanvasImage &p_image, MCArrayRef &r_metadata);
 
 // TODO - Implement image operations
 //void MCCanvasImageTransform(MCCanvasImage &x_image, const MCCanvasTransform &p_transform);


### PR DESCRIPTION
This patch adds two new properties to canvas image values, `density` and `metadata`.

The density property returns the image density in dots-per-inch,
allowing images to be scaled for display.

The metadata returns data associated with the image in the form of an array.