### PR TITLE
[[ Config ]] Added google play path to android gyp config

### DIFF
--- a/config/android.gypi
+++ b/config/android.gypi
@@ -33,8 +33,10 @@
 
 		'android_ndk_path%': '<(android_ndk_path)',
 		'android_subplatform%': 'sdk<(android_api_version)_ndk<(android_ndk_platform_version)<(android_ndk_version)',
+
+		'android_play_path': '<(android_sdk_path)/extras/google/m2repository/com/google/android/gms',
 	},
-	
+
 	'target_defaults':
 	{
 		'variables':


### PR DESCRIPTION
The root path to google play services is needed by any java
components that wrap google play. The path to the play aars
are needed when building.