### PR TITLE
[[ Bug 22104 ]] Throw error on objchunk of me if me can't be a parent

### DIFF
--- a/docs/notes-base/breaking_changes.md
+++ b/docs/notes-base/breaking_changes.md
@@ -62,3 +62,12 @@ and `image from file` to also use the host widget as the implicit object. This
 means, for example, that `image from file` will resolve a relative file path
 relative to the `stackFile` the host widget is on rather than the `stackFile` of
 the `defaultStack`.
+
+## Object Chunk of Me
+
+An execution error is now thrown when using `<object> of me` where `me` is a
+non-group control. In previous versions a button script containing
+`put the text of field "foo" of me into tText` would actually put the button's
+text into `tText`, however, in this version an error will be thrown because `me`
+can not be a parent object.
+

--- a/docs/notes/bugfix-22104.md
+++ b/docs/notes/bugfix-22104.md
@@ -1,0 +1,1 @@
+# Throw error when object chunk of me is used for a non-group control

--- a/engine/src/chunk.cpp
+++ b/engine/src/chunk.cpp
@@ -1015,6 +1015,13 @@ void MCChunk::getoptionalobj(MCExecContext& ctxt, MCObjectPtr &r_object, Boolean
 		Chunk_term t_type = t_object . object -> gettype();
 		if (MCChunkTermIsControl(t_type) && t_type != CT_GROUP)
         {
+            // object can not be a parent
+            if (!noobjectchunks())
+            {
+                ctxt . LegacyThrow(EE_CHUNK_BADOBJECTEXP);
+                return;
+            }
+            
                 MCCard *t_card;
                 t_card = t_object . object -> getcard(t_object . part_id);
                 if (t_card == nil)

--- a/tests/lcs/core/chunks/widget.livecodescript
+++ b/tests/lcs/core/chunks/widget.livecodescript
@@ -17,13 +17,10 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestWidgetSubchunk
-	-- Bug 18948
+	-- Bug 18948 & 22104
 	create widget "me" as ""
-	set the script of it to "function doTest; return the short name of button 1 of me; end doTest"
+	set the script of it to "command doTest; return the short name of button 1 of me; end doTest"
 	
-	local tResult
-	dispatch function doTest to widget 1
-	put the result into tResult
-	
-	TestAssert "'objchunk' of me in non-group non-behavior control is me", tResult is "me"
+	TestAssertThrow "'objchunk' of me in non-group non-behavior control is error", "doTest", \
+			it, "EE_CHUNK_BADOBJECTEXP"
 end TestWidgetSubchunk


### PR DESCRIPTION
This patch ensures an error is thrown when a script refers to a child object
of me where me is a control that can not be a parent. For example,
`field "foo" of me` where `me` is a button. Previously, the resolved object
would just be `me` in this case the button.