### PR TITLE
[Dictionary] print link to recordInput

### DIFF
--- a/docs/dictionary/command/print-link.lcdoc
+++ b/docs/dictionary/command/print-link.lcdoc
@@ -30,24 +30,24 @@ Description:
 Use the print link command to define a hyperlink within a pdf printing
 loop. 
 
-If the url adjective is specified, then <link> is interpreted as a URL
+If the url adjective is specified, then *linkName* is interpreted as a URL
 and an external URL launching link is created in the PDF document. The
 given rectangle jumps to that URL when it is clicked.
 
-If the anchor adjective is specified, then <link> is interpreted as an
+If the anchor adjective is specified, then *linkName* is interpreted as an
 internal anchor name, as specified by the print anchor command, and an
 internal anchor link is created in the PDF document. Clicking the given
 rectangle jumps to that anchor.
 
-If no adjective is specified then <link> is interpreted as a URL if it
+If no adjective is specified then *linkName* is interpreted as a URL if it
 begins with (ASCII) letters followed by a colon. e.g. "mailto:foobar" is
 interpreted as a URL, whereas "mail-to-anchor:foo" is interpreted as an
 anchor name.
 
 When printing fields, any text that has its <linkText> property set
 together with the link <textStyle> is treated as if a print link command
-had been executed with the contents of the property as <link>, and the
-<formattedRect> of the text as <rectangle>.
+had been executed with the contents of the property as *linkName*, and the
+<formattedRect> of the text as *rectArea*.
 
 References: print bookmark (command), print anchor (command),
 open printing to pdf (command), cancel printing (command),

--- a/docs/dictionary/command/put.lcdoc
+++ b/docs/dictionary/command/put.lcdoc
@@ -47,14 +47,14 @@ The result:
 >*Important:* If writing to a url container fails, an error is returned
 > in the result. For example: 
 
-    <put> the result into tResult.
+    <put> the result into tResult
 
 > *Note:* Unlike its use with the <file> and <binfile URL> types, the 
 > <put> <command>, when used with a <resfile>, does not create the <file>
 > if it doesn't exist. Instead, an error message is returned in the
 > <result>. To create a file, first use a statement like the following:
 
-    <open file> tFilepath
+    open file tFilepath
 
 > When used with an ftp <URL>, <upload|uploads> the <value> to an 
 > <FTP> <server>. If an error occurs during uploading, the

--- a/docs/dictionary/command/put.lcdoc
+++ b/docs/dictionary/command/put.lcdoc
@@ -47,6 +47,7 @@ The result:
 >*Important:* If writing to a url container fails, an error is returned
 > in the result. For example: 
 
+    local tResult
     <put> the result into tResult
 
 > *Note:* Unlike its use with the <file> and <binfile URL> types, the 

--- a/docs/dictionary/function/recordCompressionTypes.lcdoc
+++ b/docs/dictionary/function/recordCompressionTypes.lcdoc
@@ -66,7 +66,8 @@ function (control structure), compress (function), qtVersion (function),
 property (glossary), loaded into memory (glossary), return (glossary),
 compress (glossary), QuickTime (glossary), command (glossary),
 codec (glossary), items (keyword), character (keyword), line (keyword),
-dontUseQT (property), recordCompression (property)
+dontUseQT (property), dontUseQTEffects (property), 
+recordCompression (property), recordCompressionTypes (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/function/recordCompressionTypes.lcdoc
+++ b/docs/dictionary/function/recordCompressionTypes.lcdoc
@@ -67,7 +67,7 @@ property (glossary), loaded into memory (glossary), return (glossary),
 compress (glossary), QuickTime (glossary), command (glossary),
 codec (glossary), items (keyword), character (keyword), line (keyword),
 dontUseQT (property), dontUseQTEffects (property), 
-recordCompression (property), recordCompressionTypes (property)
+recordCompression (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/message/QTDebugStr.lcdoc
+++ b/docs/dictionary/message/QTDebugStr.lcdoc
@@ -45,7 +45,8 @@ not include 64 bit support and therefore can not be supported on OS X 64
 bit builds of LiveCode.
 
 References: QuickTime (glossary), message (glossary), player (glossary),
-player (keyword), hotspotClicked (message)
+player (keyword), hotspotClicked (message), dontUseQT (property),
+dontUseQTEffects (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/message/queryRecordChanged.lcdoc
+++ b/docs/dictionary/message/queryRecordChanged.lcdoc
@@ -39,10 +39,11 @@ when any of following events occur:
 - The query is disconnected (typically on closeCard) 
 - The query is modified in the Query Builder 
 - The user clicks a button that has been set to refresh 
-  the query. The queryRecordChanged message is only sent to stacks that
-  contain query objects. For more information about query objects and
-  how to create and use them see section 8.5 of the LiveCode User's
-  Guide. 
+  the query. 
+
+The queryRecordChanged message is only sent to stacks that contain 
+query objects. For more information about query objects and how to 
+create and use them see section 8.5 of the LiveCode User's Guide. 
 
 References: revBrowserSet (command), revBrowserNavigate (command),
 browserDownloadRequest (message)

--- a/docs/dictionary/property/printScale.lcdoc
+++ b/docs/dictionary/property/printScale.lcdoc
@@ -31,7 +31,7 @@ Use the <printScale> <property> to control the size of printed
 
 The <printScale> specifies the ratio between the number of <pixels> in
 the <card(keyword)> and the number of <points> on the printed page. A
-<ratio> of 1 means the printed and screen <card(keyword)> should be the
+*ratio* of 1 means the printed and screen <card(keyword)> should be the
 same size, if the screen's resolution is 72 <pixels> per inch.
 
 For example, if a card is 360 pixels wide and you want its printed image

--- a/docs/dictionary/property/properties.lcdoc
+++ b/docs/dictionary/property/properties.lcdoc
@@ -53,19 +53,30 @@ The key of each element in the array is the property name. Use the
 following statements to obtain a list of the properties for a particular
 object type:
 
+    put the properties of field "My Field" into myArray
+    put the keys of myArray
+
 The value of each element in the array is the value of that property for
-> the object. For example, use this statement (after the above example)
-> to get the object's ID property:
+the object. For example, use this statement (after the above example)
+to get the object's ID property:
+   
+    put the properties of field "My Field" into myArray
+    put myArray["id"]
+
 >*Note:* You can't use array notation with an expression, only with a
 > variable, so you must put the <properties> of the object into a
 > variable before you can access the individual elements of the array.
 > If you want a list of properties and their values, use the
-> combinecommand to create a list:
+> <combine> command to create a list:
+
+    put the properties of field "My Field" into myArray
+    combine myArray using return and ": "
+    put myArray
 
 If you set the <properties> of an object to an array that contains only
 some of the properties, any properties that aren't in that array are not
 changed. This means that you can select which properties to set with the
-<properties> property .
+<properties> property.
 
 For example, suppose you want to set the <properties> of a field to the
 <properties> of another field, except that you want to leave the first
@@ -77,14 +88,9 @@ field's name unchanged:
     -- leaves name property unchanged
 
 
-    put the properties of field "My Field" into myArray
-    delete variable myArray[name] -- delete this element from the array
-    set the properties of field "New Field" to myArray
-    -- leaves name property unchanged
-
-
 On storing the properties are set in the correct order to ensure correct
-> recreation of the object.
+recreation of the object.
+
 >*Note:* When setting properties which contain both non-empty color and
 > pattern properties of the same type, the color property will take
 > precedence. 
@@ -95,9 +101,9 @@ fetching it returns the minimal set of properties of an object to allow
 it to be recreated exactly, it also returns unicode variants of
 properties if, and only if, they are needed.
 
-References: setProp (control structure), keys (function),
-propertyNames (function), value (glossary), object (glossary),
-properties (property), customProperties (property)
+References: combine (command), setProp (control structure), 
+keys (function), propertyNames (function), value (glossary), 
+object (glossary), properties (property), customProperties (property)
 
 Tags: properties
 

--- a/docs/dictionary/property/properties.lcdoc
+++ b/docs/dictionary/property/properties.lcdoc
@@ -53,6 +53,7 @@ The key of each element in the array is the property name. Use the
 following statements to obtain a list of the properties for a particular
 object type:
 
+    local myArray
     put the properties of field "My Field" into myArray
     put the keys of myArray
 
@@ -69,6 +70,7 @@ to get the object's ID property:
 > If you want a list of properties and their values, use the
 > <combine> command to create a list:
 
+    local myArray
     put the properties of field "My Field" into myArray
     combine myArray using return and ": "
     put myArray

--- a/docs/dictionary/property/rawDragData.lcdoc
+++ b/docs/dictionary/property/rawDragData.lcdoc
@@ -53,13 +53,13 @@ platform-specific, but can be summarised as:
    are used
 
 
->*Tip:*		All contents of the <rawDragData> are binary - use the
+>*Tip:*	All contents of the <rawDragData> are binary - use the
 > <textEncode>/<textDecode> functions to convert to/from the appropriate
 > encoding. 
 
-References: clipboard (glossary), drag and drop (glossary),
-dragData (property), fullDragData (property),
-rawClipboardData (property)
+References: textDecode (function), textEncode (function),
+clipboard (glossary), drag and drop (glossary), dragData (property), 
+fullDragData (property), rawClipboardData (property)
 
 Tags: ui, drag-and-drop
 

--- a/docs/dictionary/property/recordFormat.lcdoc
+++ b/docs/dictionary/property/recordFormat.lcdoc
@@ -61,5 +61,6 @@ References: record sound (command), play (command), function (glossary),
 property (glossary), compress (glossary), audio clip (glossary),
 QuickTime (glossary), file path (glossary), command (glossary),
 codec (glossary), player (keyword), filename (property), 
-recordFormats (function), recordCompression (property)
+recordFormats (function), dontUseQT (property), 
+dontUseQTEffects (property), recordCompression (property)
 

--- a/docs/dictionary/property/recordInput.lcdoc
+++ b/docs/dictionary/property/recordInput.lcdoc
@@ -37,7 +37,7 @@ sound.
 
 The value "dflt" indicates that the <record sound> <command> should use
 the sound input device chosen in the user's system settings. If a
-different <soundSource> is specified, that input device is used instead.
+different *soundSource* is specified, that input device is used instead.
 
 The possible soundSources vary, depending on the QuickTime version
 installed and on the system's hardware configuration. QuickTime 3.0 and

--- a/docs/dictionary/property/recursionLimit.lcdoc
+++ b/docs/dictionary/property/recursionLimit.lcdoc
@@ -40,10 +40,11 @@ sets. To allow deeper levels of recursion than usual, increase the
 <recursionLimit>. 
 
 Recursion may also occur accidentally. In this case, the recursion is
-> usually infinite--that is, the function will keep recursing until it
-> reaches the limit and causes an execution error. To track down such
-> problems more quickly, reduce the recursionLimit. The lower the limit,
-> the more quickly a buggy routine will cause an execution error.
+usually infinite--that is, the function will keep recursing until it
+reaches the limit and causes an execution error. To track down such
+problems more quickly, reduce the recursionLimit. The lower the limit,
+the more quickly a buggy routine will cause an execution error.
+
 >*Note:* On Windows, as of version 4.5.1, the recursionLimit property is
 > bounded by the stackLimit. Attempts to set the recursionLimit greater
 > than the stackLimit will see it downwardly adjusted to the maximum


### PR DESCRIPTION
print link (command): Assumed mentions of "link" and "rectangle" to have been references to the syntax and changed them as such. Changed markup to italics anyway as it may still fail to display correctly.
printScale (property): Changed markup for parameters outside of syntax to italics as they were failing to display correctly.
properties (property): Deleted duplicate code example. Removed markup causing sentences to be broken up. Added several missing code examples - hopefully correct.
put (command): Removed link markup from code example due to text not displaying.
qtDebugStr (message): Added references used in entry.
queryRecordChanged (message): Separated prose from bullet point that seemed unrelated.
rawDragData (property): Added references used in entry.
recordCompressionTypes (function): Added reference used in entry.
recordFormat (function): Added references used in entry.
recordInput (property): Changed markup for parameters outside of syntax to italics.