### PR TITLE
[[ Widget ]] Add ability to specify property set when accessing properties

### DIFF
--- a/docs/lcb/notes/feature-property_of_set.md
+++ b/docs/lcb/notes/feature-property_of_set.md
@@ -1,0 +1,13 @@
+# LiveCode Builder Host Library
+## Engine library
+
+A new syntax variant `property <propertyName> of set <setName> of <object>` has
+been added to allow access to values from custom property sets.
+
+For example to save and restore the rect of a widget to a custom property set:
+	// save
+	set property "savedRect" of set "cGeometry" of my script object to my rect
+	
+	// restore
+	set property "rect" of my script object to property "savedRect" of set "cGeometry" of my script object
+	

--- a/engine/src/engine.lcb
+++ b/engine/src/engine.lcb
@@ -46,6 +46,8 @@ public foreign handler MCEngineEvalScriptObjectExists(in pObject as ScriptObject
 public foreign handler MCEngineEvalScriptObjectDoesNotExist(in pObject as ScriptObject, out rExists as CBool) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecGetPropertyOfScriptObject(in pProperty as String, in pObject as ScriptObject, out rValue as any) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecSetPropertyOfScriptObject(in pValue as any, in pProperty as String, in pObject as ScriptObject) returns nothing binds to "<builtin>"
+public foreign handler MCEngineExecGetPropertyOfSetOfScriptObject(in pProperty as String, in pSet as String, in pObject as ScriptObject, out rValue as any) returns nothing binds to "<builtin>"
+public foreign handler MCEngineExecSetPropertyOfSetOfScriptObject(in pValue as any, in pProperty as String, in pSet as String, in pObject as ScriptObject) returns nothing binds to "<builtin>"
 public foreign handler MCEngineEvalOwnerOfScriptObject(in pObject as ScriptObject, out rParent as ScriptObject) returns nothing binds to "<builtin>"
 public foreign handler MCEngineEvalChildrenOfScriptObject(in pObject as ScriptObject, out rChildren as List) returns nothing binds to "<builtin>"
 public foreign handler MCEngineExecSendToScriptObject(in pIsFunction as CBool, in pMessage as String, in pTarget as ScriptObject) returns optional any binds to "<builtin>"
@@ -181,6 +183,7 @@ end syntax
 /**
 Summary:	The property of a script object.
 Property: 	The name of the property to manipulate
+Set:		The name of the custom property set to access
 Object:		An expression that evaluates to a <ScriptObject>.
 
 
@@ -194,6 +197,9 @@ Example:
 	set property "invisible" of the result to true
     get property "script" of my script object
 
+Example:
+	get property "customProp" of set "cMyCustomPropertySet" of my script object
+	
 Description:
 Use to manipulate properties of a script object.
 
@@ -210,6 +216,13 @@ syntax PropertyOfScriptObject is prefix operator with property precedence
 begin
     MCEngineExecGetPropertyOfScriptObject(Property, Object, output)
     MCEngineExecSetPropertyOfScriptObject(input, Property, Object)
+end syntax
+
+syntax PropertyOfSetOfScriptObject is prefix operator with property precedence
+    "property" <Property: Expression> "of" "set" <Set: Expression> "of" <Object: Expression>
+begin
+    MCEngineExecGetPropertyOfSetOfScriptObject(Property, Set, Object, output)
+    MCEngineExecSetPropertyOfSetOfScriptObject(input, Property, Set, Object)
 end syntax
 
 /**

--- a/engine/src/module-engine.cpp
+++ b/engine/src/module-engine.cpp
@@ -267,7 +267,7 @@ bool MCEngineEvalObjectOfScriptObject(MCScriptObjectRef p_object, MCObject *&r_o
 	return true;
 }
 
-MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id)
+MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id)
 {
 	Properties t_prop;
 	t_prop = parse_property_name(p_property);
@@ -276,11 +276,14 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 	
 	if (t_prop == P_CUSTOM)
 	{
-		MCNewAutoNameRef t_propset_name, t_propset_key;
-		t_propset_name = p_object -> getdefaultpropsetname();
-		if (!MCNameCreate(p_property, &t_propset_key))
+		MCNewAutoNameRef t_set_name, t_prop_name;
+		if (MCStringIsEmpty(p_set))
+			t_set_name = p_object -> getdefaultpropsetname();
+		else if (!MCNameCreate(p_set, &t_set_name))
 			return nil;
-		p_object -> getcustomprop(ctxt, *t_propset_name, *t_propset_key, nil, t_value);
+		if (!MCNameCreate(p_property, &t_prop_name))
+			return nil;
+		p_object -> getcustomprop(ctxt, *t_set_name, *t_prop_name, nil, t_value);
 	}
 	else
 		p_object -> getprop(ctxt, p_part_id, t_prop, nil, False, t_value);
@@ -301,7 +304,7 @@ MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_proper
 	return t_value_ref;
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef& r_value)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfSetOfScriptObject(MCStringRef p_property, MCStringRef p_set, MCScriptObjectRef p_object, MCValueRef& r_value)
 {
     if (!MCEngineEnsureScriptObjectAccessIsAllowed())
     {
@@ -318,11 +321,16 @@ extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringR
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 
     // AL-2015-07-24: [[ Bug 15630 ]] Syntax binding dictates value returned as out parameter rather than directly
-	r_value = MCEngineGetPropertyOfObject(ctxt, p_property, t_object, t_part_id);
+	r_value = MCEngineGetPropertyOfObject(ctxt, p_set, p_property, t_object, t_part_id);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecGetPropertyOfScriptObject(MCStringRef p_property, MCScriptObjectRef p_object, MCValueRef& r_value)
+{
+	MCEngineExecGetPropertyOfSetOfScriptObject(p_property, kMCEmptyString, p_object, r_value);
 }
 
 // IM-2015-02-23: [[ WidgetPopup ]] Factored-out function for setting the named property of an object to a value.
-void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value)
+void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value)
 {
     MCValueRef t_value_copy;
     t_value_copy = MCValueRetain(p_value);
@@ -343,14 +351,20 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
     
     if (t_prop == P_CUSTOM)
     {
-        MCNewAutoNameRef t_propset_name, t_propset_key;
-		t_propset_name = p_object -> getdefaultpropsetname();
-        if (!MCNameCreate(p_property, &t_propset_key))
-        {
-            MCValueRelease(t_value_copy);
-            return;
-        }
-		p_object -> setcustomprop(ctxt, *t_propset_name, *t_propset_key, nil, t_value);
+		MCNewAutoNameRef t_set_name, t_prop_name;
+		if (MCStringIsEmpty(p_set))
+			t_set_name = p_object -> getdefaultpropsetname();
+		else if (!MCNameCreate(p_set, &t_set_name))
+		{
+			MCValueRelease(t_value_copy);
+			return;
+		}
+		if (!MCNameCreate(p_property, &t_prop_name))
+		{
+			MCValueRelease(t_value_copy);
+			return;
+		}
+		p_object -> setcustomprop(ctxt, *t_set_name, *t_prop_name, nil, t_value);
     }
     else
 		p_object -> setprop(ctxt, p_part_id, t_prop, nil, False, t_value);
@@ -362,21 +376,26 @@ void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MC
     }
 }
 
-extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCScriptObjectRef p_object)
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfSetOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCStringRef p_set, MCScriptObjectRef p_object)
 {
-    if (!MCEngineEnsureScriptObjectAccessIsAllowed())
-    {
-        return;
-    }
-    
+	if (!MCEngineEnsureScriptObjectAccessIsAllowed())
+	{
+		return;
+	}
+	
 	MCObject *t_object;
 	uint32_t t_part_id;
 	if (!MCEngineEvalObjectOfScriptObject(p_object, t_object, t_part_id))
 		return;
 	
-    MCExecContext ctxt(MCdefaultstackptr, nil, nil);
+	MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 
-	MCEngineSetPropertyOfObject(ctxt, p_property, t_object, t_part_id, p_value);
+	MCEngineSetPropertyOfObject(ctxt, p_set, p_property, t_object, t_part_id, p_value);
+}
+
+extern "C" MC_DLLEXPORT_DEF void MCEngineExecSetPropertyOfScriptObject(MCValueRef p_value, MCStringRef p_property, MCScriptObjectRef p_object)
+{
+	MCEngineExecSetPropertyOfSetOfScriptObject(p_value, p_property, kMCEmptyString, p_object);
 }
 
 extern "C" MC_DLLEXPORT_DEF void MCEngineEvalOwnerOfScriptObject(MCScriptObjectRef p_object, MCScriptObjectRef &r_owner)
@@ -589,9 +608,7 @@ void MCEngineDoPostToObjectWithArguments(MCStringRef p_message, MCObject *p_obje
     
     MCExecContext ctxt(MCdefaultstackptr, nil, nil);
     MCParameter *t_params;
-    MCValueRef t_result;
     t_params = nil;
-    t_result = nil;
     
     if (!MCEngineConvertToScriptParameters(ctxt, p_arguments, t_params))
         return;

--- a/engine/src/objectprops.cpp
+++ b/engine/src/objectprops.cpp
@@ -279,7 +279,7 @@ Exec_stat MCObject::sendgetprop(MCExecContext& ctxt, MCNameRef p_set_name, MCNam
 		t_getprop_name = p_set_name, t_param_name = p_prop_name;
     
 	Exec_stat t_stat = ES_NOT_HANDLED;
-	if (!MClockmessages && (ctxt . GetObject() != this || !ctxt . GetHandler() -> hasname(t_getprop_name)))
+	if (!MClockmessages && (ctxt . GetObject() != this || ctxt.GetHandler() == nil || !ctxt . GetHandler() -> hasname(t_getprop_name)))
 	{
 		MCParameter p1;
 		p1.setvalueref_argument(t_param_name);

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -57,8 +57,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id);
-extern void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value);
+extern MCValueRef MCEngineGetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id);
+extern void MCEngineSetPropertyOfObject(MCExecContext &ctxt, MCStringRef p_set, MCStringRef p_property, MCObject *p_object, uint32_t p_part_id, MCValueRef p_value);
 
 class MCWidgetPopup: public MCStack
 {
@@ -189,7 +189,7 @@ private:
 		
 		while (MCArrayIterate(p_properties, t_iter, t_key, t_value))
 		{
-			MCEngineSetPropertyOfObject(ctxt, MCNameGetString(t_key), m_widget, 0, t_value);
+			MCEngineSetPropertyOfObject(ctxt, kMCEmptyString, MCNameGetString(t_key), m_widget, 0, t_value);
 			if (MCErrorIsPending())
 				return false;
 		}
@@ -231,7 +231,7 @@ private:
 	{
 		MCExecContext ctxt(MCdefaultstackptr, nil, nil);
 		MCAutoValueRef t_value;
-		t_value = MCEngineGetPropertyOfObject(ctxt, MCSTR("preferredSize"), m_widget, 0);
+		t_value = MCEngineGetPropertyOfObject(ctxt, kMCEmptyString, MCSTR("preferredSize"), m_widget, 0);
 		if (MCErrorIsPending())
 			return false;
 		


### PR DESCRIPTION
This patch adds the syntax `property <prop> of set <set> of <object>`
to specify which object property set to fetch a value from.