### PR TITLE
[[ Cleanup ]] Cleanup unexpected passes

### DIFF
--- a/tests/lcs/core/interface/interfaceui.livecodescript
+++ b/tests/lcs/core/interface/interfaceui.livecodescript
@@ -255,39 +255,36 @@ TestAssert "test", (the resizeable of this stack is false)
 end TestInterface63
 
 on TestBug11799Part1
- 
+   create stack "Test"
+   set the defaultstack to "Test"
+   create field
 
-create stack "Test"
-set the defaultstack to "Test"
-create field
+   focus on field 1
 
-focus on field 1
+   -- For some reason focusing doesn't happen until events are processed...
+   wait 0 seconds with messages
 
--- For some reason focusing doesn't happen until events are processed...
-wait 0 seconds with messages
-
-TestAssertBroken "test", the focusedObject is the long id of field 1, "11799"
-
+   TestAssert "focusedObject correct after focusing on field ", \
+         the focusedObject is the long id of field 1
 end TestBug11799Part1
+
 on TestBug11799Part2
+   create stack "Test"
+   set the defaultstack to "Test"
+   create field 1
 
+   focus on field 1
 
-create stack "Test"
-set the defaultstack to "Test"
-create field 1
+   -- For some reason focusing doesn't happen until events are processed...
+   wait 0 seconds with messages
 
-focus on field 1
+   focus on nothing
 
--- For some reason focusing doesn't happen until events are processed...
-wait 0 seconds with messages
+   -- After unfocusing, the card will be focused until events are processed...
+   -- ... at which point nothing will be.
 
-focus on nothing
-
--- After unfocusing, the card will be focused until events are processed...
--- ... at which point nothing will be.
-
-TestAssertBroken "test", the focusedObject is the long id of this card, "11799"
-
+   TestAssert "focusedObject current card after focusing on nothing", \
+         the focusedObject is the long id of this card
 end TestBug11799Part2
 
 on TestInterface82

--- a/tests/lcs/core/interface/snapshot.livecodescript
+++ b/tests/lcs/core/interface/snapshot.livecodescript
@@ -18,9 +18,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on _TestImportScreenSnapshotFromRectHandler
     import snapshot from rectangle 100,100,500,400
-    
-    TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
-    TestAssertBroken "long id of image is it", it is the long id of the last image
+    TestAssert "long id of image is it", it is the long id of the last image
 end _TestImportScreenSnapshotFromRectHandler
 
 on TestImportScreenSnapshotFromRectNoUI
@@ -42,14 +40,11 @@ on _TestImportSnapshotFromStackHandler
     create stack "Untitled 1"
 
     import snapshot from window the windowId of stack "Untitled 1"
-    TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
-    TestAssertBroken "long id of image is it", it is the long id of the last image
+    TestAssert "long id of image is it", it is the long id of the last image
 end _TestImportSnapshotFromStackHandler
 
 on TestImportSnapshotFromStack
-    if the environment is not "command line" then
-        return "SKIP TEST"
-    end if
+    TestSkipIf "ui"
     TestAssertThrow "should now throw an error", "_TestImportSnapshotFromStackHandler",\
         the long id of me, "EE_SNAPSHOT_FAILED"
 end TestImportSnapshotFromStack
@@ -58,17 +53,14 @@ on TestImportSnapshotFromObject
     create button "b1"
 
     import snapshot from button "b1"
-
-    TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
-    TestAssertBroken "long id of image is it", it is the long id of the last image
+    TestAssert "long id of image is it", it is the long id of the last image
 end TestImportSnapshotFromObject
 
 on TestImportSnapshotFromRectOfObject
    create field "field 1"
    set the rect of field "field 1" to 0,0,100,100
-   
+
    import snapshot from rectangle 0,0,100,100 of field "field 1"
-   TestAssert "long id of new image is long id of it",  the long id of it is the long id of the last image
-   TestAssertBroken "long id of image is it", it is the long id of the last image
+   TestAssert "long id of image is it", it is the long id of the last image
 end TestImportSnapshotFromRectOfObject
 


### PR DESCRIPTION
This patch cleans up some unexpected test passes by changing the relevant calls to `TestAssertBroken` to calls to `TestAssert`