### PR TITLE
[[ Bug 22187 ]] Ensure rewind and fast forward buttons do not affect playrate

### DIFF
--- a/docs/notes/bugfix-22187.md
+++ b/docs/notes/bugfix-22187.md
@@ -1,0 +1,1 @@
+# Ensure rewind and fast forward buttons do not alter the existing playrate of the player after they are pressed

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -3351,6 +3351,9 @@ void MCPlayer::handle_mdown(int p_which)
         }
             break;
         case kMCPlayerControllerPartScrubBack:
+            
+            push_current_rate();
+
             // PM-2014-08-12: [[ Bug 13120 ]] Cmd + click on scrub buttons starts playing in the appropriate direction
             if (hasfilename() && (MCmodifierstate & MS_CONTROL) != 0)
             {
@@ -3385,6 +3388,9 @@ void MCPlayer::handle_mdown(int p_which)
             break;
             
         case kMCPlayerControllerPartScrubForward:
+            
+            push_current_rate();
+
             // PM-2014-08-12: [[ Bug 13120 ]] Cmd + click on scrub buttons starts playing in the appropriate direction
             if (hasfilename() && (MCmodifierstate & MS_CONTROL) != 0)
             {
@@ -3427,6 +3433,21 @@ void MCPlayer::handle_mdown(int p_which)
         default:
             break;
     }
+}
+
+void MCPlayer::push_current_rate()
+{
+    // get current rate
+    double t_old_rate;
+    MCPlatformGetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyPlayRate, kMCPlatformPropertyTypeDouble, &t_old_rate);
+    m_rate_before_scrub_buttons_pressed = t_old_rate;
+}
+
+void MCPlayer::pop_current_rate()
+{
+    // get current rate
+    double t_old_rate = m_rate_before_scrub_buttons_pressed;
+    MCPlatformSetPlayerProperty(m_platform_player, kMCPlatformPlayerPropertyPlayRate, kMCPlatformPropertyTypeDouble, &t_old_rate);
 }
 
 void MCPlayer::handle_mfocus(int x, int y)
@@ -3583,12 +3604,14 @@ void MCPlayer::handle_mup(int p_which)
     switch (m_grabbed_part)
     {
         case kMCPlayerControllerPartScrubBack:
+            pop_current_rate();
             m_scrub_back_is_pressed = false;
             playpause(m_was_paused);
             layer_redrawall();
             break;
             
         case kMCPlayerControllerPartScrubForward:
+            pop_current_rate();
             m_scrub_forward_is_pressed = false;
             playpause(m_was_paused);
             layer_redrawall();

--- a/engine/src/player-platform.h
+++ b/engine/src/player-platform.h
@@ -85,6 +85,7 @@ private:
     bool m_scrub_back_is_pressed : 1;
     bool m_scrub_forward_is_pressed : 1;
     bool m_modify_selection_while_playing : 1;
+    double m_rate_before_scrub_buttons_pressed;
 
 	static MCPropertyInfo kProperties[];
     static MCObjectPropertyTable kPropertyTable;
@@ -435,6 +436,9 @@ public:
     
     void handle_mup(int which);
     void handle_mfocus(int x, int y);
+    
+    void push_current_rate();
+    void pop_current_rate();
     
     void popup_closed(void);
     


### PR DESCRIPTION
Closes https://quality.livecode.com/show_bug.cgi?id=22187