### PR TITLE
[22129] Serial I/O: Expand the baudrates on Linux and Mac

### DIFF
--- a/docs/notes/bugfix-22129.md
+++ b/docs/notes/bugfix-22129.md
@@ -1,0 +1,1 @@
+# Serial I/O: Expand the baudrates on Linux and Mac

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -110,29 +110,38 @@ static void parseSerialControlStr(char *setting, struct termios *theTermios)
         if (MCU_strncasecmp(type, "baud", strlen(type)) == 0)
         {
             long baudrate = strtol(value, NULL, 10);
-            if (baudrate == 57600)
-                baud = B57600;
-            else if (baudrate == 38400)
-                baud = B38400;
-            else if (baudrate == 19200)
-                baud = B19200;
-            else if (baudrate == 9600)
+            
+            switch(baudrate)
+            {
+            case 4000000: baud = B4000000; break;
+            case 3500000: baud = B3500000; break;
+            case 3000000: baud = B3000000; break;
+            case 2500000: baud = B2500000; break;
+            case 2000000: baud = B2000000; break;
+            case 1500000: baud = B1500000; break;
+            case 1152000: baud = B1152000; break;
+            case 1000000: baud = B1000000; break;
+            case 921600: baud = B921600; break;
+            case 576000: baud = B576000; break;
+            case 500000: baud = B500000; break;
+            case 460800: baud = B460800; break;
+            case 230400: baud = B230400; break;
+            case 115200: baud = B115200; break;
+            case 57600: baud = B57600; break;
+            case 38400: baud = B38400; break;
+            case 19200: baud = B19200; break;
+            case 9600: baud = B9600; break;
+            case 4800: baud = B4800; break;
+            case 2400: baud = B2400; break;
+            case 1800: baud = B1800; break;
+            case 1200: baud = B1200; break;
+            case 600: baud = B600; break;
+            case 300: baud = B300; break;
+            default:
                 baud = B9600;
-
-            else if (baudrate == 4800)
-                baud = B4800;
-            else if (baudrate == 3600)
-                baud = B4800;
-            else if (baudrate == 2400)
-                baud = B2400;
-            else if (baudrate == 1800)
-                baud = B1800;
-            else if (baudrate == 1200)
-                baud = B1200;
-            else if (baudrate == 600)
-                baud = B600;
-            else if (baudrate == 300)
-                baud = B300;
+                break;
+            }
+            
             cfsetispeed(theTermios, baud);
             cfsetospeed(theTermios, baud);
         }

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -567,36 +567,7 @@ static void parseSerialControlStr(MCStringRef setting, struct termios *theTermio
         {
             integer_t baudrate;
             /* UNCHECKED */ MCStringToInteger(*t_value, baudrate);
-			if (baudrate == 57600)
-				baud = B57600;
-			else if (baudrate == 38400)
-				baud = B38400;
-			else if (baudrate == 28800)
-				baud = B28800;
-			else if (baudrate == 19200)
-				baud = B19200;
-			else if (baudrate == 16600)
-				baud = B16600;
-			else if (baudrate == 14400)
-				baud = B14400;
-			else if (baudrate == 9600)
-				baud = B9600;
-			else if (baudrate == 7200)
-				baud = B7200;
-			else if (baudrate == 4800)
-				baud = B4800;
-			else if (baudrate == 3600)
-				baud = B4800;
-			else if (baudrate == 2400)
-				baud = B2400;
-			else if (baudrate == 1800)
-				baud = B1800;
-			else if (baudrate == 1200)
-				baud = B1200;
-			else if (baudrate == 600)
-				baud = B600;
-			else if (baudrate == 300)
-				baud = B300;
+            baud = baudrate;
 			cfsetispeed(theTermios, baud);
 			cfsetospeed(theTermios, baud);
             


### PR DESCRIPTION
- Supported baud rates on Linux in the man page of `cfsetospeed()` command:

https://www.kernel.org/doc/man-pages/online/pages/man3/cfsetospeed.3.html

- Supported baud rates on Mac in file:

`usr/include/sys/termios.h `