### PR TITLE
[[ Bug ]] Strip quotes when pathifying arguments

### DIFF
--- a/tools/pathify.sh
+++ b/tools/pathify.sh
@@ -3,7 +3,7 @@
 # Turns a series of arguments into a path string
 
 for item in $*; do
-  path="${path:+${path}:}${item}"
+  path="${path:+${path}:}$(echo "$item" | tr -d '"')"
 done
 
 echo $path


### PR DESCRIPTION
This patch changes the pathify script to strip quotes from arguments before
appending to the path string. This resolves an issue where paths with variables
such as `$(builddir)` were being appended including quotes and breaking the
path string.