### PR TITLE
[[ Config ]] Added unzip gyp rule

### DIFF
--- a/config/unzip.gypi
+++ b/config/unzip.gypi
@@ -1,0 +1,46 @@
+{
+	'rules':
+	[
+		{
+			'rule_name': 'unzip zip',
+			'extension': 'zip',
+
+			'message': '  UNZIP ZIP <(RULE_INPUT_PATH)',
+
+			'outputs':
+			[
+				'<(PRODUCT_DIR)/<(RULE_INPUT_ROOT)',
+			],
+
+			'action':
+			[
+				'unzip',
+				'-o',
+				'<(RULE_INPUT_PATH)',
+				'-d',
+				'<@(_outputs)',
+			],
+		},
+
+		{
+			'rule_name': 'unzip aar',
+			'extension': 'aar',
+
+			'message': '  UNZIP AAR <(RULE_INPUT_PATH)',
+
+			'outputs':
+			[
+				'<(PRODUCT_DIR)/<(RULE_INPUT_ROOT)',
+			],
+
+			'action':
+			[
+				'unzip',
+				'-o',
+				'<(RULE_INPUT_PATH)',
+				'-d',
+				'<@(_outputs)',
+			],
+		},
+	],
+}


### PR DESCRIPTION
The unzip rule is useful when extracting classes.jar from a list
of aars.