### PR TITLE
[[ StandaloneBuilder ]] Use semver lib when parsing google play deps

### DIFF
--- a/Installer/package.txt
+++ b/Installer/package.txt
@@ -488,6 +488,8 @@ component Extensions
 		rfolder macosx:packaged_extensions/com.livecode.library.objectrepository
 	into [[ToolsFolder]]/Extensions place
 		rfolder macosx:packaged_extensions/com.livecode.library.native.mac.statusmenu
+	into [[ToolsFolder]]/Extensions place
+		rfolder macosx:packaged_extensions/com.livecode.library.semver
 
 	include TimeZone
 

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -83,6 +83,7 @@
 				'script-libraries/messageauthentication/messageauthentication.livecodescript',
 				'script-libraries/httpd/httpd.livecodescript',
 				'script-libraries/qr/qr.livecodescript',
+				'script-libraries/semver/semver.livecodescript',
 			],
 			
 			'dependencies':

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -149,6 +149,10 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
    
    -- Make sure all dependencies are included
    revSBUpdateForDependencies "android", tArchs, , pSettings
+   put the result into tResult
+   if tResult is not empty then
+      throw tResult
+   end if
    revSBEnsurePerExtensionSettings "android", pSettings
    put the result into tResult
    if tResult is not empty then
@@ -1179,21 +1183,37 @@ private command addPlayServiceAARsToSettings  @xSettingsA
    local tPlayServicesPath
    put pathToPlayServices() into tPlayServicesPath
    
-   repeat for each line tPlayService in xSettingsA["android,play dependencies"]
-      local tPlayVersion
-      set the itemDel to "-"
-      put the last item of tPlayService into tPlayVersion
-      delete the last item of tPlayService
-      set the itemDel to comma
+   repeat for each key tPlayService in xSettingsA["android,play dependencies"]
+      local tPlayServiceFolderPath
+      put tPlayServicesPath & slash & \
+            "play-services-" & tPlayService \
+            into tPlayServiceFolderPath
+      
+      if there is not a folder tPlayServiceFolderPath then
+         throw "unable to locate play service dependency" && tPlayService
+      end if
+      
+      local tPlayServiceVersions
+      put folders(tPlayServiceFolderPath) into tPlayServiceVersions
+      filter tPlayServiceVersions without ".*"
+      
+      local tPlayServiceVersionRange
+      put xSettingsA["android,play dependencies"][tPlayService] into tPlayServiceVersionRange
+      
+      local tPlayServiceVersion
+      put semverMaxSatisfying(tPlayServiceVersions, tPlayServiceVersionRange) \
+            into tPlayServiceVersion
+      if tPlayServiceVersion is empty then
+         throw "unable to locate compatible version for play service" && tPlayService && "version" && tPlayServiceVersionRange
+      end if
       
       local tPlayServiceAARPath
-      put tPlayServicesPath & slash & \
-            "play-services-" & tPlayService & slash & \
-            tPlayVersion & slash & \
-            "play-services-" & tPlayService & "-" & tPlayVersion & ".aar" \
+      put tPlayServiceFolderPath & slash & \
+            tPlayServiceVersion & slash & \
+            "play-services-" & tPlayService & "-" & tPlayServiceVersion & ".aar" \
             into tPlayServiceAARPath
       if there is not a file tPlayServiceAARPath then
-         throw "unable to locate play service dependency" && tPlayService && "version" && tPlayVersion
+         throw "unable to locate play service dependency" && tPlayService && "version" && tPlayServiceVersion
       end if
       
       appendToStringList tPlayServiceAARPath, xSettingsA["aarFiles"]

--- a/ide-support/revsaveasemscriptenstandalone.livecodescript
+++ b/ide-support/revsaveasemscriptenstandalone.livecodescript
@@ -58,6 +58,9 @@ command revSaveAsEmscriptenStandalone pStack, pOutputFolder, pSettings
    
    -- Make sure all dependencies are included
    revSBUpdateForDependencies "emscripten",,, pSettings
+   if the result is not empty then
+      throw the result
+   end if
    
    revSBUpdateSettingsForExtensions "emscripten", pSettings
    

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -145,6 +145,10 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       
       -- Make sure all dependencies are included
       revSBUpdateForDependencies "ios", replaceText(tArchs, space, comma), "iphoneos" & item 1 of tIosXcodePair, pSettings
+      if the result is not empty then
+         throw the result
+      end if
+
    else
       
       -- MM-2012-09-18: We now only support the 4.3 simulators or later.
@@ -157,6 +161,9 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       
       -- Make sure all dependencies are included
       revSBUpdateForDependencies "ios", "x86_64", "iphonesimulator" & tSuffix, pSettings
+      if the result is not empty then
+         throw the result
+      end if
       
       replace "." with "_" in tSuffix
       put tSuffix into tSDKS["sim"]["suffix"]

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -495,6 +495,9 @@ private on revStandalonePreBuild pStack, pFolder, pPlatform, pArchs, @rStackName
    
    -- Make sure all dependencies are included
    revSBUpdateForDependencies pPlatform, pArchs, , sStandaloneSettingsA
+   if the result is not empty then
+      return the result
+   end if
    revSBEnsurePerExtensionSettings pPlatform, sStandaloneSettingsA
    if the result is not empty then
       return the result

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -2500,12 +2500,26 @@ command revSBUpdateForDependencies pPlatform, pArchs, pSDK, @xSettings
       local tPlayVersion
       put tAndroidMetadataA["play"]["version"]into tPlayVersion
       repeat for each item tPlayDep in tAndroidMetadataA["play"]["deps"]
-         appendToStringList tPlayDep & "-" & tPlayVersion, xSettings["android,play dependencies"]
+         if xSettings["android,play dependencies"][tPlayDep] is empty then
+            put tPlayVersion into xSettings["android,play dependencies"][tPlayDep]
+         else
+            local tPlayDepVersionIntersection
+            put semverRangesIntersection(tPlayVersion, xSettings["android,play dependencies"][tPlayDep]) \
+                  into tPlayDepVersionIntersection
+            if tPlayDepVersionIntersection is empty then
+               return "unable to find version intersection between" && \
+                     tPlayVersion && "and" && xSettings["android,play dependencies"][tPlayDep] && \
+                     "for google play dependency" && tPlayDep
+            end if
+            put tPlayDepVersionIntersection into xSettings["android,play dependencies"][tPlayDep]
+         end if
       end repeat
       
       revSBUpdateExtensionCodeInclusions tExtension, pPlatform, pArchs, pSDK, xSettings
       revSBUpdatePerExtensionSettings tExtension, pPlatform, xSettings
    end repeat
+   
+   return empty
 end revSBUpdateForDependencies
 
 -- Merge any settings under cRevStandaloneSettings[<ext id>]

--- a/tests/ide-support/standalonebuilder/_support.livecodescript
+++ b/tests/ide-support/standalonebuilder/_support.livecodescript
@@ -199,3 +199,26 @@ command StandaloneBuilderTestSettings pDescription, pStackFileName, pInitialSett
          pExpectedSettingsA[tKey] is tLastSettingsA[tKey]
    end repeat
 end StandaloneBuilderTestSettings
+
+-- Attempt to build a standalone with the given settings an return the result.
+-- Useful for testing when the build process is expected to fail.
+command StandaloneBuilderBuildWithSettings pDescription, pStackFileName, pInitialSettingsA
+   local tStackName, tStackID
+   create stack
+   put it into tStackID
+   put the short name of tStackID into tStackName   
+   
+   repeat for each key tKey in pInitialSettingsA
+      set the cRevStandaloneSettings[tKey] of tStackId to \
+            pInitialSettingsA[tKey]
+   end repeat   
+   
+   set the filename of tStackID to pStackFilename
+   save stack tStackName
+   
+   revIDESaveStack tStackID	
+   
+   local tExePath
+   _TestBuildStandalone pStackFilename, tExePath
+   return the result
+end StandaloneBuilderBuildWithSettings

--- a/tests/ide-support/standalonebuilder/playaardependencies.livecodescript
+++ b/tests/ide-support/standalonebuilder/playaardependencies.livecodescript
@@ -1,0 +1,176 @@
+﻿script "StandaloneExtensionsPlayAARDependencies"
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+local sSupportStack
+
+on TestSetup
+   __InstallExtension \
+         "com.livecode.library.playaardependencytest-base_1_0_0", \
+         "playaardependencytest-base_1_0_0.lcb"
+   __InstallExtension \
+         "com.livecode.library.playaardependencytest-base_2_0_0", \
+         "playaardependencytest-base_2_0_0.lcb"
+   __InstallExtension \
+         "com.livecode.library.playaardependencytest-base_basement_1_0_0", \
+         "playaardependencytest-base_basment_1_0_0.lcb"
+   
+   start using stack "revSBLibrary"
+   
+   local tSupportStack
+   set the itemdelimiter to slash
+   put the filename of me into tSupportStack
+   put "_support.livecodescript" into item -1 of tSupportStack
+   put tSupportStack into sSupportStack
+   start using stack sSupportStack
+   set the itemDel to comma
+end TestSetup
+
+on TestTeardown
+   stop using stack sSupportStack
+end TestTeardown
+
+private function __GetExtFolder pExtName
+   return TestGetEngineRepositoryPath() & slash & \
+         "_tests/_build/packaged_extensions/" & pExtName
+end __GetExtFolder
+
+private command __InstallExtension pExtName, pExtSourceName
+   revIDEExtensionLoad "lcb", pExtName, \
+         __GetExtFolder(pExtName), "0.0.0", "installed", \
+         "", "true", pExtSourceName
+end __InstallExtension
+
+on TestPlayAARSingleDependency
+   local tDesc
+   put "standalone with single play aar dependency" into tDesc
+   
+   local tStandaloneFolder
+   set the itemdelimiter to slash
+   put item 1 to -2 of the filename of me * slash & "__TestPlayAARIncusions" \
+         into tStandaloneFolder   
+   set the itemDel to comma
+   
+   -- Single extension with single play service dependency.
+   local tExtensions
+   put "com.livecode.library.playaardependencytest-base_1_0_0" into tExtensions
+   
+   local tExpectedSettingsA
+   put "1.0.0" into tExpectedSettingsA["android,play dependencies"]["base"]
+   
+   create folder tStandaloneFolder
+   __TestPlayAARDependencies tDesc, tStandaloneFolder, tExtensions, tExpectedSettingsA
+   revDeleteFolder tStandaloneFolder
+end TestPlayAARSingleDependency
+
+on TestPlayAARMultipleDependencies
+   local tDesc
+   put "standalone with multiple play aar dependencies" into tDesc
+   
+   local tStandaloneFolder
+   set the itemdelimiter to slash
+   put item 1 to -2 of the filename of me * slash & "__TestPlayAARIncusions" \
+         into tStandaloneFolder   
+   set the itemDel to comma
+   
+   -- Single extension with multiple play service dependecies.
+   local tExtensions
+   put "com.livecode.library.playaardependencytest-base_basement_1_0_0" \
+         into tExtensions
+   
+   local tExpectedSettingsA
+   put "1.0.0" into tExpectedSettingsA["android,play dependencies"]["base"]
+   put "1.0.0" into tExpectedSettingsA["android,play dependencies"]["basement"]
+   
+   create folder tStandaloneFolder
+   __TestPlayAARDependencies tDesc, tStandaloneFolder, tExtensions, \
+         tExpectedSettingsA
+   revDeleteFolder tStandaloneFolder
+end TestPlayAARMultipleDependencies
+
+on TestPlayAARMultipleExtensions
+   local tDesc
+   put "standalone with multiple extensions with compatible play dependencies" \
+         into tDesc
+   
+   local tStandaloneFolder
+   set the itemdelimiter to slash
+   put item 1 to -2 of the filename of me * slash & "__TestPlayAARIncusions" \
+         into tStandaloneFolder   
+   set the itemDel to comma
+   
+   -- Multiple extensions which depend on the same play service.
+   local tExtensions
+   put "com.livecode.library.playaardependencytest-base_1_0_0" & return & \
+         "com.livecode.library.playaardependencytest-base_basement_1_0_0" \
+         into tExtensions
+   
+   local tExpectedSettingsA
+   put "1.0.0" into tExpectedSettingsA["android,play dependencies"]["base"]
+   
+   create folder tStandaloneFolder
+   __TestPlayAARDependencies tDesc, tStandaloneFolder, tExtensions, \
+         tExpectedSettingsA
+   revDeleteFolder tStandaloneFolder
+end TestPlayAARMultipleExtensions
+
+on TestPlayAARVersionMismatch
+   local tDesc
+   put "standalone with multiple extensions with incompatible play dependencies" \
+         into tDesc
+   
+   local tStandaloneFolder
+   set the itemdelimiter to slash
+   put item 1 to -2 of the filename of me * slash & "__TestPlayAARIncusions" \
+         into tStandaloneFolder   
+   set the itemDel to comma
+   
+   -- Multiple extensions which depend on the same play service but incompatible
+   -- versions. Should result in an error.
+   local tExtensions
+   put "com.livecode.library.playaardependencytest-base_1_0_0" & return & \
+         "com.livecode.library.playaardependencytest-base_2_0_0" \
+         into tExtensions
+   
+   create folder tStandaloneFolder
+   
+   local tResult
+   __TestPlayAARDependencies tDesc, tStandaloneFolder, tExtensions
+   put the result into tResult
+   TestAssert tDesc && ":" && tResult, tResult is not empty
+   
+   revDeleteFolder tStandaloneFolder
+end TestPlayAARVersionMismatch
+
+private command __TestPlayAARDependencies pDesc, pStandaloneFolder, pExtensions, pExpectedSettingA
+   local tStackFilename
+   put pStandaloneFolder & slash & "-standaloneplayaardependency.livecode" \
+         into tStackFilename
+   
+   local tInitialSettingsA
+   put pExtensions into tInitialSettingsA["extensions"]
+   
+   if pExpectedSettingA is empty then
+      StandaloneBuilderTestSettings pDesc, tStackFilename, \
+            tInitialSettingsA, pExpectedSettingA
+      return the result
+   else
+      StandaloneBuilderBuildWithSettings pDesc, tStackFilename, \
+            tInitialSettingsA
+      return the result
+   end if
+end __TestPlayAARDependencies

--- a/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_1_0_0.lcb
+++ b/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_1_0_0.lcb
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+library com.livecode.library.playaardependencytest-base_1_0_0
+
+metadata version is "0.0.0"
+metadata author is "LiveCode"
+metadata title is "Play AAR Dependency Test - Base 1.0.0"
+
+metadata android.play.version is "1.0.0"
+metadata android.play.deps is "base"
+
+end library

--- a/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_2_0_0.lcb
+++ b/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_2_0_0.lcb
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+library com.livecode.library.playaardependencytest-base_2_0_0
+
+metadata version is "0.0.0"
+metadata author is "LiveCode"
+metadata title is "Play AAR Dependency Test - Base 2.0.0"
+
+metadata android.play.version is "2.0.0"
+metadata android.play.deps is "base"
+
+end library

--- a/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_basment_1_0_0.lcb
+++ b/tests/lcs/extensions/libraries/playaarinclusions/playaardependencytest-base_basment_1_0_0.lcb
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+library com.livecode.library.playaardependencytest-base_basment_1_0_0
+
+metadata version is "0.0.0"
+metadata author is "LiveCode"
+metadata title is "Play AAR Dependency Test - Base and Basment 1.0.0"
+
+metadata android.play.version is "1.0.0"
+metadata android.play.deps is "base,basement"
+
+end library


### PR DESCRIPTION
The standalone builder has been updated to use semantic version
checking when including play aar dependencies. If multiple
extensions depend on the the same play service, the standalone
builder will use the semver library to find the correct version
(if any) to use.

Relies on https://github.com/livecode/livecode/pull/7096
