### PR TITLE
[[ ReleaseNotes ]] Fix issue with release notes extension category

### DIFF
--- a/builder/release_notes_builder.livecodescript
+++ b/builder/release_notes_builder.livecodescript
@@ -97,6 +97,9 @@ command releaseNotesBuilderRun pEdition, pVersion, pReleaseType, pOutputDir
                   case "scriptprofiler"
                   case "securekey"
                   case "pdf"
+                  case "androidbarcode"
+                  case "androidbarcodescanner"
+                  case "androidbarcodesupport"                     
                      put "business" into tComponents[tIndex]["metadata"]["edition"]
                      break
                   default


### PR DESCRIPTION
Make sure thre android barcode components notes are in the correct
release notes edition.