### PR TITLE
[Bugfix-22207] Fix garbled text in selectedObject

### DIFF
--- a/docs/dictionary/function/selectedObject.lcdoc
+++ b/docs/dictionary/function/selectedObject.lcdoc
@@ -29,7 +29,7 @@ repeat with x = 1 to the number of lines of the selectedObjects
 
 Returns:
 The <selectedObject> <function> <return|returns> a list with the long
-<ID> <property> of each selected <object>.
+<ID> <property> of each <selected> <object>.
 
 Description:
 Use the <selectedObject> <function> to perform an action on all the

--- a/docs/dictionary/function/selectedObject.lcdoc
+++ b/docs/dictionary/function/selectedObject.lcdoc
@@ -29,7 +29,7 @@ repeat with x = 1 to the number of lines of the selectedObjects
 
 Returns:
 The <selectedObject> <function> <return|returns> a list with the long
-<ID> <property> of each <operty)d.
+<ID> <property> of each selected <object>.
 
 Description:
 Use the <selectedObject> <function> to perform an action on all the

--- a/docs/notes/bugfix-22207.md
+++ b/docs/notes/bugfix-22207.md
@@ -1,1 +1,1 @@
-# Fixed garbled text in the documentation for selectedObjects
+# Fixed garbled text in the documentation for selectedObject

--- a/docs/notes/bugfix-22207.md
+++ b/docs/notes/bugfix-22207.md
@@ -1,0 +1,1 @@
+# Fixed garbled text in the documentation for selectedObjects


### PR DESCRIPTION
Fixed garbled text in the Returns section of the selectedObject entry.