### PR TITLE
[[ canvas ]] Add `begin effect only layer with <effect> on <canvas>` syntax

### DIFF
--- a/docs/lcb/notes/feature-effect_only_layer.md
+++ b/docs/lcb/notes/feature-effect_only_layer.md
@@ -1,0 +1,13 @@
+# LiveCode Builder Host Library
+## Canvas library
+
+A new statement `begin effect only layer with <effect>` has been implemented to
+allow drawing shadow & glow effects without rendering the source content
+
+For example to draw a dropshadow of a rectangle without drawing the rectangle itself:
+	variable tEffect as Effect
+	put outer shadow effect into tEffect
+
+	begin effect only layer with tEffect on this canvas
+	fill rectangle path of rectangle [50,50,100,100] on this canvas
+	end layer on this canvas

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -4281,6 +4281,7 @@ public foreign handler MCCanvasSaveState(in pCanvas as Canvas) returns nothing b
 public foreign handler MCCanvasRestoreState(in pCanvas as Canvas) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasBeginLayer(in pCanvas as Canvas) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasBeginLayerWithEffect(in pEffect as Effect, in pCanvas as Canvas) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasBeginEffectOnlyLayerWithEffect(in pEffect as Effect, in pCanvas as Canvas) returns nothing binds to "<builtin>"
 public foreign handler MCCanvasEndLayer(in pCanvas as Canvas) returns nothing binds to "<builtin>"
 
 public foreign handler MCCanvasFill(in pCanvas as Canvas) returns nothing binds to "<builtin>"
@@ -4485,6 +4486,11 @@ syntax CanvasOperationBeginLayer is statement
 begin
 	MCCanvasBeginLayer(mCanvas)
 	MCCanvasBeginLayerWithEffect(mEffect, mCanvas)
+end syntax
+syntax CanvasOperationBeginEffectOnlyLayer is statement
+	"begin" "effect" "only" "layer" "with" <mEffect: Expression> "on" <mCanvas: Expression>
+begin
+	MCCanvasBeginEffectOnlyLayerWithEffect(mEffect, mCanvas)
 end syntax
 
 //////////

--- a/engine/src/graphicscontext.cpp
+++ b/engine/src/graphicscontext.cpp
@@ -236,11 +236,7 @@ void MCGraphicsContext::begin(bool p_group)
 
 bool MCGraphicsContext::begin_with_effects(MCBitmapEffectsRef p_effects, const MCRectangle &p_shape)
 {
-	MCGBitmapEffects t_effects;
-	t_effects . has_drop_shadow = false;
-	t_effects . has_outer_glow = false;
-	t_effects . has_inner_glow = false;
-	t_effects . has_inner_shadow = false;
+	MCGBitmapEffects t_effects = MCGBitmapEffects();
 
 	if ((p_effects -> mask & kMCBitmapEffectTypeColorOverlayBit) != 0)
 	{

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -5658,8 +5658,21 @@ static void MCPolarCoordsToCartesian(MCGFloat p_distance, MCGFloat p_angle, MCGF
 	r_y = p_distance * sin(p_angle);
 }
 
+void _MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas, bool p_isolated);
+
 MC_DLLEXPORT_DEF
 void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas)
+{
+	_MCCanvasBeginLayerWithEffect(p_effect, p_canvas, false);
+}
+
+MC_DLLEXPORT_DEF
+void MCCanvasBeginEffectOnlyLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas)
+{
+	_MCCanvasBeginLayerWithEffect(p_effect, p_canvas, true);
+}
+
+void _MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas, bool p_isolated)
 {
 	__MCCanvasImpl *t_canvas;
 	t_canvas = MCCanvasGet(p_canvas);
@@ -5675,6 +5688,8 @@ void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canv
 	
 	MCCanvasFloat t_spread;
 	t_spread = MCClamp(t_effect_impl->spread, 0.0, 1.0);
+	
+	t_effects.isolated = p_isolated;
 	
 	switch (t_effect_impl->type)
 	{

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -5668,9 +5668,8 @@ void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canv
 	if (!MCCanvasPropertiesPush(*t_canvas))
 		return;
 
-	MCGBitmapEffects t_effects;
-	t_effects.has_color_overlay = t_effects.has_drop_shadow = t_effects.has_inner_glow = t_effects.has_inner_shadow = t_effects.has_outer_glow = false;
-	
+	MCGBitmapEffects t_effects = MCGBitmapEffects();
+
 	__MCCanvasEffectImpl *t_effect_impl;
 	t_effect_impl = MCCanvasEffectGet(p_effect);
 	

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -563,6 +563,7 @@ extern "C" MC_DLLEXPORT void MCCanvasSaveState(MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasRestoreState(MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasBeginLayer(MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasBeginLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas);
+extern "C" MC_DLLEXPORT void MCCanvasBeginEffectOnlyLayerWithEffect(MCCanvasEffectRef p_effect, MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasEndLayer(MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasFill(MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasFillPath(MCCanvasPathRef p_path, MCCanvasRef p_canvas);

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -180,13 +180,9 @@ public:
         MCRectangle t_volume_well;
         t_volume_well = getVolumeBarPartRect(dirty, kMCPlayerControllerPartVolumeWell);
         
-        MCGBitmapEffects t_effects;
-        t_effects . has_drop_shadow = false;
-        t_effects . has_outer_glow = false;
-        t_effects . has_inner_glow = false;
+        MCGBitmapEffects t_effects = MCGBitmapEffects();
         t_effects . has_inner_shadow = true;
-        t_effects . has_color_overlay = false;
-        
+		
         MCGShadowEffect t_inner_shadow;
         t_inner_shadow . color = MCGColorMakeRGBA(0.0f, 0.0f, 0.0f, 56.0 / 255.0);
         t_inner_shadow . blend_mode = kMCGBlendModeClear;
@@ -526,13 +522,9 @@ public:
         MCRectangle t_rate_well;
         t_rate_well = getRateBarPartRect(dirty, kMCPlayerControllerPartRateWell);
         
-        MCGBitmapEffects t_effects;
-        t_effects . has_drop_shadow = false;
-        t_effects . has_outer_glow = false;
-        t_effects . has_inner_glow = false;
+        MCGBitmapEffects t_effects = MCGBitmapEffects();
         t_effects . has_inner_shadow = true;
-        t_effects . has_color_overlay = false;
-        
+
         MCGShadowEffect t_inner_shadow;
         t_inner_shadow . color = MCGColorMakeRGBA(0.0f, 0.0f, 0.0f, 56.0 / 255.0);
         t_inner_shadow . blend_mode = kMCGBlendModeClear;
@@ -2590,13 +2582,9 @@ void MCPlayer::drawControllerWellButton(MCGContextRef p_gcontext)
     t_drawn_well_rect . x += 4;
     t_drawn_well_rect . width -= 10;
     
-    MCGBitmapEffects t_effects;
-	t_effects . has_drop_shadow = false;
-	t_effects . has_outer_glow = false;
-	t_effects . has_inner_glow = false;
-	t_effects . has_inner_shadow = true;
-    t_effects . has_color_overlay = false;
-    
+    MCGBitmapEffects t_effects = MCGBitmapEffects();
+    t_effects . has_inner_shadow = true;
+
     MCGShadowEffect t_inner_shadow;
     t_inner_shadow . color = MCGColorMakeRGBA(56.0 / 255.0, 56.0 / 255.0, 56.0 / 255.0, 56.0 / 255.0);
     t_inner_shadow . blend_mode = kMCGBlendModeClear;

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -531,6 +531,8 @@ struct MCGBitmapEffects
 	bool has_inner_shadow = false;
 	bool has_outer_glow = false;
 	bool has_drop_shadow = false;
+	
+	bool isolated = false;
 };
 
 struct MCGDeviceMaskInfo

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -1183,12 +1183,14 @@ static void MCGContextRenderEffects(MCGContextRef self, MCGContextLayerRef p_chi
 							   p_effects . outer_glow . color,
 							   p_effects . outer_glow . blend_mode);
 							   
-	
-	// Render the layer itself (using the layer's alpha and blend mode - well, if we can agree that's a good change!).
-	self->layer->canvas->save();
-	self->layer->canvas->resetMatrix();
-	self->layer->canvas->drawBitmap(t_child_bitmap, p_child->origin_x, p_child->origin_y, NULL);
-	self->layer->canvas->restore();
+	if (!p_effects . isolated)
+	{
+		// Render the layer itself (using the layer's alpha and blend mode - well, if we can agree that's a good change!).
+		self->layer->canvas->save();
+		self->layer->canvas->resetMatrix();
+		self->layer->canvas->drawBitmap(t_child_bitmap, p_child->origin_x, p_child->origin_y, NULL);
+		self->layer->canvas->restore();
+	}
 	
 	if (p_effects . has_inner_shadow)
 		MCGContextRenderEffect(self,


### PR DESCRIPTION
This adds `begin effect only layer with <effect>` syntax to allow drawing shadow & glow effects without rendering the source