### PR TITLE
[[ Build ]] Only fetch prebuilts for target arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
 
 # Set up the source tree by fetching Linux-specific prebuilt objects
 install: 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then (cd prebuilt && ./fetch-libraries.sh linux) ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then (cd prebuilt && ./fetch-libraries.sh linux x86_64) ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]] ; then (cd prebuilt && ./fetch-libraries.sh mac)   ; fi
 
 # Bootstrap the LCB compiler, build the default target set and run a

--- a/prebuilt/fetch-libraries.sh
+++ b/prebuilt/fetch-libraries.sh
@@ -118,7 +118,29 @@ function fetchLibrary {
 if [ 0 -eq "$#" ]; then
     SELECTED_PLATFORMS="${PLATFORMS[@]}"
 else
-    SELECTED_PLATFORMS="$@"
+    ARGS_ARE_PLATFORMS=1
+    for SELECTED_PLATFORM in "$@" ; do
+        ARG_IS_PLATFORM=0
+        for AVAILABLE_PLATFORM in "${PLATFORMS[@]}"; do
+            if [ "$AVAILABLE_PLATFORM" == "$SELECTED_PLATFORM" ]; then
+                ARG_IS_PLATFORM=1
+                break
+            fi
+        done
+        if [ "$ARG_IS_PLATFORM" != "1" ]; then
+            ARGS_ARE_PLATFORMS=0
+            break
+        fi
+    done
+
+    if [ "$ARGS_ARE_PLATFORMS" == "1" ]; then
+        SELECTED_PLATFORMS="$@"
+    else
+        # If not all args are platforms, assume first arg is platform and the
+        # rest are architectures
+        SELECTED_PLATFORMS="$1"
+        shift 1
+    fi
 fi
 
 FETCH_HEADERS=0
@@ -132,11 +154,17 @@ for PLATFORM in ${SELECTED_PLATFORMS} ; do
 		FETCH_HEADERS=1
 	fi
 
-	eval "ARCHS=( \${ARCHS_${PLATFORM}[@]} )"
+    if [ "$ARGS_ARE_PLATFORMS" == "1" ]; then
+	    eval "ARCHS=( \${ARCHS_${PLATFORM}[@]} )"
+        SELECTED_ARCHS="${ARCHS[@]}"
+    else
+        SELECTED_ARCHS="$@"
+    fi
+
 	eval "LIBS=( \${LIBS_${PLATFORM}[@]} )"
 	eval "SUBPLATFORMS=( \${SUBPLATFORMS_${PLATFORM}[@]} )"
 
-	for ARCH in "${ARCHS[@]}" ; do
+	for ARCH in ${SELECTED_ARCHS} ; do
 		for LIB in "${LIBS[@]}" ; do
 			if [ ! -z "${SUBPLATFORMS}" ] ; then
 				for SUBPLATFORM in "${SUBPLATFORMS[@]}" ; do
@@ -168,7 +196,7 @@ for PLATFORM in ${SELECTED_PLATFORMS} ; do
 		# the "Release" configuration, in terms of linkability.  So if
 		# there's a "Release" build of any given library, duplicate
 		# it for "Fast"
-        for ARCH in "${ARCHS[@]}" ; do
+        for ARCH in ${SELECTED_ARCHS} ; do
                 for LIB in "${LIBS[@]}" ; do
                         echo "Providing 'Fast' configuration for ${LIB} library"
                         for SUBPLATFORM in "${SUBPLATFORMS[@]}"; do
@@ -186,7 +214,7 @@ for PLATFORM in ${SELECTED_PLATFORMS} ; do
                 done
         done
                         
-        for ARCH in "${ARCHS[@]}" ; do
+        for ARCH in ${SELECTED_ARCHS} ; do
                 for LIB in "${LIBS[@]}" ; do
                         echo "Monkey patching toolset/arch for ${LIB} library"
                         for SUBPLATFORM in "v140_static_debug" "v140_static_release" "v140_static_fast"; do

--- a/prebuilt/fetch.gyp
+++ b/prebuilt/fetch.gyp
@@ -311,13 +311,14 @@
 					
 					'outputs':
 					[
-						'lib/android/<(target_arch)',
+						'lib/android/>(target_arch)',
 					],
 					
 					'action':
 					[
 						'./fetch-libraries.sh',
 						'android',
+						'>(target_arch)',
 					],
 				},
 			],
@@ -347,6 +348,7 @@
 					[
 						'./fetch-libraries.sh',
 						'linux',
+						'<(host_arch)',
 					],
 				},
 			],
@@ -384,6 +386,22 @@
 			'target_name': 'fetch-win',
 			'type': 'none',
 
+			'variables':
+			{
+				'conditions':
+				[
+					[
+						'target_arch == "x64"',
+						{
+							'fetch_arch': 'x86_64',
+						},
+						{
+							'fetch_arch': 'x86',
+						},
+					],
+				],
+			},
+
 			'actions':
 			[
 				{
@@ -397,8 +415,8 @@
 					
 					'outputs':
 					[
-						'bin/win32/<(target_arch)',
-						'lib/win32/<(target_arch)',
+						'bin/win32/>(fetch_arch)',
+						'lib/win32/>(fetch_arch)',
                         'unpacked',
 					],
 					
@@ -407,7 +425,9 @@
 						'call',
 						'../util/invoke-unix.bat',
 						'./fetch-libraries.sh',
-						'win32',
+						# Ensure gyp does not treat these parameters as paths
+						'$(not_a_real_variable)win32',
+						'$(not_a_real_variable)>(fetch_arch)',
 					],
 				},
 			],


### PR DESCRIPTION
Previously all arguments to the fetch-libraries.sh script were
interpreted as platforms. This patch actually checks the arguments
are valid platforms, and if not, assumes only the first argument
is a platform and subsequent args are target architectures.

The prebuilt fetch gyp action has been modified to call the script
with the appropriate platform and architecture arguments.