### PR TITLE
[[ Bug ]] Fix module lcext note to describe correct docs update

### DIFF
--- a/docs/notes/feature-modulelcext.md
+++ b/docs/notes/feature-modulelcext.md
@@ -2,6 +2,6 @@
 
 The standalone builder now supports `.lcext` compiled objects that link static
 libraries used by a LCB module to the module compiled as C++ using lc-compile's
-`--forcebuiltins --outputauxc` options. Additionaly, a new section named 
-Foreign Code Libraries has been added to the LiveCode Builder Language Reference
-describing the creation of `.lcext` objects and use of code libraries in general.
+`--forcebuiltins --outputauxc` options. Additionally, the `Using compiled libraries`
+section of the `Extending LiveCode` guide has been updated to describe the
+creation of `.lcext` objects.


### PR DESCRIPTION
The release note for the changes to static linked code libraries for iOS was
not updated when the documentation changes were moved to the `Extending LiveCode`
guide.