### PR TITLE
[[ Bug 22063 ]] Ensure nothing is a valid optional foreign handler value

### DIFF
--- a/docs/lcb/notes/22063.md
+++ b/docs/lcb/notes/22063.md
@@ -1,0 +1,1 @@
+# [22063] Ensure nothing can be passed to an optional foreign handler type parameter

--- a/libscript/src/script-execute.cpp
+++ b/libscript/src/script-execute.cpp
@@ -1224,7 +1224,8 @@ MCScriptExecuteContext::UnboxingConvert(MCValueRef p_value,
         }
 	}
 	else if (MCTypeInfoIsHandler(p_slot_type.type) &&
-			 MCHandlerTypeInfoIsForeign(p_slot_type.type))
+			 MCHandlerTypeInfoIsForeign(p_slot_type.type) &&
+             p_value != kMCNull)
 	{
 		// If the slot type is a foreign handler, then we fetch a closure
 		// from the handler value.

--- a/tests/lcb/vm/native-callback.lcb
+++ b/tests/lcb/vm/native-callback.lcb
@@ -58,6 +58,23 @@ public handler TestNativeCallback()
 	test "use function pointer" when sTotal is (1 + 2 + 3 + 4 + 5 + 6)
 end handler
 
+--------- NULLPTR FUNCTION PTRS
+
+foreign handler type DummyHandlerType() returns nothing
+
+/* To test whether nothing can be passed as an optional handler type value we
+ * need any function which takes a pointer, but will ignore it. */
+foreign handler MCDataCreateWithBytes(in pPointer as optional DummyHandlerType, in pLength as LCUIndex, out rData as Data) returns CBool binds to "<builtin>"
+
+public handler TestNullptrNativeCallback()
+	variable tDummyHandler as optional DummyHandlerType
+	variable tDummyData as optional Data
+	unsafe
+		MCDataCreateWithBytes(tDummyHandler, 0, tDummyData)
+	end unsafe
+	test "use nothing as optional function pointer" when tDummyData is not nothing
+end handler
+
 --------- FOREIGN HANDLER FUNCTION PTRS
 
 -- This test checks that it is possible to pass foreign handlers around as


### PR DESCRIPTION
This patch ensures that nothing can be passed as an argument to a handler
parameter which is typed as an optional foreign handler type. Previously
the value passed was being dereferenced as a handler value without checking
whether it was kMCNull first.