### PR TITLE
[[ Build ]] Allow Xcode SDK to be set by environment

### DIFF
--- a/config.py
+++ b/config.py
@@ -302,7 +302,7 @@ def validate_target_arch(opts):
 
         if re.match('^(ios|mac)', platform) is not None:
             validate_xcode_sdks(opts)
-            arch = guess_xcode_arch(opts['XCODE_TARGET_SDK'])
+            arch = guess_xcode_arch('macosx' + opts['XCODE_TARGET_SDK'])
             if arch is not None:
                 opts['TARGET_ARCH'] = arch
                 opts['UNIFORM_ARCH'] = opts['TARGET_ARCH']
@@ -498,14 +498,14 @@ def validate_xcode_sdks(opts):
     if opts['XCODE_TARGET_SDK'] is None:
         validate_os(opts)
         if opts['OS'] == 'mac':
-            opts['XCODE_TARGET_SDK'] = 'macosx10.9'
+            opts['XCODE_TARGET_SDK'] = '10.9'
         elif opts['OS'] == 'ios':
             opts['XCODE_TARGET_SDK'] = 'iphoneos'
 
     if opts['XCODE_HOST_SDK'] is None:
         validate_os(opts)
         if opts['OS'] == 'mac':
-            opts['XCODE_HOST_SDK'] = opts['XCODE_TARGET_SDK']
+            opts['XCODE_HOST_SDK'] = 'macosx' + opts['XCODE_TARGET_SDK']
         elif opts['OS'] == 'ios':
             opts['XCODE_HOST_SDK'] = 'macosx'
 

--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -1,7 +1,7 @@
 {
 	'variables':
 	{
-		'target_sdk%': 'macosx10.8',
+		'target_sdk%': '10.9',
 		'host_sdk%': 'macosx',
 		
 		'output_dir': '../mac-bin',
@@ -11,7 +11,7 @@
 	
 	'xcode_settings':
 	{
-		'SDKROOT': '<(target_sdk)',
+		'SDKROOT': 'macosx<(target_sdk)',
 
 		'SOLUTION_DIR': '<(DEPTH)',
 		'SYMROOT': '$(SOLUTION_DIR)/_build/mac',
@@ -24,7 +24,7 @@
 		'SHARED_PRECOMPS_DIR': '$(OBJROOT)/Precompiled/$(CURRENT_ARCH)',
 		'GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS': 'NO',
 		'ALWAYS_SEARCH_USER_PATHS': 'NO',
-		'MACOSX_DEPLOYMENT_TARGET': '10.9',
+		'MACOSX_DEPLOYMENT_TARGET': '<(target_sdk)',
 		'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
 		'COPY_PHASE_STRIP': 'NO',
 		'STRIP_INSTALLED_PRODUCT': 'NO',


### PR DESCRIPTION
This patch allows you to specify the SDK used when building mac
on the command line using the XCODE_TARGET_SDK environment
variable