### PR TITLE
[[ Bug 20472 ]] fullclipboarddata["image"] missing BMP

### DIFF
--- a/docs/dictionary/property/fullClipboardData.lcdoc
+++ b/docs/dictionary/property/fullClipboardData.lcdoc
@@ -40,10 +40,11 @@ Use the <fullClipboardData> to gain access to the system
   - "rtftext": LiveCode rich text format data
   - "htmltext": LiveCode HTML text
   - "styledtext": array of LiveCode styled text
-  - "image": any of PNG, GIF or JPEG image
+  - "image": any of PNG, GIF or JPEG image. BMP is supported on Windows only.
   - "png": PNG image
   - "gif": GIF image
   - "jpeg": JPEG image
+  - "windows bitmap": BMP (Windows only)
   - "rtf": Rich Text Format data
   - "html": HTML
   - "styles": LiveCode styled text data

--- a/docs/notes/bugfix-20472.md
+++ b/docs/notes/bugfix-20472.md
@@ -1,0 +1,1 @@
+# fullclipboarddata["image"] missing BMP


### PR DESCRIPTION
Docs say fullclipboarddata["image"] can be gif, png, or jpeg but BMP data can be present on Windows