### PR TITLE
[[ Build ]] Don't rebuild thirdparty libs

### DIFF
--- a/engine/kernel-development.gyp
+++ b/engine/kernel-development.gyp
@@ -50,7 +50,7 @@
 				'kernel.gyp:kernel',
 
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'sources':

--- a/engine/kernel-installer.gyp
+++ b/engine/kernel-installer.gyp
@@ -37,8 +37,7 @@
 			'dependencies':
 			[
 				'kernel.gyp:kernel',
-				
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'includes':

--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -56,9 +56,14 @@
 				
 				'../prebuilt/libcurl.gyp:libcurl',
 				'../prebuilt/libopenssl.gyp:libopenssl',
-				
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
-				
+
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pcre',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
+		
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+		
 				'engine-common.gyp:quicktime_stubs',
 				
 				'lcb-modules.gyp:engine_lcb_modules',
@@ -87,11 +92,11 @@
 				[
 					'OS == "linux"',
 					{
-						'include_dirs':
+						'dependencies':
 						[
-							'../thirdparty/headers/linux/include/cairo',
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_cairo',
 						],
-						
+
 						'defines':
                         [
 	                        'PANGO_ENABLE_BACKEND',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -24,7 +24,12 @@
 				
 				'../prebuilt/libopenssl.gyp:libopenssl_headers',
 
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pcre',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
+
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 
 				'engine-common.gyp:encode_version',
 				'engine-common.gyp:quicktime_stubs',
@@ -72,7 +77,12 @@
 							'src/mblcamera.cpp',
 						],
 										
-						
+						'dependencies':
+						[
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_freetype',
+						],
+
 						'link_settings':
 						{
 							'ldflags':
@@ -94,6 +104,11 @@
 						'sources':
 						[
 							'<@(engine_minizip_source_files)',
+						],
+
+						'dependencies':
+						[
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
 						],
 					},
 				],

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -45,9 +45,9 @@
 			
 			'dependencies':
 			[
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
 				'../prebuilt/libicu.gyp:libicu',
 				'../prebuilt/libicu.gyp:encode_minimal_icu_data',
+                '../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 				'../thirdparty/libffi/libffi.gyp:libffi',
 			],
 			

--- a/libgraphics/libgraphics.gyp
+++ b/libgraphics/libgraphics.gyp
@@ -14,10 +14,28 @@
 			
 			'dependencies':
 			[
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
 				'../libfoundation/libfoundation.gyp:libFoundation',
 			],
-			
+
+			'conditions':
+			[
+				[
+					'OS in ("emscripten", "android")',
+					{
+						'dependencies':
+						[
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_freetype',
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_harfbuzz',
+							'../prebuilt/libicu.gyp:libicu',
+						],
+					},
+				],
+			],		
+	
 			'include_dirs':
 			[
 				'include',

--- a/libscript/libscript.gyp
+++ b/libscript/libscript.gyp
@@ -48,7 +48,7 @@
 			'dependencies':
 			[
 				'../libfoundation/libfoundation.gyp:libFoundation',
-				'../thirdparty/libffi/libffi.gyp:libffi',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
 			],
 			
 			'include_dirs':

--- a/prebuilt/thirdparty.gyp
+++ b/prebuilt/thirdparty.gyp
@@ -7,7 +7,7 @@
 	'targets':
 	[
 		{
-			'target_name': 'thirdparty_prebuilt',
+			'target_name': 'thirdparty_prebuilt_dep',
 			'type': 'none',
 
 			'toolsets': ['host','target'],
@@ -17,23 +17,558 @@
 				'fetch.gyp:fetch',
 			],
 
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR != "xcode"',
+									{
+										'library_dirs':
+										[
+											'lib/mac',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							# Gyp doesn't seem to handle non-absolute paths here properly...
+							'library_dirs':
+							[
+								'lib/linux/>(toolset_arch)',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							# Gyp doesn't seem to handle non-absolute paths here properly...
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'library_dirs':
+										[
+											'lib/android/<(target_arch)/<(android_subplatform)',
+										],
+									},
+								]
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{
+							'library_dirs':
+							[
+								'unpacked/Thirdparty/<(uniform_arch)-win32-$(PlatformToolset)_static_$(ConfigurationName)/lib',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'library_dirs':
+							[
+								'lib/emscripten/js',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_expat',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
 			'direct_dependent_settings':
 			{
-				'defines':
-				[
-					'PCRE_STATIC=1',
-				],
-				
 				'include_dirs':
 				[
 					'../thirdparty/libexpat',
 					'../thirdparty/libexpat/lib',
-					'../thirdparty/libgif/include',
-					'../thirdparty/libharfbuzz/src',
-					'../thirdparty/libjpeg/include',
-					'../thirdparty/libpcre/include',
-					'../thirdparty/libpng/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lexpat',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{	
+										'libraries':
+										[
+											'-lexpat',
+										],
+									},
+								],
+							],
+						}
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_z',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
 					'../thirdparty/libz/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libz.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lz',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libz.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lz',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lz',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibz',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lz',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_gif',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libgif/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libgif.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lgif',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libgif.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lgif',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lgif',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibgif',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lgif',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_jpeg',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libjpeg/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libjpeg.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-ljpeg',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libjpeg.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-ljpeg',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-ljpeg',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibjpeg',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-ljpeg',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_png',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_z',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libpng/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libpng.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lpng',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libpng.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lpng',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lpng',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibpng',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lpng',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_skia',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_z',
+				'thirdparty_prebuilt_gif',
+				'thirdparty_prebuilt_png',
+				'thirdparty_prebuilt_jpeg',
+				'thirdparty_prebuilt_expat',
+				'thirdparty_prebuilt_freetype',
+				'thirdparty_prebuilt_fontconfig',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
 					'../thirdparty/libskia/include/config',
 					'../thirdparty/libskia/include/core',
 					'../thirdparty/libskia/include/device',
@@ -52,13 +587,8 @@
 					'../thirdparty/libskia/src/ports',
 					'../thirdparty/libskia/include/private',
 					'../thirdparty/libskia/src/utils/win',
-
-					'../thirdparty/libfreetype/include',
 				],
-			},
-			
-			'all_dependent_settings':
-			{
+
 				'defines':
 				[
 					# Disable Skia debugging
@@ -75,7 +605,410 @@
 					'SK_SUPPORT_GPU=0',
 				],
 			},
-			
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libskia.a',
+											'lib/mac/libskia_opt_none.a',
+											'lib/mac/libskia_opt_arm.a',
+											'lib/mac/libskia_opt_sse2.a',
+											'lib/mac/libskia_opt_sse3.a',
+											'lib/mac/libskia_opt_sse41.a',
+											'lib/mac/libskia_opt_sse42.a',
+											'lib/mac/libskia_opt_avx.a',
+											'lib/mac/libskia_opt_hsw.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lskia',
+											'-lskia_opt_none',
+											'-lskia_opt_arm',
+											'-lskia_opt_sse2',
+											'-lskia_opt_sse3',
+											'-lskia_opt_sse41',
+											'-lskia_opt_sse42',
+											'-lskia_opt_avx',
+											'-lskia_opt_hsw',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libskia.a',
+								'lib/ios/$(SDK_NAME)/libskia.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_none.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_arm.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_sse2.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_sse3.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_sse41.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_sse42.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_avx.a',
+								'lib/ios/$(SDK_NAME)/libskia_opt_hsw.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lskia',
+								'-lskia_opt_none',
+								'-lskia_opt_arm',
+								'-lskia_opt_sse2',
+								'-lskia_opt_sse3',
+								'-lskia_opt_sse41',
+								'-lskia_opt_sse42',
+								'-lskia_opt_avx',
+								'-lskia_opt_hsw',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lskia',
+											'-lskia_opt_none',
+											'-lskia_opt_arm',
+											'-lskia_opt_sse2',
+											'-lskia_opt_sse3',
+											'-lskia_opt_sse41',
+											'-lskia_opt_sse42',
+											'-lskia_opt_avx',
+											'-lskia_opt_hsw',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibskia',
+								'-llibskia_opt_none',
+								'-llibskia_opt_arm',
+								'-llibskia_opt_sse2',
+								'-llibskia_opt_sse3',
+								'-llibskia_opt_sse41',
+								'-llibskia_opt_sse42',
+								'-llibskia_opt_avx',
+								'-llibskia_opt_hsw',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lskia',
+								'-lskia_opt_none',
+								'-lskia_opt_arm',
+								'-lskia_opt_sse2',
+								'-lskia_opt_sse3',
+								'-lskia_opt_sse41',
+								'-lskia_opt_sse42',
+								'-lskia_opt_avx',
+								'-lskia_opt_hsw',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_harfbuzz',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libharfbuzz/src',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											# Hack to put licuuc after lharfbuzz in library list
+											# to force the linking order we need
+											'-lharfbuzz -licuuc',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lharfbuzz',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_freetype',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_z',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libfreetype/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[	
+								'-lfreetype',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lfreetype',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lfreetype',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_fontconfig',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libfontconfig/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[	
+								'-lfontconfig',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_cairo',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_z',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libcairo/src',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libcairo.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lcairo',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libcairo.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "mac" or toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'$(SDKROOT)/System/Library/Frameworks/ApplicationServices.framework',
+								'$(SDKROOT)/System/Library/Frameworks/CoreGraphics.framework',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lcairo',
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{						
+							'libraries':
+							[
+								'-lgdi32',
+								'-luser32',
+								'-lmsimg32',
+								'-llibcairo',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_pcre',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libpcre/include',
+				],
+
+				'defines':
+				[
+					'PCRE_STATIC=1',
+				],
+			},
+
 			'link_settings':
 			{
 				'target_conditions':
@@ -91,47 +1024,12 @@
 										'libraries':
 										[
 											'lib/mac/libpcre.a',
-											# libskia depends on libgif, libjpeg, libpng, libz
-											'lib/mac/libskia.a',
-											'lib/mac/libskia_opt_none.a',
-											'lib/mac/libskia_opt_arm.a',
-											'lib/mac/libskia_opt_sse2.a',
-											'lib/mac/libskia_opt_sse3.a',
-											'lib/mac/libskia_opt_sse41.a',
-											'lib/mac/libskia_opt_sse42.a',
-											'lib/mac/libskia_opt_avx.a',
-											'lib/mac/libskia_opt_hsw.a',
-											'lib/mac/libgif.a',
-											'lib/mac/libjpeg.a',
-											# libpng depends on libz
-											'lib/mac/libpng.a',
-											'lib/mac/libz.a',
 										],
 									},
 									{
-										'library_dirs':
-										[
-											'lib/mac',
-										],
-										
 										'libraries':
 										[
 											'-lpcre',
-											# libskia depends on libgif, libjpeg, libpng, libz
-											'-lskia',
-											'-lskia_opt_none',
-											'-lskia_opt_arm',
-											'-lskia_opt_sse2',
-											'-lskia_opt_sse3',
-											'-lskia_opt_sse41',
-											'-lskia_opt_sse42',
-											'-lskia_opt_avx',
-											'-lskia_opt_hsw',
-											'-lgif',
-											'-ljpeg',
-											# libpng depends on libz
-											'-lpng',
-											'-lz',
 										],
 									},
 								],
@@ -144,100 +1042,29 @@
 							'libraries':
 							[
 								'lib/ios/$(SDK_NAME)/libpcre.a',
-								'lib/ios/$(SDK_NAME)/libskia.a',
-								# libskia depends on libgif, libjpeg, libpng, libz
-								'lib/ios/$(SDK_NAME)/libskia.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_none.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_arm.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_sse2.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_sse3.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_sse41.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_sse42.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_avx.a',
-								'lib/ios/$(SDK_NAME)/libskia_opt_hsw.a',
-								'lib/ios/$(SDK_NAME)/libgif.a',
-								'lib/ios/$(SDK_NAME)/libjpeg.a',
-								# libpng depends on libz
-								'lib/ios/$(SDK_NAME)/libpng.a',
-								'lib/ios/$(SDK_NAME)/libz.a',
 							],
 						},
 					],
 					[
 						'toolset_os == "linux"',
 						{
-							# Gyp doesn't seem to handle non-absolute paths here properly...
-							'library_dirs':
-							[
-								'lib/linux/>(toolset_arch)',
-							],
-							
 							'libraries':
 							[
 								'-lpcre',
-								# libskia depends on libgif, libjpeg, libpng, libz
-								'-lskia',
-								'-lskia_opt_none',
-								'-lskia_opt_arm',
-								'-lskia_opt_sse2',
-								'-lskia_opt_sse3',
-								'-lskia_opt_sse41',
-								'-lskia_opt_sse42',
-								'-lskia_opt_avx',
-								'-lskia_opt_hsw',
-								'-lgif',
-								'-ljpeg',
-								# libpng depends on libz
-								'-lpng',
-								'-lz',
-								
-								#'-lGL',
-								'-lfreetype',
-								'-lfontconfig',
 							],
 						},
 					],
 					[
 						'toolset_os == "android"',
 						{
-							# Gyp doesn't seem to handle non-absolute paths here properly...
 							'conditions':
 							[
 								[
 									'OS == "android"',
 									{
-										'library_dirs':
-										[
-											'lib/android/<(target_arch)/<(android_subplatform)',
-										],
-										
 										'libraries':
 										[
-											# *ANDROID* libharfbuzz depends on libicu
-											'-lharfbuzz',
 											'-lpcre',
-											# *ANDROID* libskia depends on libexpat, libfreetype
-											# libskia depends on libgif, libjpeg, libpng, libz
-											'-lskia',
-											'-lskia_opt_none',
-											'-lskia_opt_arm',
-											'-lskia_opt_sse2',
-											'-lskia_opt_sse3',
-											'-lskia_opt_sse41',
-											'-lskia_opt_sse42',
-											'-lskia_opt_avx',
-											'-lskia_opt_hsw',
-											'-lexpat',
-											# libfreetype depends on libz
-											'-lfreetype',
-											'-lgif',
-											'-ljpeg',
-											# libpng depends on libz
-											'-lpng',
-											'-lz',
-											
-											#'-lEGL',
-											#'-lGLESv2',
 										],
 									},
 								],
@@ -246,66 +1073,926 @@
 					],
 					[
 						'toolset_os == "win"',
-						{
-							'library_dirs':
-							[
-								'unpacked/Thirdparty/<(uniform_arch)-win32-$(PlatformToolset)_static_$(ConfigurationName)/lib',
-							],
-							
+						{							
 							'libraries':
 							[
 								'-llibpcre',
-								# libskia depends on libgif, libjpeg, libpng, libz
-								'-llibskia',
-								'-llibskia_opt_none',
-								'-llibskia_opt_arm',
-								'-llibskia_opt_sse2',
-								'-llibskia_opt_sse3',
-								'-llibskia_opt_sse41',
-								'-llibskia_opt_sse42',
-								'-llibskia_opt_avx',
-								'-llibskia_opt_hsw',
-								'-llibgif',
-								'-llibjpeg',
-								# libpng depends on libz
-								'-llibpng',
-								'-llibz',
-								
-								#'-lOpenGL32.lib'
 							],
 						},
 					],
 					[
 						'OS == "emscripten"',
 						{
-							'library_dirs':
-							[
-								'lib/emscripten/js',
-							],
-
 							'libraries':
 							[
-								# *EMSCRIPTEN* libharfbuzz depends on libicu
-								'-lharfbuzz',
 								'-lpcre',
-								# *EMSCRIPTEN* libskia depends on libfreetype
-								# libskia depends on libgif, libjpeg, libpng, libz
-								'-lskia',
-								'-lskia_opt_none',
-								'-lskia_opt_arm',
-								'-lskia_opt_sse2',
-								'-lskia_opt_sse3',
-								'-lskia_opt_sse41',
-								'-lskia_opt_sse42',
-								'-lskia_opt_avx',
-								'-lskia_opt_hsw',
-								# libfreetype depends on libz
-								'-lfreetype',
-								'-lgif',
-								'-ljpeg',
-								# libpng depends on libz
-								'-lpng',
-								'-lz',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_xml',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libxml/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libxml.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lxml',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libxml.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lxml',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lxml',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibxml',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lxml',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_xslt',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libxslt/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libxslt.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lxslt',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libxslt.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lxslt',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lxslt',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibxslt',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lxslt',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_ffi',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'all_dependent_settings':
+			{
+				'msvs_settings':
+				{
+					'VCLinkerTool':
+					{
+						# libffi is not safe exception handler compatible therefore nothing
+						# linked to it is compatible either
+						'ImageHasSafeExceptionHandlers': 'false',
+					},
+				},
+			},
+
+			'variables':
+			{
+				'conditions':
+				[
+					[
+						'_toolset == "host"',
+						{
+							'toolset_os': '<(host_os)',
+							'toolset_arch': '<(host_arch)',
+						},
+						{
+							'toolset_os': '<(OS)',
+							'toolset_arch': '<(target_arch)',
+						},
+					],
+				],
+
+				'libffi_public_headers_darwin_osx_dir':
+				[
+					'../thirdparty/libffi/include_darwin'
+				],
+				
+				'libffi_public_headers_darwin_ios_dir':
+				[
+					'../thirdparty/libffi/git_master/darwin_ios/include',
+					'../thirdparty/libffi/git_master/darwin_common/include',
+				],
+				
+				'libffi_public_headers_win32_dir':
+				[
+					'../thirdparty/libffi/include_win32',
+				],
+
+				'libffi_public_headers_win64_dir':
+				[
+					'../thirdparty/libffi/include_win64',
+				],
+				
+				'libffi_public_headers_linux_x86_dir':
+				[
+					'../thirdparty/libffi/include_linux/x86',
+				],
+				
+				'libffi_public_headers_linux_x86_64_dir':
+				[
+					'../thirdparty/libffi/include_linux/x86_64',
+				],
+
+				'libffi_public_headers_linux_arm64_dir':
+				[
+					'../thirdparty/libffi/include_linux/arm64',
+				],
+				
+				'libffi_public_headers_android_dir':
+				[
+					'../thirdparty/libffi/include_android',
+				],
+			},
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'<@(_platform_include_dirs)',
+				],
+			},
+
+			'conditions':
+			[
+				[
+					'toolset_os == "mac"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_darwin_osx_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os == "ios"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_darwin_ios_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os == "linux"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_darwin_osx_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os == "win"',
+					{							
+						'conditions':
+						[
+							[
+								'toolset_arch == "x86"',
+								{
+									'platform_include_dirs':
+									[
+										'<@(libffi_public_headers_win32_dir)',
+									],
+								},
+								{
+									'platform_include_dirs':
+									[
+										'<@(libffi_public_headers_win64_dir)',
+									],
+								},
+							],
+						],
+					},
+				],
+				[
+					'(toolset_os == "linux" or toolset_os == "android") and toolset_arch == "x86"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_linux_x86_dir)',
+						],
+					},
+				],
+				[
+					'(toolset_os == "linux" or toolset_os == "android") and toolset_arch == "x86_64"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_linux_x86_64_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os in ("linux", "android") and toolset_arch in ("armv6", "armv6hf", "armv7")',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_android_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os in ("linux", "android") and toolset_arch == "arm64"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_linux_arm64_dir)',
+						],
+					},
+				],
+				[
+					'toolset_os == "emscripten"',
+					{
+						'platform_include_dirs':
+						[
+							'<@(libffi_public_headers_linux_x86_dir)',
+						],
+					},
+				],
+			],
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libffi.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lffi',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libffi.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lffi',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lffi',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibffi',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lffi',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_zip',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libzip/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libzip.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lzip',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libzip.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lzip',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lzip',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibzip',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lzip',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_iodbc',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libiodbc/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libiodbc.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-liodbc',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-liodbc',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_pq',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libpq/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libpq.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lpq',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lpq',
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-ladvapi32',
+								'-lsecur32',
+								'-lshell32',
+								'-lwldap32',
+								'-lws2_32',
+								'-lwsock32',
+								'-llibpq',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_mysql',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_z',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libmysql/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libmysql.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lmysql',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libmysql.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lmysql',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lmysql',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-ladvapi32',
+								'-luser32',
+								'-llibmysql',
+							],
+						},
+					],
+				],
+			},
+		},
+		{
+			'target_name': 'thirdparty_prebuilt_sqlite',
+			'type': 'none',
+
+			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'thirdparty_prebuilt_dep',
+			],
+
+			'direct_dependent_settings':
+			{
+				'include_dirs':
+				[
+					'../thirdparty/libsqlite/include',
+				],
+			},
+
+			'link_settings':
+			{
+				'target_conditions':
+				[
+					[
+						'toolset_os == "mac"',
+						{
+							'conditions':
+							[
+								[
+									'GENERATOR == "xcode"',
+									{
+										'libraries':
+										[
+											'lib/mac/libsqlite.a',
+										],
+									},
+									{
+										'libraries':
+										[
+											'-lsqlite',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "ios"',
+						{
+							'libraries':
+							[
+								'lib/ios/$(SDK_NAME)/libsqlite.a',
+							],
+						},
+					],
+					[
+						'toolset_os == "linux"',
+						{
+							'libraries':
+							[
+								'-lsqlite',
+							],
+						},
+					],
+					[
+						'toolset_os == "android"',
+						{
+							'conditions':
+							[
+								[
+									'OS == "android"',
+									{
+										'libraries':
+										[
+											'-lsqlite',
+										],
+									},
+								],
+							],
+						},
+					],
+					[
+						'toolset_os == "win"',
+						{							
+							'libraries':
+							[
+								'-llibsqlite',
+							],
+						},
+					],
+					[
+						'OS == "emscripten"',
+						{
+							'libraries':
+							[
+								'-lsqlite',
 							],
 						},
 					],

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -98,9 +98,8 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libmysql/libmysql.gyp:libmysql',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_mysql',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
 			],
 			
 			'include_dirs':
@@ -157,9 +156,8 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libmysql/libmysql.gyp:libmysql',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_mysql',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
 			],
 			
 			'include_dirs':
@@ -225,7 +223,7 @@
 					{
 						'dependencies':
 						[
-							'../thirdparty/libiodbc/libiodbc.gyp:libiodbc',
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_iodbc',
 						],
 					},
 					{
@@ -289,7 +287,7 @@
 					{
 						'dependencies':
 						[
-							'../thirdparty/libiodbc/libiodbc.gyp:libiodbc',
+							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_iodbc',
 						],
 					},
 					{
@@ -361,8 +359,8 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libpq/libpq.gyp:libpq',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pq',
 			],
 			
 			'include_dirs':
@@ -407,7 +405,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libpq/libpq.gyp:libpq',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pq',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
@@ -469,7 +467,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libsqlite/libsqlite.gyp:libsqlite',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_sqlite',
 			],
 			
 			'include_dirs':
@@ -576,7 +574,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libsqlite/libsqlite.gyp:libsqlite',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_sqlite',
 			],
 			
 			'include_dirs':

--- a/revpdfprinter/revpdfprinter.gyp
+++ b/revpdfprinter/revpdfprinter.gyp
@@ -17,7 +17,7 @@
 			[
 				'../libcore/libcore.gyp:libCore',
 				'../libexternal/libexternal.gyp:libExternal',
-				'../thirdparty/libcairo/libcairo.gyp:libcairo',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_cairo',
 			],
 			
 			'include_dirs':

--- a/revxml/revxml.gyp
+++ b/revxml/revxml.gyp
@@ -30,9 +30,9 @@
             [
                 '../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../thirdparty/libxml/libxml.gyp:libxml',
-				'../thirdparty/libxslt/libxslt.gyp:libxslt',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xml',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xslt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'include_dirs':
@@ -58,7 +58,7 @@
 					'dist_files': [ '<(PRODUCT_DIR)/<(_product_name)>(ext_bundle_suffix)' ],
 				},
 			},
-			
+		
 			'conditions':
 			[
 				[
@@ -80,9 +80,9 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../thirdparty/libxml/libxml.gyp:libxml',
-				'../thirdparty/libxslt/libxslt.gyp:libxslt',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xml',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xslt',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'include_dirs':
@@ -100,6 +100,7 @@
 				'INFOPLIST_FILE': 'rsrc/revxml-Info.plist',
 				'EXPORTED_SYMBOLS_FILE': 'revxml.exports',
 			},
+
 			'conditions':
 			[
 				[

--- a/revzip/revzip.gyp
+++ b/revzip/revzip.gyp
@@ -25,7 +25,8 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../thirdparty/libzip/libzip.gyp:libzip',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_zip',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'sources':
@@ -76,7 +77,8 @@
 			[
                 '../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../thirdparty/libzip/libzip.gyp:libzip',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_zip',
+				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
 			],
 			
 			'sources':

--- a/toolchain/lc-compile-ffi-java/lc-compile-ffi-java.gyp
+++ b/toolchain/lc-compile-ffi-java/lc-compile-ffi-java.gyp
@@ -13,6 +13,11 @@
 			
 			'toolsets': ['host','target'],
 			
+			'dependencies':
+			[
+				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+			],
+
 			'conditions':
 			[
 				[

--- a/toolchain/lc-compile/lc-compile.gyp
+++ b/toolchain/lc-compile/lc-compile.gyp
@@ -12,6 +12,11 @@
 			'type': 'none',
 			
 			'toolsets': ['host','target'],
+
+			'dependencies':
+			[
+				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+			],
 			
 			'conditions':
 			[

--- a/toolchain/lc-compile/lc-run.gyp
+++ b/toolchain/lc-compile/lc-run.gyp
@@ -19,7 +19,7 @@
 				'../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../libscript/libscript.gyp:libScript',
 				'../../libscript/libscript.gyp:stdscript',
-				'../../thirdparty/libffi/libffi.gyp:libffi',
+				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
 			],
 			
 			'sources':

--- a/toolchain/lc-compile/src/lc-compile-lib.gyp
+++ b/toolchain/lc-compile/src/lc-compile-lib.gyp
@@ -20,7 +20,7 @@
 				'../../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../../libscript/libscript.gyp:libScript',
 				'../../libcompile/libcompile.gyp:libcompile',
-				'../../../thirdparty/libffi/libffi.gyp:libffi',
+				'../../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
 			],
 
 			'sources':

--- a/toolchain/libcompile/libcompile.gyp
+++ b/toolchain/libcompile/libcompile.gyp
@@ -18,7 +18,7 @@
 			[
 				'../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../libscript/libscript.gyp:libScript',
-				'../../thirdparty/libffi/libffi.gyp:libffi',
+				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
 			],
 
 			'sources':


### PR DESCRIPTION
This patch splits the thirdparty gyp file into multiple targets -
one for each thirdparty library, so that other libraries can depend
on particular thirdparty libs. In particular, revxml now depends
on the thirdparty prebuilt libxml and libxslt instead of their
own gyp files in the thirdparty module. Likewise libffi and its
dependencies. The upshot is that these libraries are no longer
rebuilt.