### PR TITLE
[Dictionary] mobilePickDate to movieTouched

### DIFF
--- a/docs/dictionary/command/mobilePickDate.lcdoc
+++ b/docs/dictionary/command/mobilePickDate.lcdoc
@@ -67,8 +67,6 @@ Android is "date"
 
 - "datetime" (default on iOS) (iOS only): display a native picker to
   choose the date and time
-
-
 -   "date" (default on Android): display a native picker to choose the
     date 
 -   "time": display a native picker to choose the time

--- a/docs/dictionary/command/mobileSetFullScreenRectForOrientations.lcdoc
+++ b/docs/dictionary/command/mobileSetFullScreenRectForOrientations.lcdoc
@@ -53,4 +53,5 @@ the <mobileAllowedOrientations>.
 References: mobileLockOrientation (command), mobileSetAllowedOrientations (command),
 mobileUnlockOrientation (command), mobileAllowedOrientations (function),
 mobileDeviceOrientation (function), mobileOrientation (function),
-orientationChanged (message), resizeStack (message)
+orientationChanged (message), resizeStack (message),
+fullscreenMode (property)

--- a/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
+++ b/docs/dictionary/command/mobileSetLocationHistoryLimit.lcdoc
@@ -70,6 +70,6 @@ mobileStartTrackingSensor (command),
 mobileGetLocationHistory (function),
 mobileGetLocationHistoryLimit (function),
 mobileSensorAvailable (function), mobileSensorReading (function),
-mobileLocationAuthorizationStatus (function),
+mobileLocationAuthorizationStatus (function), function (glossary),
 locationChanged (message), trackingError (message)
 

--- a/docs/dictionary/function/mobileSensorReading.lcdoc
+++ b/docs/dictionary/function/mobileSensorReading.lcdoc
@@ -38,19 +38,21 @@ false
 
 
 Returns:
-Location -  a comma separated list of the latitude, longitude and
+-   Location -  a comma separated list of the latitude, longitude and
 altitude of the device. If any of these readings are not available, an
 empty item will be returned in its place. If <detailed> is true an array
 containing the keys latitude, longitude, altitude, timestamp, horizontal
-accuracy and vertical accuracy is returned. Heading - the heading of the
+accuracy and vertical accuracy is returned. 
+-   Heading - the heading of the
 device in degrees. If <detailed> is true an array containing the keys
 heading, magnetic heading, true heading, timestamp, x, y, z and accuracy
-is returned. Acceleration - a comma separated list of the acceleration
+is returned. 
+-   Acceleration - a comma separated list of the acceleration
 in the x, y and z axes. If <detailed> is true an array containing the
-keys x, y, z and timestamp is returned. Rotation Rate - a comma
-separated list of the rate of rotation around the x, y and z axes. If
-<detailed> is true an array containin the keys x, y, z and timestamp is
-returned. 
+keys x, y, z and timestamp is returned. 
+-   Rotation Rate - a comma separated list of the rate of rotation 
+around the x, y and z axes. If <detailed> is true an array containing 
+the keys x, y, z and timestamp is returned. 
 
 Description:
 Use the <mobileSensorReading> function to fetch a reading from the named

--- a/docs/dictionary/function/mouseChunk.lcdoc
+++ b/docs/dictionary/function/mouseChunk.lcdoc
@@ -43,8 +43,8 @@ the first <character> of the <word>, and the endChar is the last
 To get the text of the word or text group, use the mouseText <function>.
 
 >*Important:*  Words are defined a little differently by the
-> <mouseChunk> <function> than the way they are used in <chunk
-> expression|chunk expressions>. A word, for purposes of the
+> <mouseChunk> <function> than the way they are used in 
+> <chunk expression|chunk expressions>. A word, for purposes of the
 > <mouseChunk>, is any text delimited by spaces, tabs, returns, or
 > punctuation. If the mouse pointer is over a punctuation <character>,
 > only that <character> is returned.

--- a/docs/dictionary/function/mouseControl.lcdoc
+++ b/docs/dictionary/function/mouseControl.lcdoc
@@ -52,7 +52,7 @@ References: function (control structure), within (function),
 mouseCharChunk (function), property (glossary), mouse pointer (glossary),
 return (glossary), string (keyword), control (keyword), graphic (keyword),
 mouseEnter (message), mouseLeave (message), stack (object),
-control (object), graphic (object), filled (property), layer (property)
+graphic (object), filled (property), layer (property)
 
 Tags: ui
 

--- a/docs/dictionary/message/mouseDoubleDown.lcdoc
+++ b/docs/dictionary/message/mouseDoubleDown.lcdoc
@@ -37,20 +37,20 @@ The <mouseDoubleDown> <message> is sent to the <control> that was
 under the <mouse pointer>.
 
 The <mouseDoubleDown> <message> is sent only when the <Browse tool> is
-being used. If an <unlock|unlocked> <field> is clicked with <mouse
-button> 1 or 2, no <mouseDoubleDown> <message> is sent.
+being used. If an <unlock|unlocked> <field> is clicked with 
+<mouse button> 1 or 2, no <mouseDoubleDown> <message> is sent.
 
 >*Note:*  If the user clicks a transparent <pixel> in an <image>,
 > the <mouseDoubleDown> <message> is sent to the <object(glossary)>
 > behind the <image>, not to the <image>.
 
-References: Browse tool (glossary), card (glossary), 
-control (glossary), double-click (glossary), 
+References: pass (control structure), Browse tool (glossary), 
+card (glossary), control (glossary), double-click (glossary), 
 doubleClickDelta (property), doubleClickInterval (property), 
 field (glossary), image (glossary), message (glossary), 
 mouse button (glossary), mouse pointer (glossary), 
 mouseDoubleUp (message), mouseStillDown (message), object (glossary), 
-pass (command), pixel (glossary), unlock (glossary)
+pixel (glossary), unlock (glossary)
 
 Tags: ui
 

--- a/docs/dictionary/message/mouseDoubleUp.lcdoc
+++ b/docs/dictionary/message/mouseDoubleUp.lcdoc
@@ -50,14 +50,13 @@ what LiveCode accepts as a <double-click|double click>.
 > the <mouseDoubleUp> <message> is sent to the <object(glossary)> behind
 > the <image>, not to the <image>.
 
-References: answer file (command), Browse tool (glossary), 
-card (glossary), click (command), clickLoc (function), 
+References: answer file (command), click (command), pass (control structure),
+Browse tool (glossary), card (glossary), clickLoc (function), 
 control (glossary), double-click (glossary), doubleClickDelta (property), 
 doubleClickInterval (property), field (glossary), image (glossary), 
 message (glossary), mouse (function), mouse button (glossary), 
 mouse pointer (glossary), mouseDoubleDown (message), object (glossary), 
-pass (command), pixel (glossary), properties (property), 
-unlock (glossary)
+pixel (glossary), properties (property), unlock (glossary)
 
 Tags: ui
 

--- a/docs/dictionary/message/mouseUp.lcdoc
+++ b/docs/dictionary/message/mouseUp.lcdoc
@@ -59,9 +59,10 @@ sent instead of <mouseUp>. If the click is the second click of a
 > example, if the user clicks an "Increase" button that increases a
 > number by 1), some of the clicks may send a <mouseDoubleUp> <message>
 > instead of <mouseUp>. If your <script> only handles the <mouseUp>
-> <message>, these accidental double-click|double-clicks> will be lost. One way to
-> prevent this is to install a <handler> in an <object(glossary)> that's
-> further in the <message path>, to re-send double-click|double-clicks>:
+> <message>, these accidental <double-click|double-clicks> will be lost. 
+> One way to prevent this is to install a <handler> in an 
+> <object(glossary)> that's further in the <message path>, to re-send 
+> double-click|double-clicks>:
 
     on mouseDoubleUp
       if "on mouseUp" is in the script of the target and \

--- a/docs/dictionary/message/mouseUpInBackdrop.lcdoc
+++ b/docs/dictionary/message/mouseUpInBackdrop.lcdoc
@@ -5,7 +5,7 @@ Type: message
 Syntax: mouseUpInBackdrop <pButtonNumber>
 
 Summary:
-Sent when the user releases the <mouse button>. while the 
+Sent when the user releases the <mouse button>, while the 
 <mouse pointer> is in the backdrop.
 
 Associations: card

--- a/docs/dictionary/message/movieTouched.lcdoc
+++ b/docs/dictionary/message/movieTouched.lcdoc
@@ -16,7 +16,7 @@ Platforms: mobile
 
 Example:
 on movieTouched
-  stop me
+  play stop
 end movieTouched
 
 Description:
@@ -27,12 +27,12 @@ The <movieTouched> message is sent to the object whose script started
 the movie playing.
 
 The principal purpose of the <movieTouched> message is to allow the
-<stop> command to be used to stop the movie when the screen is touched. 
+<play|play stop> command to be used to stop the movie when the screen is touched. 
 
 >*Note:* The <movieTouched> message is not sent if the video is played
 > with the <showController> property set to true.
 
-References: stop (command), play video (command),
+References: play (command), play video (command),
 showController (property)
 
 Tags: ui

--- a/docs/dictionary/message/movieTouched.lcdoc
+++ b/docs/dictionary/message/movieTouched.lcdoc
@@ -16,7 +16,7 @@ Platforms: mobile
 
 Example:
 on movieTouched
-  play stop
+  stop me
 end movieTouched
 
 Description:
@@ -27,13 +27,12 @@ The <movieTouched> message is sent to the object whose script started
 the movie playing.
 
 The principal purpose of the <movieTouched> message is to allow the
-<play stop> command to be used to stop the movie when the screen is
-touched. 
+<stop> command to be used to stop the movie when the screen is touched. 
 
 >*Note:* The <movieTouched> message is not sent if the video is played
 > with the <showController> property set to true.
 
-References: play stop (command), play video (command),
+References: stop (command), play video (command),
 showController (property)
 
 Tags: ui

--- a/docs/dictionary/property/HTMLText.lcdoc
+++ b/docs/dictionary/property/HTMLText.lcdoc
@@ -156,7 +156,7 @@ attributes of the &lt;font&gt; tag.
   <fontLanguage|language> specification.
 * color="#NNNNNN" appears if the <foregroundColor> is not the <default>.
 * bgcolor="#NNNNNN" appears if the <backgroundColor> is not the
-  > <default>. 
+  <default>. 
 
 >*Note:* An <HTML>-style color definition consists of a hash mark (#)
 > followed by three 2-digit hexadecimal numbers,

--- a/docs/dictionary/property/label.lcdoc
+++ b/docs/dictionary/property/label.lcdoc
@@ -7,8 +7,8 @@ Type: property
 Syntax: set the label of <object> to <labelString>
 
 Summary:
-Specifies the <string> shown in a <stack window|stack window's> <title
-bar>, or a text label to be displayed on the specified
+Specifies the <string> shown in a <stack window|stack window's> 
+<title bar>, or a text label to be displayed on the specified
 <object(glossary)> if its <showName> <property> is true.
 
 Associations: stack, button, graphic


### PR DESCRIPTION
mobilePickDate (command): Adjusted linespacing to dispose of "One of the following items:"
mobileSensorReading (function): reformatted returns details.
mobileSetFullscreenRectForOrientation (command): Added missing reference.
label (property): Fixed broken link.
mouseChunk (function): Fixed broken link.
mouseControl (function): Removed reference to non-existent entry.
mouseDoubleDown (message): Corrected a reference's type.
mouseDoubleUp (message): Corrected a reference's type.
mouseUp (message): Fixed broken links
mouseUpInBackdrop (message): Changed punctuation to make it stop looking like text was missing.
HTMLText (property): Removed formatting that separated a word from the rest of the sentence it was in.
movieTouched (message): Replaced incorrect reference.