### PR TITLE
[[ Bug 22085 ]] Fix use after release of dashes struct lengths field

### DIFF
--- a/docs/notes/bugfix-22085.md
+++ b/docs/notes/bugfix-22085.md
@@ -1,0 +1,1 @@
+# Ensure dashes offset drawing library opcode works correctly

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -1694,10 +1694,17 @@ void MCGContextSetStrokeCapStyle(MCGContextRef self, MCGCapStyle p_style)
 
 void MCGContextSetStrokeDashOffset(MCGContextRef self, MCGFloat p_offset)
 {
-    MCGContextSetStrokeDashes(self,
-                              p_offset,
-                              self->state->stroke_attr.dashes != nullptr ? self->state->stroke_attr.dashes->lengths : nullptr,
-                              self->state->stroke_attr.dashes != nullptr ? self->state->stroke_attr.dashes->count : 0);
+	if (self->state->stroke_attr.dashes != nullptr)
+	{
+		MCGContextSetStrokeDashes(self,
+								  p_offset,
+								  self->state->stroke_attr.dashes->lengths,
+								  self->state->stroke_attr.dashes->count);
+	}
+	else
+	{
+		MCGContextSetStrokeDashes(self, p_offset, nullptr, 0);
+	}
 }
 
 void MCGContextSetStrokeDashArray(MCGContextRef self, const MCGFloat *p_lengths, uindex_t p_arity)
@@ -1706,22 +1713,25 @@ void MCGContextSetStrokeDashArray(MCGContextRef self, const MCGFloat *p_lengths,
 }
 
 void MCGContextSetStrokeDashes(MCGContextRef self, MCGFloat p_phase, const MCGFloat *p_lengths, uindex_t p_arity)
-{	
+{
 	if (!MCGContextIsValid(self))
 		return;
-	
-	bool t_success;
-	t_success = true;	
-	
+
+	bool t_success = true;
+
+	MCGDashesRef t_dashes = nullptr;
 	if (t_success)
 	{
+		t_success = MCGDashesCreate(p_phase, p_lengths, p_arity, t_dashes);
+	}
+
+	if (t_success)
+    {
 		MCGDashesRelease(self -> state -> stroke_attr . dashes);
-		self -> state -> stroke_attr . dashes = NULL;
-		
-        t_success = MCGDashesCreate(p_phase, p_lengths, p_arity, self -> state -> stroke_attr . dashes);
-	}	
-		
-	self -> is_valid = t_success;	
+		self -> state -> stroke_attr . dashes = t_dashes;
+    }
+
+	self -> is_valid = t_success;
 }
 
 void MCGContextSetStrokePaintStyle(MCGContextRef self, MCGPaintStyle p_paint_style)


### PR DESCRIPTION
This patch fixes an issue that arises when using the dashes offset
opcode of the drawing library - the dashes struct's lengths field
is meant to be re-used for the new dashes with offset, but it is
actually released first, causing the passed-in lengths pointer to be
invalid.