### PR TITLE
[[Bug 22182]] Add support for `Apple Development:` certificates

### DIFF
--- a/docs/notes/Bugfix-22182.md
+++ b/docs/notes/Bugfix-22182.md
@@ -1,1 +1,0 @@
-Add support for Apple Development certificates when building for iOS. These certificates can be used for development on macOS, iOS, tvOS, and watchOS.

--- a/docs/notes/Bugfix-22182.md
+++ b/docs/notes/Bugfix-22182.md
@@ -1,0 +1,1 @@
+Add support for Apple Development certificates when building for iOS. These certificates can be used for development on macOS, iOS, tvOS, and watchOS.

--- a/docs/notes/bugfix-22182.md
+++ b/docs/notes/bugfix-22182.md
@@ -1,0 +1,1 @@
+# Add support for Apple Development certificates when building for iOS. These certificates can be used for development on macOS, iOS, tvOS, and watchOS.

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1899,6 +1899,8 @@ private function revGetMobileProfileInfo pProfileId
          get offset("iPhone Distribution:", tCert)
       else if tCert Contains "iOS Development:" then
          get offset("iOS Development:", tCert)
+      else if tCert Contains "Apple Development:" then
+         get offset("Apple Development:", tCert)
       else
          get offset("iPhone Developer:", tCert)
       end if


### PR DESCRIPTION
`Apple Development:` is the label for certificates that can be used for development on macOS, iOS, tvOS, and watchOS.