### PR TITLE
[[ Bug 17323 ]] refresh windows after backdrop is created

### DIFF
--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -1387,21 +1387,21 @@ void MCScreenDC::enablebackdrop(bool p_hard)
 	
 	if (!t_error)	
 	{
-        MCstacks -> refresh();
         gdk_window_set_functions(backdrop, GdkWMFunction(0));
         gdk_window_set_decorations(backdrop, GdkWMDecoration(0));
         gdk_window_set_skip_taskbar_hint(backdrop, TRUE);
         gdk_window_set_skip_pager_hint(backdrop, TRUE);
-	gdk_window_move_resize(backdrop, 0, 0, device_getwidth(), device_getheight());
+        gdk_window_move_resize(backdrop, 0, 0, device_getwidth(), device_getheight());
         gdk_window_lower(backdrop);
-	gdk_window_show_unraised(backdrop);
+        gdk_window_show_unraised(backdrop);
 	}
 	else
 	{
 		backdrop_active = False;
-		MCstacks -> refresh();
 		//finalisebackdrop();
 	}
+    // MDW [17323] - refresh *after* the gdk calls
+    MCstacks -> refresh();
 }
 
 void MCScreenDC::disablebackdrop(bool p_hard)


### PR DESCRIPTION
This patch moves the call to `MCstacks->refresh()` to after the creation of the
presentation of the backdrop window to ensure that stack windows are raised
above it.

Notes:

1. Submitting this PR on behalf of @mwieder 
2. This PR replaces https://github.com/livecode/livecode/pull/6496
3. No bugfix note included, as there is already a file `docs/notes/bugfix-17323.md` from a previous PR that worked partially (i.e. fixed the problem in some Linux distros)