### PR TITLE
[[ Bug 21941 ]] Ensure calls into Java don't accumulate JNI local-refs

### DIFF
--- a/docs/notes/bugfix-21941.md
+++ b/docs/notes/bugfix-21941.md
@@ -1,0 +1,1 @@
+# Fix local-ref overflow when repeatedly calling Java from LCB on older Android OSes


### PR DESCRIPTION
This patch fixes an issue where multiple calls into Java from LCB could
cause a local-ref table overflow on older Android OS versions.

The issue has been fixed by ensuring that all local-refs which are
generated by JNI calls are deleted when no longer used, rather than
assuming that they will be cleared up automatically by the JVM when
control is returned to Java.

To achieve this a new (templatized) auto class has been introduced:
MCJavaAutoLocalRef<T>. This holds a JNI object reference of type T
which it takes on construction, it then deletes the local-ref on
destruction. The auto-class casts automatically to T.