### PR TITLE
[[ Bug 22142 ]] Add x86_64 to as possible value of the machine on win

### DIFF
--- a/docs/dictionary/function/machine.lcdoc
+++ b/docs/dictionary/function/machine.lcdoc
@@ -24,7 +24,8 @@ if the machine contains "Powerbook" then checkBattery
 Returns (enum):
 The <machine> <function> <return|returns> a <string>.
 
--   x86: windows based system
+-   x86: windows 32 bit based system
+-   x86_64: windows 64 bit based system
 -   iPod Touch: the device is one of the iPod Touch models
 -   iPhone: the device is one of the iPhone models
 -   iPhone Simulator: the device is a simulated iPhone

--- a/docs/notes/bugfix-22142.md
+++ b/docs/notes/bugfix-22142.md
@@ -1,0 +1,1 @@
+# Update `the machine` documentation to include `x86_64` return value on Windows 64 bit


### PR DESCRIPTION
This patch updates `the machine` function documentation for the 64 bit Win engine.