### PR TITLE
[Bugfix-21803] Add file overwrite warning to rename entry

### DIFF
--- a/docs/dictionary/command/rename.lcdoc
+++ b/docs/dictionary/command/rename.lcdoc
@@ -42,6 +42,9 @@ on the same volume.
 > rename or move <files> and <folders> it didn't create without
 > obtaining explicit confirmation from the user.
 
+>*Warning:* If a file with the same file path as the newPath already exists, 
+> that file will be overwritten without confirmation.
+
 Changes:
 The ability to move a file or folder on Mac OS and Windows systems with
 the rename command was introduced in version 1.1.1. In previous

--- a/docs/notes/bugfix-21803.md
+++ b/docs/notes/bugfix-21803.md
@@ -1,3 +1,2 @@
-# Added documentation note for the rename command that it can overwrite 
-existing files
+# Added documentation note for the rename command that it can overwrite existing files
 

--- a/docs/notes/bugfix-21803.md
+++ b/docs/notes/bugfix-21803.md
@@ -1,0 +1,3 @@
+# Added documentation note for the rename command that it can overwrite 
+existing files
+


### PR DESCRIPTION
Added warning that if renaming a file to something that already exists, the already-existing file is overwritten.