### PR TITLE
[[ Browser ]] Add additional callbacks & handlers to support file upload & download

### DIFF
--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -53,6 +53,7 @@ public type MCBrowserRequestType is CInt
 public type MCBrowserRequestState is CInt
 public type MCBrowserFileDialogType is CInt
 public type MCBrowserFileDialogOption is CInt
+public type MCBrowserDownloadState is CInt
 
 --
 
@@ -114,14 +115,22 @@ public foreign handler type MCBrowserRequestCallback(in pContext as optional Poi
 public foreign handler type MCBrowserJavaScriptCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pHandler as ZStringUTF8, in pParams as MCBrowserListRef) returns nothing
 public foreign handler type MCBrowserProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pProgress as UInt32) returns nothing
 public foreign handler type MCBrowserFileDialogCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserFileDialogType, in pOptions as MCBrowserFileDialogOption, in pTitle as optional ZStringUTF8, in pDefaultPath as optional ZStringUTF8, in pFilters as optional ZStringUTF8, in pDefaultFilter as UInt32) returns CBool
+public foreign handler type MCBrowserDownloadRequestCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pSuggestedName as optional ZStringUTF8) returns CBool
+public foreign handler type MCBrowserDownloadProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pState as MCBrowserDownloadState, in pBytesReceived as UInt32, in pTotalBytes as Int32) returns nothing
 
 public foreign handler MCBrowserSetRequestHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetJavaScriptHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserJavaScriptCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetProgressHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserProgressCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetFileDialogHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserFileDialogCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetDownloadRequestHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserDownloadRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetDownloadProgressHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserDownloadProgressCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 
 public foreign handler MCBrowserFileDialogCancel(in pBrowser as MCBrowserRef) returns nothing binds to "<builtin>"
 public foreign handler MCBrowserFileDialogSelectPaths(in pBrowser as MCBrowserRef, in pPaths as ZStringUTF8, in pSelectedFilter as UInt32) returns nothing binds to "<builtin>"
+
+public foreign handler MCBrowserDownloadCancel(in pBrowser as MCBrowserRef) returns nothing binds to "<builtin>"
+public foreign handler MCBrowserDownloadContinueWithSavePath(in pBrowser as MCBrowserRef, in pSavePath as ZStringUTF8) returns nothing binds to "<builtin>"
+public foreign handler MCBrowserDownloadContinueWithSaveDialog(in pBrowser as MCBrowserRef) returns nothing binds to "<builtin>"
 
 --------------------------------------------------------------------------------
 
@@ -175,6 +184,15 @@ public constant kMCBrowserFileDialogTypeMap is ["open", "openMultiple", "openFol
 
 public constant kMCBrowserFileDialogOptionOverwritePrompt is 1
 public constant kMCBrowserFileDialogOptionHideReadOnly is 2
+
+--
+
+public constant kMCBrowserDownloadStateInProgress is 0
+public constant kMCBrowserDownloadStateCompleted is 1
+public constant kMCBrowserDownloadStateCancelled is 2
+public constant kMCBrowserDownloadStateFailed is 3
+
+public constant kMCBrowserDownloadStateMap is [ "inProgress", "completed", "cancelled", "failed" ]
 
 --
 

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -51,6 +51,8 @@ public type MCBrowserProperty is CInt
 public type MCBrowserValueType is CInt
 public type MCBrowserRequestType is CInt
 public type MCBrowserRequestState is CInt
+public type MCBrowserFileDialogType is CInt
+public type MCBrowserFileDialogOption is CInt
 
 --
 
@@ -111,10 +113,15 @@ public foreign handler MCBrowserDictionaryGetDictionary(in pDictionary as MCBrow
 public foreign handler type MCBrowserRequestCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserRequestType, in pState as MCBrowserRequestState, in pFrame as CBool, in pUrl as ZStringUTF8, in pError as optional ZStringUTF8) returns nothing
 public foreign handler type MCBrowserJavaScriptCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pHandler as ZStringUTF8, in pParams as MCBrowserListRef) returns nothing
 public foreign handler type MCBrowserProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pProgress as UInt32) returns nothing
+public foreign handler type MCBrowserFileDialogCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserFileDialogType, in pOptions as MCBrowserFileDialogOption, in pTitle as optional ZStringUTF8, in pDefaultPath as optional ZStringUTF8, in pFilters as optional ZStringUTF8, in pDefaultFilter as UInt32) returns CBool
 
 public foreign handler MCBrowserSetRequestHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserRequestCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetJavaScriptHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserJavaScriptCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
 public foreign handler MCBrowserSetProgressHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserProgressCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+public foreign handler MCBrowserSetFileDialogHandler(in pBrowser as MCBrowserRef, in pCallback as optional MCBrowserFileDialogCallback, in pContext as optional Pointer) returns CBool binds to "<builtin>"
+
+public foreign handler MCBrowserFileDialogCancel(in pBrowser as MCBrowserRef) returns nothing binds to "<builtin>"
+public foreign handler MCBrowserFileDialogSelectPaths(in pBrowser as MCBrowserRef, in pPaths as ZStringUTF8, in pSelectedFilter as UInt32) returns nothing binds to "<builtin>"
 
 --------------------------------------------------------------------------------
 
@@ -156,6 +163,18 @@ public constant kMCBrowserRequestStateFailed is 2
 public constant kMCBrowserRequestStateUnhandled is 3
 
 public constant kMCBrowserRequestStateMap is ["begin", "complete", "failed", "unhandled"]
+
+--
+
+public constant kMCBrowserFileDialogTypeOpen is 0
+public constant kMCBrowserFileDialogTypeOpenMultiple is 1
+public constant kMCBrowserFileDialogTypeOpenFolder is 2
+public constant kMCBrowserFileDialogTypeSave is 3
+
+public constant kMCBrowserFileDialogTypeMap is ["open", "openMultiple", "openFolder", "save"]
+
+public constant kMCBrowserFileDialogOptionOverwritePrompt is 1
+public constant kMCBrowserFileDialogOptionHideReadOnly is 2
 
 --
 

--- a/engine/src/browser.lcb
+++ b/engine/src/browser.lcb
@@ -150,12 +150,13 @@ public constant kMCBrowserPropertyAllowNewWindows is 2
 public constant kMCBrowserPropertyEnableContextMenu is 3
 public constant kMCBrowserPropertyAllowUserInteraction is 4
 public constant kMCBrowserPropertyIsSecure is 5
-public constant kMCBrowserPropertyUrl is 6
-public constant kMCBrowserPropertyHtmlText is 7
-public constant kMCBrowserPropertyUserAgent is 8
-public constant kMCBrowserPropertyJavaScriptHandlers is 9
+public constant kMCBrowserPropertyEnableDragDrop is 6
+public constant kMCBrowserPropertyUrl is 7
+public constant kMCBrowserPropertyHtmlText is 8
+public constant kMCBrowserPropertyUserAgent is 9
+public constant kMCBrowserPropertyJavaScriptHandlers is 10
 
-public constant kMCBrowserPropertyMap is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "allowUserInteraction", "isSecure", "url", "htmlText", "userAgent", "javaScriptHandlers"]
+public constant kMCBrowserPropertyMap is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "allowUserInteraction", "isSecure", "enableDragDrop", "url", "htmlText", "userAgent", "javaScriptHandlers"]
 
 --
 
@@ -198,11 +199,11 @@ public constant kMCBrowserDownloadStateMap is [ "inProgress", "completed", "canc
 
 -- constant kStringProps is ["url", "htmlText", "userAgent", "javaScriptHandlers"]
 -- TODO - replace literal values with constants when possible
-constant kStringProps is [6, 7, 8, 9]
+constant kStringProps is [7, 8, 9, 10]
 
 -- constant kBoolProps is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "allowUserInteraction", "isSecure"]
 -- TODO - replace literal values with constants when possible
-constant kBoolProps is [0, 1, 2, 3, 4, 5]
+constant kBoolProps is [0, 1, 2, 3, 4, 5, 6]
 
 --------------------------------------------------------------------------------
 

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -397,6 +397,29 @@ metadata allowUserInteraction.default is "true"
 metadata allowUserInteraction.label is "Allow user interaction"
 
 /**
+Name: enableDragDrop
+Type: property
+
+Syntax:
+set the enableDragDrop of <widget> to <enableDragDrop>
+get the enableDragDrop of <widget>
+
+Summary: Controls whether the browser responds to drag 'n drop interactions.
+
+Value (boolean):
+`true` if the browser should respond to drag 'n drop interaction;
+`false` otherwise.
+
+Description:
+Use the <enableDragDrop> property to control if the browser should respond
+to drag 'n drop interaction.
+*/
+property enableDragDrop get getEnableDragDrop set setEnableDragDrop
+metadata enableDragDrop is "com.livecode.pi.boolean"
+metadata enableDragDrop.default is "true"
+metadata enableDragDrop.label is "Enable drag 'n drop within the browser"
+
+/**
 Name: isSecure
 Type: property
 
@@ -513,7 +536,7 @@ variable mScriptObject as ScriptObject
 
 --------------------------------------------------------------------------------
 
-constant kPersistentProps is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "userAgent", "javaScriptHandlers", "allowUserInteraction", "isSecure"]
+constant kPersistentProps is ["verticalScrollbarEnabled", "horizontalScrollbarEnabled", "allowNewWindows", "enableContextMenu", "enableDragDrop", "userAgent", "javaScriptHandlers", "allowUserInteraction", "isSecure"]
 
 --------------------------------------------------------------------------------
 
@@ -875,6 +898,16 @@ end handler
 
 private handler getIsSecure() returns Boolean
 	return getProperty("isSecure")
+end handler
+
+--
+
+private handler getEnableDragDrop() returns Boolean
+	return getProperty("enableDragDrop")
+end handler
+
+private handler setEnableDragDrop(in pEnableDragDrop as Boolean)
+	setProperty("enableDragDrop", pEnableDragDrop)
 end handler
 
 ----------

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -555,6 +555,7 @@ private unsafe handler InitBrowserView()
 	MCBrowserSetRequestHandler(mBrowser, OnBrowserRequestCallback, nothing)
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
 	MCBrowserSetProgressHandler(mBrowser, OnProgressCallback, nothing)
+	MCBrowserSetFileDialogHandler(mBrowser, OnFileDialogCallback, nothing)
 
 	applyProperties(mProperties)
 end handler
@@ -567,6 +568,7 @@ private unsafe handler FinalizeBrowserView()
             MCBrowserSetRequestHandler(mBrowser, nothing, nothing)
             MCBrowserSetJavaScriptHandler(mBrowser, nothing, nothing)
             MCBrowserSetProgressHandler(mBrowser, nothing, nothing)
+			MCBrowserSetFileDialogHandler(mBrowser, nothing, nothing)
 
 			MCBrowserRelease(mBrowser)
 			put nothing into mBrowser
@@ -668,6 +670,45 @@ end handler
 
 private handler OnProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pProgress as UInt32) returns nothing
 	post "browserProgressChanged" to mScriptObject with [pUrl, pProgress]
+end handler
+
+private handler OnFileDialogCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pType as MCBrowserFileDialogType, in pOptions as MCBrowserFileDialogOption, in pTitle as optional ZStringUTF8, in pDefaultPath as optional ZStringUTF8, in pFilters as optional ZStringUTF8, in pDefaultFilter as UInt32) returns CBool
+	if pTitle is nothing then
+		put the empty string into pTitle
+	end if
+
+	variable tScript
+	if pType is kMCBrowserFileDialogTypeOpen then
+		put "answer file param(1)" into tScript
+	else if pType is kMCBrowserFileDialogTypeOpenMultiple then
+		put "answer files param(1)" into tScript
+	else if pType is kMCBrowserFileDialogTypeOpenFolder then
+		put "answer folder param(1)" into tScript
+	else if pType is kMCBrowserFileDialogTypeSave then
+		put "ask file param(1)" into tScript
+	end if
+
+	variable tParams
+	put [ pTitle ] into tParams
+
+	if pDefaultPath is not nothing then
+		put " with param(2)" after tScript
+		push pDefaultPath onto tParams
+	end if
+
+	put "\nif the result is empty then return it else return empty" after tScript
+
+	variable tResult
+	execute script tScript with tParams
+	put the result into tResult
+	log tResult
+	if tResult is empty then
+		MCBrowserFileDialogCancel(pBrowser)
+	else
+		MCBrowserFileDialogSelectPaths(pBrowser, tResult, pDefaultFilter)
+	end if
+
+	return true
 end handler
 
 ----------

--- a/extensions/widgets/browser/browser.lcb
+++ b/extensions/widgets/browser/browser.lcb
@@ -203,6 +203,23 @@ The <browserProgressChanged> message is sent to the widget's script
 object when a the loading progress of the current document changes. The <pUrl>
 parameter contains the URL of the loading document. The <pProgress> parameter
 contains the percentage (between 0 and 100) of the document loaded.
+
+
+Name: browserDownloadProgressChanged
+Type: message
+Syntax: browserDownloadProgressChanged <pUrl>, <pState>, <pBytesReceived>, <pTotalBytes>
+
+Summary: Sent when the load progress of a file download changes.
+
+Parameters:
+pUrl (string): The URL of the downloading file.
+pState (string): The current status of the download. one of 'inProgress', 'complete', 'cancelled', 'failed'
+pBytesReceived (number): The number of bytes already downloaded.
+pTotalBytes (number): The total size of the download file. This will be -1 if the size is unknown.
+
+Description:
+The <browserDownloadProgressChanged> message is sent to the widget's script
+object when progress of a file download changes.
 */
 
 -- declaring extension as widget, followed by identifier
@@ -556,6 +573,8 @@ private unsafe handler InitBrowserView()
 	MCBrowserSetJavaScriptHandler(mBrowser, OnJavaScriptCallback, nothing)
 	MCBrowserSetProgressHandler(mBrowser, OnProgressCallback, nothing)
 	MCBrowserSetFileDialogHandler(mBrowser, OnFileDialogCallback, nothing)
+	MCBrowserSetDownloadRequestHandler(mBrowser, OnDownloadRequestCallback, nothing)
+	MCBrowserSetDownloadProgressHandler(mBrowser, OnDownloadProgressCallback, nothing)
 
 	applyProperties(mProperties)
 end handler
@@ -569,6 +588,8 @@ private unsafe handler FinalizeBrowserView()
             MCBrowserSetJavaScriptHandler(mBrowser, nothing, nothing)
             MCBrowserSetProgressHandler(mBrowser, nothing, nothing)
 			MCBrowserSetFileDialogHandler(mBrowser, nothing, nothing)
+			MCBrowserSetDownloadRequestHandler(mBrowser, nothing, nothing)
+			MCBrowserSetDownloadProgressHandler(mBrowser, nothing, nothing)
 
 			MCBrowserRelease(mBrowser)
 			put nothing into mBrowser
@@ -709,6 +730,15 @@ private handler OnFileDialogCallback(in pContext as optional Pointer, in pBrowse
 	end if
 
 	return true
+end handler
+
+private handler OnDownloadRequestCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pSuggestedName as optional ZStringUTF8) returns CBool
+	MCBrowserDownloadContinueWithSaveDialog(pBrowser)
+	return true
+end handler
+
+private handler OnDownloadProgressCallback(in pContext as optional Pointer, in pBrowser as MCBrowserRef, in pUrl as ZStringUTF8, in pState as MCBrowserDownloadState, in pBytesReceived as UInt32, in pTotalBytes as Int32) returns nothing
+	post "browserDownloadProgressChanged" to mScriptObject with [ pUrl, kMCBrowserDownloadStateMap[pState + 1], pBytesReceived, pTotalBytes ]
 end handler
 
 ----------

--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -66,6 +66,35 @@ public:
 	virtual void OnProgressChanged(MCBrowser *p_browser, const char *p_url, uint32_t p_progress) = 0;
 };
 
+// File Dialog handler
+enum MCBrowserFileDialogType
+{
+	kMCBrowserFileDialogTypeOpen,
+	kMCBrowserFileDialogTypeOpenMultiple,
+	kMCBrowserFileDialogTypeOpenFolder,
+	kMCBrowserFileDialogTypeSave,
+};
+
+enum MCBrowserFileDialogOptions
+{
+	kMCBrowserFileDialogOptionOverwritePrompt = 1 << 0,
+	kMCBrowserFileDialogOptionHideReadOnly = 1 << 1,
+};
+
+class MCBrowserFileDialogHandler : public MCBrowserRefCounted
+{
+public:
+	virtual bool OnFileDialog(
+		MCBrowser *p_browser,
+		MCBrowserFileDialogType p_type,
+		MCBrowserFileDialogOptions p_options,
+		const char *p_title,
+		const char *p_default_path,
+		const char *p_filters,
+		uindex_t p_default_filter
+	) = 0;
+};
+
 // Properties
 enum MCBrowserProperty
 {
@@ -91,6 +120,14 @@ struct MCBrowserRect
 	int32_t left, top, right, bottom;
 };
 
+// File dialog response
+struct MCBrowserFileDialogResponse
+{
+	bool cancelled;
+	const char *selected_paths;
+	uindex_t selected_filter;
+};
+
 // Browser interface
 class MCBrowser : public MCBrowserRefCounted
 {
@@ -98,6 +135,7 @@ public:
 	virtual void SetEventHandler(MCBrowserEventHandler *p_handler) = 0;
 	virtual void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler) = 0;
 	virtual void SetProgressHandler(MCBrowserProgressHandler *p_handler) = 0;
+	virtual void SetFileDialogHandler(MCBrowserFileDialogHandler *p_handler) = 0;
 
 	virtual void *GetNativeLayer() = 0;
 	
@@ -114,6 +152,11 @@ public:
 	virtual bool GoForward() = 0;
 	virtual bool GoToURL(const char *p_url) = 0;
 	virtual bool EvaluateJavaScript(const char *p_script, char *&r_result) = 0;
+
+	virtual void FileDialogClearResponse(void) = 0;
+	virtual bool FileDialogGetResponse(MCBrowserFileDialogResponse &r_response) = 0;
+	virtual void FileDialogCancel(void) = 0;
+	virtual void FileDialogSelectPaths(const char *p_paths, uindex_t p_selected_filter) = 0;
 };
 
 // Browser factory interface
@@ -271,6 +314,9 @@ MC_BROWSER_DLLEXPORT bool MCBrowserGoForward(MCBrowserRef p_browser);
 MC_BROWSER_DLLEXPORT bool MCBrowserGoToURL(MCBrowserRef p_browser, const char *p_url);
 MC_BROWSER_DLLEXPORT bool MCBrowserEvaluateJavaScript(MCBrowserRef p_browser, const char *p_script, char *&r_result);
 
+MC_BROWSER_DLLEXPORT void MCBrowserFileDialogCancel(MCBrowserRef p_browser);
+MC_BROWSER_DLLEXPORT void MCBrowserFileDialogSelectPaths(MCBrowserRef p_browser, const char *p_paths, uindex_t p_selected_filter);
+
 enum MCBrowserRequestType
 {
 	kMCBrowserRequestTypeNavigate,
@@ -288,10 +334,21 @@ enum MCBrowserRequestState
 typedef void (*MCBrowserRequestCallback)(void *p_context, MCBrowserRef p_browser, MCBrowserRequestType p_type, MCBrowserRequestState p_state, bool p_in_frame, const char *p_url, const char *p_error);
 typedef void (*MCBrowserJavaScriptCallback)(void *p_context, MCBrowserRef p_browser, const char *p_handler, MCBrowserListRef p_params);
 typedef void (*MCBrowserProgressCallback)(void *p_context, MCBrowserRef p_browser, const char *p_url, uint32_t p_progress);
+typedef bool (*MCBrowserFileDialogCallback)(
+	void *p_context,
+	MCBrowserRef p_browser,
+	MCBrowserFileDialogType p_type,
+	MCBrowserFileDialogOptions p_options,
+	const char *p_title,
+	const char *p_default_path,
+	const char *p_filters,
+	uindex_t p_default_filter
+);
 
 MC_BROWSER_DLLEXPORT bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetProgressHandler(MCBrowserRef p_browser, MCBrowserProgressCallback p_callback, void *p_context);
+MC_BROWSER_DLLEXPORT bool MCBrowserSetFileDialogHandler(MCBrowserRef p_browser, MCBrowserFileDialogCallback p_callback, void *p_context);
 
 }
 

--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -128,6 +128,7 @@ enum MCBrowserProperty
 	kMCBrowserEnableContextMenu,
 	kMCBrowserAllowUserInteraction,
 	kMCBrowserIsSecure,
+	kMCBrowserEnableDragDrop,
 	
 	// String properties
 	kMCBrowserURL,

--- a/libbrowser/include/libbrowser.h
+++ b/libbrowser/include/libbrowser.h
@@ -95,6 +95,28 @@ public:
 	) = 0;
 };
 
+// Download request handler
+enum MCBrowserDownloadState
+{
+	kMCBrowserDownloadStateInProgress,
+	kMCBrowserDownloadStateCompleted,
+	kMCBrowserDownloadStateCancelled,
+	kMCBrowserDownloadStateFailed,
+};
+
+class MCBrowserDownloadRequestHandler : public MCBrowserRefCounted
+{
+public:
+	virtual bool OnDownloadRequest(MCBrowser *p_browser, const char *p_url, const char *p_suggested_name) = 0;
+};
+
+// Download progress handler
+class MCBrowserDownloadProgressHandler : public MCBrowserRefCounted
+{
+public:
+	virtual void OnDownloadProgress(MCBrowser *p_browser, const char *p_url, MCBrowserDownloadState p_state, uint32_t p_bytes_received, int32_t p_total_bytes) = 0;
+};
+
 // Properties
 enum MCBrowserProperty
 {
@@ -128,6 +150,13 @@ struct MCBrowserFileDialogResponse
 	uindex_t selected_filter;
 };
 
+// Download request response
+struct MCBrowserDownloadRequestResponse
+{
+	bool cancelled;
+	const char *save_path;
+};
+
 // Browser interface
 class MCBrowser : public MCBrowserRefCounted
 {
@@ -136,6 +165,8 @@ public:
 	virtual void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler) = 0;
 	virtual void SetProgressHandler(MCBrowserProgressHandler *p_handler) = 0;
 	virtual void SetFileDialogHandler(MCBrowserFileDialogHandler *p_handler) = 0;
+	virtual void SetDownloadRequestHandler(MCBrowserDownloadRequestHandler *p_handler) = 0;
+	virtual void SetDownloadProgressHandler(MCBrowserDownloadProgressHandler *p_handler) = 0;
 
 	virtual void *GetNativeLayer() = 0;
 	
@@ -157,6 +188,12 @@ public:
 	virtual bool FileDialogGetResponse(MCBrowserFileDialogResponse &r_response) = 0;
 	virtual void FileDialogCancel(void) = 0;
 	virtual void FileDialogSelectPaths(const char *p_paths, uindex_t p_selected_filter) = 0;
+
+	virtual void DownloadClearResponse(void) = 0;
+	virtual bool DownloadGetResponse(MCBrowserDownloadRequestResponse &r_response) = 0;
+	virtual void DownloadCancel(void) = 0;
+	virtual void DownloadContinueWithSavePath(const char *p_save_path) = 0;
+	virtual void DownloadContinueWithSaveDialog(void) = 0;
 };
 
 // Browser factory interface
@@ -317,6 +354,10 @@ MC_BROWSER_DLLEXPORT bool MCBrowserEvaluateJavaScript(MCBrowserRef p_browser, co
 MC_BROWSER_DLLEXPORT void MCBrowserFileDialogCancel(MCBrowserRef p_browser);
 MC_BROWSER_DLLEXPORT void MCBrowserFileDialogSelectPaths(MCBrowserRef p_browser, const char *p_paths, uindex_t p_selected_filter);
 
+MC_BROWSER_DLLEXPORT void MCBrowserDownloadCancel(MCBrowserRef p_browser);
+MC_BROWSER_DLLEXPORT void MCBrowserDownloadContinueWithSavePath(MCBrowserRef p_browser, const char *p_save_path);
+MC_BROWSER_DLLEXPORT void MCBrowserDownloadContinueWithSaveDialog(MCBrowserRef p_browser);
+
 enum MCBrowserRequestType
 {
 	kMCBrowserRequestTypeNavigate,
@@ -345,10 +386,15 @@ typedef bool (*MCBrowserFileDialogCallback)(
 	uindex_t p_default_filter
 );
 
+typedef bool (*MCBrowserDownloadRequestCallback)(void *p_context, MCBrowserRef p_browser, const char *p_url, const char *p_suggested_name);
+typedef void (*MCBrowserDownloadProgressCallback)(void *p_context, MCBrowserRef p_browser, const char *p_url, MCBrowserDownloadState p_state, uint32_t p_bytes_received, int32_t p_total_bytes);
+
 MC_BROWSER_DLLEXPORT bool MCBrowserSetRequestHandler(MCBrowserRef p_browser, MCBrowserRequestCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetJavaScriptHandler(MCBrowserRef p_browser, MCBrowserJavaScriptCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetProgressHandler(MCBrowserRef p_browser, MCBrowserProgressCallback p_callback, void *p_context);
 MC_BROWSER_DLLEXPORT bool MCBrowserSetFileDialogHandler(MCBrowserRef p_browser, MCBrowserFileDialogCallback p_callback, void *p_context);
+MC_BROWSER_DLLEXPORT bool MCBrowserSetDownloadRequestHandler(MCBrowserRef p_browser, MCBrowserDownloadRequestCallback p_callback, void *p_context);
+MC_BROWSER_DLLEXPORT bool MCBrowserSetDownloadProgressHandler(MCBrowserRef p_browser, MCBrowserDownloadProgressCallback p_callback, void *p_context);
 
 }
 

--- a/libbrowser/src/libbrowser.cpp
+++ b/libbrowser/src/libbrowser.cpp
@@ -53,8 +53,11 @@ void MCBrowserRefCounted::Destroy()
 MCBrowserBase::MCBrowserBase(void)
     : m_event_handler(nil),
       m_javascript_handler(nil),
-      m_progress_handler(nil)
+      m_progress_handler(nil),
+	  m_file_dialog_handler(nil),
+	  m_file_dialog_have_response(false),
 {
+	MCBrowserMemoryClear(m_file_dialog_response);
 }
 
 MCBrowserBase::~MCBrowserBase(void)
@@ -67,6 +70,11 @@ MCBrowserBase::~MCBrowserBase(void)
 
 	if (m_progress_handler)
 		m_progress_handler->Release();
+
+	if (m_file_dialog_handler)
+		m_file_dialog_handler->Release();
+
+	FileDialogClearResponse();
 }
 
 void MCBrowserBase::SetEventHandler(MCBrowserEventHandler *p_handler)
@@ -171,6 +179,85 @@ void MCBrowserBase::OnProgressChanged(const char *p_url, uint32_t p_progress)
 {
 	if (m_progress_handler != nil)
 		m_progress_handler->OnProgressChanged(this, p_url, p_progress);
+}
+
+//////////
+
+void MCBrowserBase::SetFileDialogHandler(MCBrowserFileDialogHandler *p_handler)
+{
+	if (p_handler != nil)
+		p_handler->Retain();
+
+	if (m_file_dialog_handler != nil)
+		m_file_dialog_handler->Release();
+
+	m_file_dialog_handler = p_handler;
+}
+
+MCBrowserFileDialogHandler *MCBrowserBase::GetFileDialogHandler(void)
+{
+	return m_file_dialog_handler;
+}
+
+bool MCBrowserBase::OnFileDialog(
+	MCBrowserFileDialogType p_type,
+	MCBrowserFileDialogOptions p_options,
+	const char *p_title,
+	const char *p_default_path,
+	const char *p_filters,
+	uindex_t p_default_filter
+)
+{
+	if (m_file_dialog_handler)
+		return m_file_dialog_handler->OnFileDialog(this, p_type, p_options, p_title, p_default_path, p_filters, p_default_filter);
+
+	return false;
+}
+
+//////////
+
+void MCBrowserBase::FileDialogClearResponse(void)
+{
+	if (!m_file_dialog_have_response)
+		return;
+
+	m_file_dialog_response.cancelled = false;
+	if (m_file_dialog_response.selected_paths != nil)
+		MCCStringFree(const_cast<char*>(m_file_dialog_response.selected_paths));
+	m_file_dialog_response.selected_paths = nil;
+	m_file_dialog_response.selected_filter = 0;
+
+	m_file_dialog_have_response = false;
+}
+
+bool MCBrowserBase::FileDialogGetResponse(MCBrowserFileDialogResponse &r_response)
+{
+	if (!m_file_dialog_have_response)
+		return false;
+
+	r_response = m_file_dialog_response;
+	return true;
+}
+
+void MCBrowserBase::FileDialogCancel(void)
+{
+	if (m_file_dialog_have_response)
+		return;
+
+	m_file_dialog_response.cancelled = true;
+	m_file_dialog_have_response = true;
+}
+
+void MCBrowserBase::FileDialogSelectPaths(const char *p_paths, uindex_t p_selected_filter)
+{
+	if (m_file_dialog_have_response)
+		return;
+
+	char *t_paths = nil;
+	/* UNCHECKED */ MCCStringClone(p_paths, t_paths);
+	m_file_dialog_response.selected_paths = t_paths;
+	m_file_dialog_response.selected_filter = p_selected_filter;
+	m_file_dialog_have_response = true;
 }
 
 //////////
@@ -435,6 +522,24 @@ bool MCBrowserEvaluateJavaScript(MCBrowserRef p_browser, const char *p_script, c
 	return p_browser->EvaluateJavaScript(p_script, r_result);
 }
 
+MC_BROWSER_DLLEXPORT_DEF
+void MCBrowserFileDialogCancel(MCBrowserRef p_browser)
+{
+	if (p_browser == nil)
+		return;
+
+	p_browser->FileDialogCancel();
+}
+
+MC_BROWSER_DLLEXPORT_DEF
+void MCBrowserFileDialogSelectPaths(MCBrowserRef p_browser, const char *p_paths, uindex_t p_selected_filter)
+{
+	if (p_browser == nil)
+		return;
+
+	p_browser->FileDialogSelectPaths(p_paths, p_selected_filter);
+}
+
 //////////
 
 // Event handler c++ wrapper
@@ -608,6 +713,63 @@ bool MCBrowserSetProgressHandler(MCBrowserRef p_browser, MCBrowserProgressCallba
 		return false;
 
 	p_browser->SetProgressHandler(t_wrapper);
+
+	t_wrapper->Release();
+
+	return true;
+}
+
+//////////
+
+class MCBrowserFileDialogHandlerWrapper : public MCBrowserFileDialogHandler
+{
+public:
+	MCBrowserFileDialogHandlerWrapper(MCBrowserFileDialogCallback p_callback, void *p_context)
+	{
+		m_callback = p_callback;
+		m_context = p_context;
+	}
+
+	virtual bool OnFileDialog(
+		MCBrowser *p_browser,
+		MCBrowserFileDialogType p_type,
+		MCBrowserFileDialogOptions p_options,
+		const char *p_title,
+		const char *p_default_path,
+		const char *p_filters,
+		uindex_t p_default_filter
+	)
+	{
+		if (m_callback)
+			return m_callback(m_context, p_browser, p_type, p_options, p_title, p_default_path, p_filters, p_default_filter);
+
+		return false;
+	}
+
+private:
+	MCBrowserFileDialogCallback m_callback;
+	void *m_context;
+};
+
+MC_BROWSER_DLLEXPORT_DEF
+bool MCBrowserSetFileDialogHandler(MCBrowserRef p_browser, MCBrowserFileDialogCallback p_callback, void *p_context)
+{
+	if (p_browser == nil)
+		return false;
+
+	if (p_callback == nil)
+	{
+		p_browser->SetFileDialogHandler(nil);
+		return true;
+	}
+
+	MCBrowserFileDialogHandlerWrapper *t_wrapper;
+	t_wrapper = new (nothrow) MCBrowserFileDialogHandlerWrapper(p_callback, p_context);
+
+	if (t_wrapper == nil)
+		return false;
+
+	p_browser->SetFileDialogHandler(t_wrapper);
 
 	t_wrapper->Release();
 

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -1007,8 +1007,16 @@ public:
 	// Called on UI thread
 	virtual bool OnDragEnter(CefRefPtr<CefBrowser> p_browser, CefRefPtr<CefDragData> p_drag_data, CefDragHandler::DragOperationsMask p_mask)
 	{
-		// cancel the drag event
-		return true;
+		if (m_owner->GetEnableDragDrop())
+		{
+			// allow drag event to be processed
+			return false;
+		}
+		else
+		{
+			// cancel the drag event
+			return true;
+		}
 	}
 
 	// CefRequestHandler interface
@@ -1482,6 +1490,7 @@ MCCefBrowserBase::MCCefBrowserBase()
 	m_send_advanced_messages = false;
 	m_show_context_menu = false;
 	m_allow_new_window = false;
+	m_enable_drag_drop = false;
 	
 	m_javascript_handlers = nil;
 	m_js_handler_list = CefListValue::Create();
@@ -1826,6 +1835,16 @@ void MCCefBrowserBase::SetHorizontalScrollbarEnabled(bool p_scrollbars)
 	/* UNCHECKED */ SetOverflowHidden(kMCCefScrollbarHorizontal, !p_scrollbars);
 }
 
+bool MCCefBrowserBase::GetEnableDragDrop(void)
+{
+	return m_enable_drag_drop;
+}
+
+void MCCefBrowserBase::SetEnableDragDrop(bool p_enable_drag_drop)
+{
+	m_enable_drag_drop = p_enable_drag_drop;
+}
+
 bool MCCefBrowserBase::GetRect(MCBrowserRect &r_rect)
 {
 	return PlatformGetRect(r_rect);
@@ -2088,6 +2107,10 @@ bool MCCefBrowserBase::GetBoolProperty(MCBrowserProperty p_property, bool &r_val
 			r_value = GetAllowUserInteraction();
 			return true;
 
+		case kMCBrowserEnableDragDrop:
+			r_value = GetEnableDragDrop();
+			return true;
+
 		default:
 			break;
 	}
@@ -2117,6 +2140,10 @@ bool MCCefBrowserBase::SetBoolProperty(MCBrowserProperty p_property, bool p_valu
 
 		case kMCBrowserAllowUserInteraction:
 			SetAllowUserInteraction(p_value);
+			return true;
+
+		case kMCBrowserEnableDragDrop:
+			SetEnableDragDrop(p_value);
 			return true;
 
 		default:

--- a/libbrowser/src/libbrowser_cef.h
+++ b/libbrowser/src/libbrowser_cef.h
@@ -73,6 +73,7 @@ private:
 	
 	bool m_show_context_menu;
 	bool m_allow_new_window;
+	bool m_enable_drag_drop;
 	bool m_send_advanced_messages;
 	int m_instance_id;
 	
@@ -129,6 +130,9 @@ public:
 
 	virtual bool GetAllowUserInteraction(void);
 	virtual void SetAllowUserInteraction(bool p_allow);
+
+	virtual bool GetEnableDragDrop(void);
+	virtual void SetEnableDragDrop(bool p_enable_drag_drop);
 
 	// Browser Actions
 	

--- a/libbrowser/src/libbrowser_internal.h
+++ b/libbrowser/src/libbrowser_internal.h
@@ -36,10 +36,12 @@ public:
 	void SetEventHandler(MCBrowserEventHandler *p_handler);
 	void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler);
 	void SetProgressHandler(MCBrowserProgressHandler *p_handler);
+	void SetFileDialogHandler(MCBrowserFileDialogHandler *p_handler);
 
 	MCBrowserEventHandler *GetEventHandler(void);
 	MCBrowserJavaScriptHandler *GetJavaScriptHandler(void);
 	MCBrowserProgressHandler *GetProgressHandler(void);
+	MCBrowserFileDialogHandler *GetFileDialogHandler(void);
 
 	virtual void OnNavigationBegin(bool p_in_frame, const char *p_url);
 	virtual void OnNavigationComplete(bool p_in_frame, const char *p_url);
@@ -53,6 +55,20 @@ public:
 	virtual void OnJavaScriptCall(const char *p_handler, MCBrowserListRef p_params);
 
 	virtual void OnProgressChanged(const char *p_url, uint32_t p_progress);
+
+	virtual void FileDialogClearResponse(void);
+	virtual bool FileDialogGetResponse(MCBrowserFileDialogResponse &r_response);
+	virtual void FileDialogCancel(void);
+	virtual void FileDialogSelectPaths(const char *p_paths, uindex_t p_selected_filter);
+
+	virtual bool OnFileDialog(
+		MCBrowserFileDialogType p_type,
+		MCBrowserFileDialogOptions p_options,
+		const char *p_title,
+		const char *p_default_path,
+		const char *p_filters,
+		uindex_t p_default_filter
+	);
 
 	static bool BrowserListAdd(MCBrowser *p_browser);
 	static void BrowserListRemove(MCBrowser *p_browser);
@@ -71,6 +87,10 @@ private:
 	MCBrowserEventHandler *m_event_handler;
 	MCBrowserJavaScriptHandler *m_javascript_handler;
 	MCBrowserProgressHandler *m_progress_handler;
+	MCBrowserFileDialogHandler *m_file_dialog_handler;
+
+	bool m_file_dialog_have_response;
+	MCBrowserFileDialogResponse m_file_dialog_response;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libbrowser/src/libbrowser_internal.h
+++ b/libbrowser/src/libbrowser_internal.h
@@ -37,11 +37,15 @@ public:
 	void SetJavaScriptHandler(MCBrowserJavaScriptHandler *p_handler);
 	void SetProgressHandler(MCBrowserProgressHandler *p_handler);
 	void SetFileDialogHandler(MCBrowserFileDialogHandler *p_handler);
+	void SetDownloadRequestHandler(MCBrowserDownloadRequestHandler *p_handler);
+	void SetDownloadProgressHandler(MCBrowserDownloadProgressHandler *p_handler);
 
 	MCBrowserEventHandler *GetEventHandler(void);
 	MCBrowserJavaScriptHandler *GetJavaScriptHandler(void);
 	MCBrowserProgressHandler *GetProgressHandler(void);
 	MCBrowserFileDialogHandler *GetFileDialogHandler(void);
+	MCBrowserDownloadRequestHandler *GetDownloadRequestHandler(void);
+	MCBrowserDownloadProgressHandler *GetDownloadProgressHandler(void);
 
 	virtual void OnNavigationBegin(bool p_in_frame, const char *p_url);
 	virtual void OnNavigationComplete(bool p_in_frame, const char *p_url);
@@ -70,6 +74,15 @@ public:
 		uindex_t p_default_filter
 	);
 
+	virtual void DownloadClearResponse(void);
+	virtual bool DownloadGetResponse(MCBrowserDownloadRequestResponse &r_response);
+	virtual void DownloadCancel(void);
+	virtual void DownloadContinueWithSavePath(const char *p_save_path);
+	virtual void DownloadContinueWithSaveDialog(void);
+
+	virtual bool OnDownloadRequest(const char *p_url, const char *p_suggested_name);
+	virtual void OnDownloadProgress(const char *p_url, MCBrowserDownloadState p_state, uint32_t p_bytes_recieved, int32_t p_total_bytes);
+
 	static bool BrowserListAdd(MCBrowser *p_browser);
 	static void BrowserListRemove(MCBrowser *p_browser);
 	static bool BrowserListIterate(MCBrowserIterateCallback p_callback, void *p_context);
@@ -88,9 +101,14 @@ private:
 	MCBrowserJavaScriptHandler *m_javascript_handler;
 	MCBrowserProgressHandler *m_progress_handler;
 	MCBrowserFileDialogHandler *m_file_dialog_handler;
+	MCBrowserDownloadRequestHandler *m_download_request_handler;
+	MCBrowserDownloadProgressHandler *m_download_progress_handler;
 
 	bool m_file_dialog_have_response;
 	MCBrowserFileDialogResponse m_file_dialog_response;
+
+	bool m_download_request_have_response;
+	MCBrowserDownloadRequestResponse m_download_request_response;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch adds the OnFileDialog, OnDownloadRequest, and OnDownloadProgress callbacks to libbrowser. These are intercepted by the browser widget to allow selection of files to upload to a website, or to choose the location to save files downloaded from the site.

In addition, the boolean property `enableDragDrop` has been added to allow files to be selected for upload by dragging onto the browser window.

*Note* Only the CEF implementation has been extended to use these callbacks, however the other implementations should continue to work as before until they too are extended.