### PR TITLE
[[ Bug ]] Ensure browser widget callbacks are reset on finalize

### DIFF
--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -112,9 +112,9 @@ public foreign handler type MCBrowserRequestCallback(in pContext as optional Poi
 public foreign handler type MCBrowserJavaScriptCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pHandler as ZStringUTF8, in pParams as MCBrowserListRef) returns nothing
 public foreign handler type MCBrowserProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pProgress as UInt32) returns nothing
 
-public foreign handler MCBrowserSetRequestHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
-public foreign handler MCBrowserSetJavaScriptHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserJavaScriptCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
-public foreign handler MCBrowserSetProgressHandler(in pBrowser as MCBrowserRef, in pCallback as MCBrowserProgressCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetRequestHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetJavaScriptHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserJavaScriptCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetProgressHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserProgressCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 
 --------------------------------------------------------------------------------
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -560,10 +560,14 @@ private unsafe handler InitBrowserView()
 end handler
 
 private unsafe handler FinalizeBrowserView()
-	if mOpenState is not kOpenStateClosed then
+    if mOpenState is not kOpenStateClosed then
 		set my native layer to nothing
 
-		if mBrowser is not nothing then
+        if mBrowser is not nothing then
+            MCBrowserSetRequestHandler(mBrowser, nothing, nothing)
+            MCBrowserSetJavaScriptHandler(mBrowser, nothing, nothing)
+            MCBrowserSetProgressHandler(mBrowser, nothing, nothing)
+
 			MCBrowserRelease(mBrowser)
 			put nothing into mBrowser
 		end if


### PR DESCRIPTION
This patch ensures that the foreign handler callbacks used by the browser
widget are reset to nothing when the widget is finalized. This stops them
being triggered when the widget's script object is destroyed before the
internal browser object.