### PR TITLE
[Bugfix 22198] Fix missing text in hiliteColor

### DIFF
--- a/docs/dictionary/property/hiliteColor.lcdoc
+++ b/docs/dictionary/property/hiliteColor.lcdoc
@@ -64,8 +64,8 @@ depending on the <object type>:
   the <button(keyword)> when it is <highlight|highlighted>. If the
   <button(keyword)> is a <menu>, the <hiliteColor> is used to
   <highlight> the <button(keyword)>, but not the active menu choice. The
-  <hiliteColor> has no effect if the <button(keyword)> is a <tabbed
-  button>. The <hiliteColor> has no effect until the button is
+  <hiliteColor> has no effect if the <button(keyword)> is a 
+  <tabbed button>. The <hiliteColor> has no effect until the button is
   <highlight|highlighted>. 
 
 

--- a/docs/notes/bugfix-22198.md
+++ b/docs/notes/bugfix-22198.md
@@ -1,0 +1,2 @@
+# Fix missing text in the hiliteColor entry
+


### PR DESCRIPTION
Moved a link such that it is all on the same line to have it display correctly.