### PR TITLE
[[ Bug ]] Fix project section capsule for mac x86_64

### DIFF
--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1320,9 +1320,7 @@ IO_stat MCDispatch::startup(void)
 
 	// Lookup the name of the project section - if this can't be found there's
 	// something up with the exe.
-	MCCapsuleInfo *t_project_info;
-	t_project_info = (MCCapsuleInfo *)MCExecutableFindSection(PROJECT_SECTION_NAME);
-	if (t_project_info == nil || t_project_info -> size <= sizeof(MCCapsuleInfo))
+	if (MCcapsule.size == 0)
 	{
 #if DEBUG_INSTALLER_STARTUP
         char *openpath = t_mccmd; //point to MCcmd string
@@ -1368,10 +1366,10 @@ IO_stat MCDispatch::startup(void)
 
 	// Decide where to fill from, depending on whether the project data was
 	// spilled or not.
-	if (((t_project_info -> size) & (1U << 31)) == 0)
+	if (((MCcapsule.size) & (1U << 31)) == 0)
 	{
 		// Capsule is not spilled - just use the project section.
-		if (!MCCapsuleFillNoCopy(t_capsule, (const void *)&t_project_info -> data, t_project_info -> size - 4, true))
+		if (!MCCapsuleFillNoCopy(t_capsule, (const void *)&MCcapsule.data, MCcapsule.size - 4, true))
 		{
 			MCCapsuleClose(t_capsule);
 			return IO_ERROR;


### PR DESCRIPTION
This patch uses `MCcapsule` directly rather than using `MCExecutableFindSection`.