### PR TITLE
[Docs] Intersect function. Remove glossary reference from Syntax example

### DIFF
--- a/docs/dictionary/function/intersect.lcdoc
+++ b/docs/dictionary/function/intersect.lcdoc
@@ -2,7 +2,7 @@ Name: intersect
 
 Type: function
 
-Syntax: intersect(<object(glossary)>, <object> [, <threshold>] )
+Syntax: intersect(<object>, <object> [, <threshold>] )
 
 Summary:
 <return|Returns> true if two <object|objects> overlap, false otherwise.


### PR DESCRIPTION
If this is in the wrong base, please rebase it for me. I could not see a Livecode 9.5 branch.