### PR TITLE
[[ Bug 22060 ]] Stop point values with matching hashes from overwriting each other.

### DIFF
--- a/docs/lcb/notes/22060.md
+++ b/docs/lcb/notes/22060.md
@@ -1,0 +1,1 @@
+# [22060] Fix bug in canvas library that can result in Points being initialized with previously used values.

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -843,7 +843,7 @@ static bool __MCCanvasPointEqual(MCValueRef p_left, MCValueRef p_right)
 	if (p_left == p_right)
 		return true;
 	
-	return MCMemoryCompare(MCValueGetExtraBytesPtr(p_left), MCValueGetExtraBytesPtr(p_left), sizeof(__MCCanvasPointImpl)) == 0;
+	return MCMemoryCompare(MCValueGetExtraBytesPtr(p_left), MCValueGetExtraBytesPtr(p_right), sizeof(__MCCanvasPointImpl)) == 0;
 }
 
 static hash_t __MCCanvasPointHash(MCValueRef p_value)


### PR DESCRIPTION
False positives in MCCanvasPoint compare function were leading to point
values with duplicate hashes being incorrectly identified as unique,
causing the most recent value to be replaced with the existing value.

This patch fixes the comparison function in order to remove these false
positives.