### PR TITLE
[[ LCIDLC ]] Fix build issue

### DIFF
--- a/lcidlc/lcidlc.gyp
+++ b/lcidlc/lcidlc.gyp
@@ -75,13 +75,7 @@
     {
       'target_name': 'encode_support',
       'type': 'none',
-
-      'sources':
-			[
-				'src/Support.java',
-				'src/Support.mm',
-			],
-
+	  
       'actions':
 			[
 				{


### PR DESCRIPTION
This patch removes the sources block of the lcidlc `encode_support` target
due to MSVC getting perplexed by `Support.java` due to our java source
rules. The change has no impact on the functioning of the target.