### PR TITLE
[[ Config ]] Allow base android toolchain location to be specified

### DIFF
--- a/config.py
+++ b/config.py
@@ -148,7 +148,7 @@ def process_env_options(opts):
         'TARGET_ARCH', 'PERL', 'ANDROID_NDK_VERSION', 'ANDROID_LIB_PATH',
         'ANDROID_NDK_PLATFORM_VERSION', 'ANDROID_PLATFORM',
         'ANDROID_SDK', 'ANDROID_NDK', 'ANDROID_BUILD_TOOLS', 'LTO',
-        'ANDROID_TOOLCHAIN', 'ANDROID_API_VERSION',
+        'ANDROID_TOOLCHAIN_DIR', 'ANDROID_TOOLCHAIN', 'ANDROID_API_VERSION',
         'AR', 'CC', 'CXX', 'LINK', 'OBJCOPY', 'OBJDUMP',
         'STRIP', 'JAVA_SDK', 'NODE_JS', 'BUILD_EDITION', 'CC_PREFIX', 'CROSS',
         'SYSROOT', 'AUX_SYSROOT', 'TRIPLE', 'MS_SPEECH_SDK5', 'QUICKTIME_SDK',
@@ -514,8 +514,11 @@ def validate_xcode_sdks(opts):
 
 # We suggest some symlinks for Android toolchain components in the
 # INSTALL-android.md file.  This checks if a directory is present
-def guess_android_tooldir(name):
-    dir = os.path.join(os.path.expanduser('~'), 'android', 'toolchain', name)
+def guess_android_tooldir(toolchain, name):
+    if toolchain is None:
+        dir = os.path.join(os.path.expanduser('~'), 'android', 'toolchain', name)
+    else:
+        dir = os.path.join(toolchain, name)
     if os.path.isdir(dir):
         return dir
     return None
@@ -600,8 +603,11 @@ def validate_android_tools(opts):
         opts['ANDROID_NDK_VERSION'] = 'r15'
 
     ndk_ver = opts['ANDROID_NDK_VERSION']
+
+    toolchain_dir = opts['ANDROID_TOOLCHAIN_DIR']
+
     if opts['ANDROID_NDK'] is None:
-        ndk = guess_android_tooldir('android-ndk')
+        ndk = guess_android_tooldir(toolchain_dir, 'android-ndk')
         if ndk is None:
             error('Android NDK not found; set $ANDROID_NDK')
         opts['ANDROID_NDK'] = ndk
@@ -618,7 +624,7 @@ def validate_android_tools(opts):
         opts['ANDROID_PLATFORM'] = 'android-' + api_ver
 
     if opts['ANDROID_SDK'] is None:
-        sdk = guess_android_tooldir('android-sdk')
+        sdk = guess_android_tooldir(toolchain_dir, 'android-sdk')
         if sdk is None:
             error('Android SDK not found; set $ANDROID_SDK')
         opts['ANDROID_SDK'] = sdk
@@ -630,7 +636,7 @@ def validate_android_tools(opts):
         opts['ANDROID_BUILD_TOOLS'] = tools
 
     if opts['ANDROID_TOOLCHAIN'] is None:
-        dir = guess_android_tooldir(guess_standalone_toolchain_dir_name(opts['TARGET_ARCH']))
+        dir = guess_android_tooldir(toolchain_dir, guess_standalone_toolchain_dir_name(opts['TARGET_ARCH']))
         if dir is None:
             error('Android toolchain not found for architecture {}; set $ANDROID_TOOLCHAIN'.format(opts['TARGET_ARCH']))
         prefix = guess_compiler_prefix(opts['TARGET_ARCH'])

--- a/docs/development/build-android.md
+++ b/docs/development/build-android.md
@@ -16,84 +16,84 @@ The main non-standard dependency needed for building LiveCode is a Java Developm
 
 LiveCode requires both the Android Software Development Kit (SDK) and Native Development Kit (NDK).  You can download both from the [Android Developers site](https://developer.android.com/sdk/index.html).
 
-Extract both the NDK and SDK to a suitable directory, e.g. `~/android/toolchain`.  For example, you would run:
+Extract both the NDK and SDK to a suitable directory, e.g. `~/android/toolchain`.  For example, for the following values of `<host>`
+
+- mac: `darwin`
+- linux: `linux`
+- windows: `windows`
+
+you would run:
 
 ````bash
-mkdir -p ~/android/toolchain/android-sdk-linux
+mkdir -p ~/android/toolchain/android-sdk-<host>
 cd ~/android/toolchain
 
-wget https://dl.google.com/android/repository/android-ndk-r15-linux-x86_64.zip
-wget https://dl.google.com/android/repository/tools_r25.2.3-linux.zip
+wget https://dl.google.com/android/repository/android-ndk-r15-<host>-x86_64.zip
+wget https://dl.google.com/android/repository/tools_r25.2.3-<host>.zip
 
-unzip android-ndk-r15-linux-x86_64.zip
+unzip android-ndk-r15-<host>-x86_64.zip
 
-pushd android-sdk-linux
-unzip tools_r25.2.3-linux.zip
+pushd android-sdk-<host>
+unzip ../tools_r25.2.3-<host>.zip
 popd
 ````
 
 Update the SDK:
 
-    android-sdk-linux/tools/android update sdk --no-ui
+    android-sdk-<host>/tools/android update sdk --no-ui
 
-### Setting up the ARM toolchain
+(This command will download and install every Android SDK and will take some time).
+
+### Creating the toolchains
 
 Create a standalone toolchain (this simplifies setting up the build environment):
 
 ````bash
-android-ndk-r15/build/tools/make_standalone_toolchain.py \
-    --arch arm --api 16 --deprecated-headers \
-    --install-dir ${HOME}/android/toolchain/standalone
-```
+for arch in arm arm64 x86 x86_64; do
+    android-ndk-r15/build/tools/make_standalone_toolchain.py \
+        --arch ${arch} --api 21 --deprecated-headers \
+        --install-dir ${HOME}/android/toolchain/standalone-${arch}
+done
+
+**Note:** If you are only interested in building one particular flavour
+of Android engines, leave out the architectures you're not interested in
+from the above commands.
+
+### Final toolchain setup
 
 Add a couple of symlinks to allow the engine configuration script to find the Android toolchain:
 
 ````bash
 ln -s android-ndk-r15 android-ndk
-ln -s android-sdk-linux android-sdk
+ln -s android-sdk-<host> android-sdk
 ````
 
 ## Configuring LiveCode
 
 ### Build environment
 
-The Android build expects a large number of environment variables to be set.  If the environment variables aren't set, the build process will attempt to guess sensible defaults. If you've set up the directory structure as described above, the make command should detect everything automatically and these variables shouldn't be necessary.
+The Android build expects a number of environment variables to be set.  If the environment variables aren't set, the build process will attempt to guess sensible defaults. If you've set up the directory structure as described above, the make command should detect everything automatically and these variables shouldn't be necessary.
 
-The following script will set up the environment variables correctly.  You may need to edit it depending on where your JDK and ARM toolchain are installed:
+The following script will set up the environment variables correctly.  You may need to edit it depending on where your JDK and toolchain are installed:
 
 ````bash
-ARCH=armv6
-TRIPLE=arm-linux-androideabi
-
-TOOLCHAIN=${HOME}/android/toolchain # Edit me!
+ANDROID_TOOLCHAIN_DIR=${HOME}/android/toolchain # Edit me!
 
 # Java SDK
-JAVA_SDK=/usr/lib/jvm/java-8-openjdk-amd64/ # Edit me!
-
-# Build tools
-BINDIR=$TOOLCHAIN/standalone/bin
-COMMON_FLAGS="-target ${TRIPLE} -march=${ARCH}"
-
-CC="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -integrated-as"
-CXX="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -integrated-as"
-LINK="${BINDIR}/${TRIPLE}-clang ${COMMON_FLAGS} -fuse-ld=bfd"
-AR="${BINDIR}/${TRIPLE}-ar"
+JAVA_SDK=/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home
 
 # Android platform information
 ANDROID_NDK_VERSION=r15
 ANDROID_NDK_PLATFORM_VERSION=16
 ANDROID_API_VERSION=28
 ANDROID_PLATFORM=android-${ANDROID_API_VERSION}
-ANDROID_NDK=${TOOLCHAIN}/android-ndk-${ANDROID_NDK_VERSION}
-ANDROID_SDK=${TOOLCHAIN}/android-sdk-linux
-ANDROID_BUILD_TOOLS=27.0.3
-ANDROID_LIB_PATH=${TOOLCHAIN}/standalone/${TRIPLE}/lib
+ANDROID_NDK=${ANDROID_TOOLCHAIN_DIR}/android-ndk-${ANDROID_NDK_VERSION}
+ANDROID_SDK=${ANDROID_TOOLCHAIN_DIR}/android-sdk
+ANDROID_BUILD_TOOLS=28.0.3
 
-export JAVA_SDK
-export CC CXX LINK AR
-export ANDROID_PLATFORM ANDROID_NDK ANDROID_NDK_PLATFORM_VERSION
-export ANDROID_SDK ANDROID_BUILD_TOOLS
-export ANDROID_LIB_PATH ANDROID_API_VERSION
+export JAVA_SDK ANDROID_TOOLCHAIN_DIR
+export ANDROID_NDK_PLATFORM_VERSION ANDROID_API_VERSION
+export ANDROID_PLATFORM ANDROID_NDK ANDROID_SDK ANDROID_BUILD_TOOLS
 ````
 
 ### Generating makefiles


### PR DESCRIPTION
This patch allows the path to the base of the android toolchain to
be specified with ANDROID_TOOLCHAIN_DIR so that config can add the
per-target-arch toolchain suffix to it.