### PR TITLE
[Dictionary] pan to preOpenControl

### DIFF
--- a/docs/dictionary/command/pop.lcdoc
+++ b/docs/dictionary/command/pop.lcdoc
@@ -37,10 +37,10 @@ If you specify a container, the long <ID> of the <card> is placed in the
 change. 
 
 If the list is empty when you use the <pop> <command>, LiveCode goes to
-the Home <card>. If you are running in the LiveCode <development
-environment>, this is the first <card> of the "license.rev" <stack>,
-which is the splash screen that appears when you start up LiveCode.
-(Click this card to close the stack.) If you are running in a
+the Home <card>. If you are running in the LiveCode 
+<development environment>, this is the first <card> of the "license.rev" 
+<stack>, which is the splash screen that appears when you start up 
+LiveCode. (Click this card to close the stack.) If you are running in a
 <standalone application>, the Home <card> is the first <card> of the
 <standalone application|standalone's> <main stack>.
 

--- a/docs/dictionary/command/popup-widget.lcdoc
+++ b/docs/dictionary/command/popup-widget.lcdoc
@@ -34,18 +34,28 @@ end mouseDown
 
 Parameters:
 kind: The unique identifier of the widget to use for the popup.
-location: A point or expression that evaluates to a point. Two integers separated by a comma.
-properties:	An expression that evaluates to an array. For each key of the array, the popup widget will be initialized by setting that property to the value for that key.
+location: A point or expression that evaluates to a point. Two integers 
+separated by a comma.
+properties: An expression that evaluates to an array. For each key of the 
+array, the popup widget will be initialized by setting that property to 
+the value for that key.
 
-The result: If the user dismisses the popup, the it variable is set to empty, and the result function returns "Cancel".
+The result: If the user dismisses the popup, the it variable is set to 
+empty, and the result function returns "Cancel".
 
-It: The <popup widget> command places the widget return value in the it variable.
+It: The <popup widget> command places the widget return value in the it 
+variable.
 
 Description:
-Use to display a widget within a popup window, for example as a tooltip or picker dialog.
+Use to display a widget within a popup window, for example as a tooltip 
+or picker dialog.
 
-The popup appears with its top left corner at the <location>. If no <location> is specified, the popup's top left corner is at the <mouse location>. While the popup widget is displayed, the handler pauses.
+The popup appears with its top left corner at the <location>. If no 
+<location> is specified, the popup's top left corner is at the 
+<mouseLoc|mouse location>. While the popup widget is displayed, the 
+handler pauses.
 
-References: mouseDown (message), mouseDown message (message), mouseUp message (message), popup (keyword), clickLoc (function), mouse location (function), result (function), it (keyword)
+References: mouseDown (message), mouseUp (message), popup (keyword), 
+clickLoc (function), mouseLoc (function), result (function), it (keyword)
 
 Tags: widget

--- a/docs/dictionary/command/popup.lcdoc
+++ b/docs/dictionary/command/popup.lcdoc
@@ -55,7 +55,7 @@ clicked control in the stack (for a stack menu). The button or stack
 menu handles the menu choice.
 
 If you use a button to hold the contents of the menu, the contents of
-the button's <menuItem Keyword> is displayed in the popup.
+the button's <menuItem> is displayed in the popup.
 
 **Important:**  If you use a button to hold the contents of the menu,
 the following properties must be set:
@@ -82,8 +82,8 @@ parameter of the <mouseDown(message)> message, as described above.
 References: pulldown (command), clickLoc (function), mouseLoc (function),
 menu item (glossary), popup menu (glossary), button (keyword),
 menuItem (keyword), popup (keyword), menuPick (message),
-mouseDown (message), mouseDown (message), mouseUp (message), message (glossary),
-stack (object), button (object), style property (property),
+mouseDown (message), mouseDown (message), mouseUp (message), 
+message (glossary), stack (object), button (object), style (property),
 toolTip (property), menuMode (property), visible (property),
 menuMouseButton (property)
 

--- a/docs/dictionary/command/post.lcdoc
+++ b/docs/dictionary/command/post.lcdoc
@@ -5,7 +5,7 @@ Type: command
 Syntax: post <data> to URL <destinationURL>
 
 Summary:
-Sends data to a <web server> using the POST action of <HTTP>.
+Sends data to a <web server> using the POST action of <http|HTTP>.
 
 Associations: internet library
 
@@ -120,11 +120,13 @@ function (control structure), result (function), URLStatus (function),
 URLEncode (function), libURLFormData (function), URLDecode (function),
 libURLMultipartFormAddPart (function), libURLMultipartFormData (function),
 variable (glossary), command (glossary), 
-Livecode custom library (glossary), property (glossary),
+LiveCode custom library (glossary), property (glossary),
 standalone application (glossary), blocking (glossary), 
 web server (glossary), command (glossary), expression (glossary), 
 syntax (glossary), server (glossary), upload (glossary), 
-statement (glossary), handler (glossary), URL (keyword), ftp (keyword), 
+statement (glossary), handler (glossary), 
+Standalone Application Settings (glossary),
+URL (keyword), ftp (keyword), 
 http (keyword), Internet library (library), urlProgress (message), 
 httpHeaders (property), HTTPProxy (property)
 

--- a/docs/dictionary/function/param.lcdoc
+++ b/docs/dictionary/function/param.lcdoc
@@ -62,9 +62,13 @@ to assign it a name:
 
 
 LiveCode evaluates the parameters before passing them. So if you call
-myHandler with the following statement: myHandler 1+1,"A","Hello" &&
-"world" the parameters returned by the <param> <function> are 2, A,
-and "Hello World".
+myHandler with the following statement: 
+
+     myHandler 1+1,"A","Hello" && "world" 
+
+the parameters returned by the <param> <function> are 
+
+    2, A, and "Hello World".
 
 References: function (control structure), paramCount (function),
 pass (glossary), handler (glossary), parameter (glossary),

--- a/docs/dictionary/function/params.lcdoc
+++ b/docs/dictionary/function/params.lcdoc
@@ -75,11 +75,16 @@ If you call "myFunction" with the following statement:
 
     get myFunction("red","green","blue")
 
-the value returned by the <params> function is "myFunction("red","green","blue")".
+the value returned by the <params> function is 
+
+    "myFunction("red","green","blue")".
 
 LiveCode evaluates the parameters before passing them. So if you call
-myHandler with the following statement: myHandler 1+1,"A","Hello" &&
-"world" the value returned by the <params> <function> is
+myHandler with the following statement: 
+
+    myHandler 1+1,"A","Hello" && "world" 
+
+the value returned by the <params> <function> is 
 
     myHandler "2","A","Hello world"
 

--- a/docs/dictionary/message/playerProgressChanged.lcdoc
+++ b/docs/dictionary/message/playerProgressChanged.lcdoc
@@ -22,8 +22,8 @@ Description:
 Handle the <playerProgressChanged> message when the loadState of the
 player has changed.
 
-You should query the <loadState> to determine which of the states have
-changed: 
+You should query the loadState with the <mobileControlGet> function to 
+determine which of the states have changed: 
 
     * playable - enough data is available to start playing, but it may
       run out before playback finishes
@@ -35,7 +35,7 @@ changed:
 
 Zero or more of these are returned in a comma delimited string value.
 
-References: loadState (function), playerFinished (message),
+References: mobileControlGet (function), playerFinished (message),
 playerError (message), playerLeaveFullscreen (message),
 playerStopped (message), playerMovieChanged (message),
 playerPropertyAvailable (message), playerEnterFullscreen (message)

--- a/docs/dictionary/message/preOpenControl.lcdoc
+++ b/docs/dictionary/message/preOpenControl.lcdoc
@@ -27,14 +27,10 @@ Description:
 Handle the <preOpenControl> message to update a group's appearance
 before it appears on screen.
 
-&nbsp;
-
 For groups with their <backgroundBehavior> <property> set to true, the
 <preOpenControl> message is sent immediately after the
 <preOpenBackground> <message> is sent to the <card(object)> being opened.
 For non-background groups, it is sent after the <preOpenCard> <message>.
-
-&nbsp;
 
 For nested groups, the <preOpenControl> message is sent to the parent
 group first, if it is passed or not handled by the parent group, then it

--- a/docs/dictionary/property/pan.lcdoc
+++ b/docs/dictionary/property/pan.lcdoc
@@ -27,8 +27,8 @@ Value:
 The <pan> is a number between zero and 360.
 
 Description:
-Use the <pan> <property> to find out where the user is in a <QuickTime
-VR> movie.
+Use the <pan> <property> to find out where the user is in a 
+<QuickTime VR> movie.
 
 The user can move the view of a QuickTime VR movie using the
 navigational controls in the player; a handler can change the view by
@@ -42,7 +42,7 @@ zero corresponds to the straight-ahead view of the scene. As the viewer
 turns clockwise, the <pan> increases.
 
 If you set the <pan> of a player to a number outside the range zero to
-360, no <error> results, but the <pan> is set tonumber mod 360. For
+360, no <error> results, but the <pan> is set to number mod 360. For
 example, if you attempt to set the <pan> of a <player(keyword)> to -20,
 its <pan> is actually set to 340.
 

--- a/docs/dictionary/property/penPattern.lcdoc
+++ b/docs/dictionary/property/penPattern.lcdoc
@@ -43,12 +43,12 @@ borders of shapes.
 
 Pattern images can be color or black-and-white.
 
->*Cross-platform note:*  To be used as a pattern on <Mac OS|Mac OS
-> systems>, an <image> must be 128x128 <pixels> or less, and both its
-> <height> and <width> must be a power of 2. To be used on <Windows> and
-> <Unix|Unix systems>, <height> and <width> must be divisible by 8. To
-> be used as a fully cross-platform pattern, both an image's dimensions
-> should be one of 8, 16, 32, 64, or 128.
+>*Cross-platform note:*  To be used as a pattern on 
+> <Mac OS|Mac OS systems>, an <image> must be 128x128 <pixels> or less, 
+> and both its <height> and <width> must be a power of 2. To be used on 
+> <Windows> and <Unix|Unix systems>, <height> and <width> must be 
+> divisible by 8. To be used as a fully cross-platform pattern, both an 
+> image's dimensions should be one of 8, 16, 32, 64, or 128.
 
 If the <penColor> has been set since the last time the <penPattern> was
 set, the color is used instead of the pattern specified by <penPattern>.

--- a/docs/dictionary/property/pointerFocus.lcdoc
+++ b/docs/dictionary/property/pointerFocus.lcdoc
@@ -34,9 +34,9 @@ setup.
 If the <pointerFocus> <property> is true, moving the <mouse pointer>
 into a window makes it the <active window>. Set the <pointerFocus> to
 true to work around problems in some <Unix> window managers
-(specifically, "olwm" and "fvwm" ) that prevent <explicit
-focus|active-focus> applications such as LiveCode from operating
-correctly. 
+(specifically, "olwm" and "fvwm" ) that prevent 
+<explicit focus|active-focus> applications such as LiveCode from 
+operating correctly. 
 
 If the application is started from a Unix command line, this property
 can be set to true on startup by using the -pointerfocus option.

--- a/docs/glossary/p/Pointer-tool.lcdoc
+++ b/docs/glossary/p/Pointer-tool.lcdoc
@@ -5,7 +5,7 @@ Synonyms: pointer tool, arrow tool
 Type: glossary
 
 Description:
-<Tool> used in the LiveCode <development environment> to select, move,
+<tool|Tool> used in the LiveCode <development environment> to select, move,
 and resize <control|controls>.
 
 When the Pointer tool is being used, the <cursor> is in the shape of an


### PR DESCRIPTION
pan (property): Fixed broken link, corrected spelling.
param (function): Spaced out example for clarity and so that the example here and in params are formatted the same way.
params (function): As param.
penPattern (property): Fixed broken link.
playerProgressChanged (message): Added that the loadState of a player on iOS is queried with the mobileControlGet function.
Pointer tool (glossary): Fixed broken link.
pointerFocus (property): Fixed broken link.
pop (command): Fixed broken link.
popup (command): Fixed broken links.
popup widget (command): Fixed broken links and references. Hard wrapped markup.
post (command): Fixed various casing issues for references. Added a reference.
preOpenControl (message): Removed non-breaking spaces causing double spacing.