### PR TITLE
[[ Bug 22070 ]] Fix answer with type on macOS

### DIFF
--- a/docs/notes/bugfix-22070.md
+++ b/docs/notes/bugfix-22070.md
@@ -1,0 +1,1 @@
+# Fix `answer file with type` setting `the result` to the chosen file path instead of chosen file type on macOS

--- a/engine/src/desktop-ans.cpp
+++ b/engine/src/desktop-ans.cpp
@@ -211,7 +211,7 @@ int MCA_file_with_types(MCStringRef p_title, MCStringRef p_prompt, MCStringRef *
     {        
         r_value = MCValueRetain(*t_file);
         if (*t_type != nil)
-            r_result = MCValueRetain(*t_file);
+            r_result = MCValueRetain(*t_type);
     }
 	
 	return 0;


### PR DESCRIPTION
This patch fixes a bug introduced during the refactor of LiveCode where on macOS the
answer file with type command sets both `the result` and `it` to the chosen file path
rather than setting `the result` to the chosen file type.