### PR TITLE
[Dictionary] relayerGroupsControls to return

### DIFF
--- a/docs/dictionary/command/reply.lcdoc
+++ b/docs/dictionary/command/reply.lcdoc
@@ -8,7 +8,7 @@ Syntax: reply error <string>
 
 Summary:
 <return|Returns> data to an application that sent LiveCode an 
-<Apple event>. 
+<Apple Event>. 
 
 Introduced: 1.0
 
@@ -65,9 +65,10 @@ is equivalent to
     reply string with keyword "errs"
 
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at http://developer.apple.com/techpubs/mac/IAC/IAC-2.html.
+For more information about Apple events, refer to the section entitled
+"Apple Events Sent by the Mac OS" in the technical documentation section
+located on [Apple's website] 
+(http://developer.apple.com/documentation/coreservices/apple_events).
 
 References: send to program (command), return (constant),
 Apple Event (glossary), command (glossary), return (glossary),

--- a/docs/dictionary/command/request-appleEvent.lcdoc
+++ b/docs/dictionary/command/request-appleEvent.lcdoc
@@ -7,7 +7,7 @@ Type: command
 Syntax: request appleEvent {class|ID|sender|returnID|data [with keyword <aeKey>]}
 
 Summary:
-Gets data about an <Apple event> that was sent to LiveCode.
+Gets data about an <Apple Event> that was sent to LiveCode.
 
 Introduced: 1.0
 
@@ -73,7 +73,7 @@ specify which pieces you want to get.
 For more information about Apple events, refer to the section entitled 
 "Apple Events Sent by the Mac OS" in the technical documentation section 
 located on [Apple's website]
-(https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-1117769).
+(https://developer.apple.com/documentation/coreservices/apple_events).
 
 References: send to program (command), handler (glossary),
 Apple Event (glossary), variable (glossary), command (glossary),

--- a/docs/dictionary/command/request.lcdoc
+++ b/docs/dictionary/command/request.lcdoc
@@ -5,8 +5,8 @@ Type: command
 Syntax: request <expression> {of | from} {program | application} <programAddress>
 
 Summary:
-The <request> data gets information from another application via <Apple
-Event|Apple events>.
+The <request> data gets information from another application via 
+<Apple Event|Apple Events>.
 
 Introduced: 1.0
 
@@ -34,10 +34,10 @@ omit the zone. If the other program is running on the same computer, you
 can omit both the zone and the computer name.
 
 It:
-If the program supports this <Apple event>, it evaluates the expression
+If the program supports this <Apple Event>, it evaluates the expression
 and sends the result back to LiveCode, which places it in the <it>
-<variable>. The <request> <command> sends aneval <Apple event> to the
-<programAddress>. If the program supports this <Apple event>, it
+<variable>. The <request> <command> sends aneval <Apple Event> to the
+<programAddress>. If the program supports this <Apple Event>, it
 evaluates the expression and sends the result back to LiveCode, which
 places it in the <it> <variable>.
 
@@ -49,11 +49,12 @@ the result <function>.
 
 Description:
 Use the <request> <command> to obtain data from another application via
-the eval <Apple event>.
+the eval <Apple Event>.
 
-For more information about Apple events, see Apple Computer's technical
-documentation, Inside Macintosh: Interapplication Communication, located
-at [Apple's developer site](https://developer.apple.com/library/archive/documentation/mac/IAC/IAC-2.html)
+For more information about Apple events, refer to the section entitled
+"Apple Events Sent by the Mac OS" in the technical documentation section
+located on [Apple's website]
+(https://developer.apple.com/documentation/coreservices/apple_events).
 
 References: send to program (command), function (control structure),
 command (glossary), variable (glossary), Apple Event (glossary),

--- a/docs/dictionary/control_st/return.lcdoc
+++ b/docs/dictionary/control_st/return.lcdoc
@@ -134,7 +134,7 @@ value can be processed to continue operation.
 >*Note:* The <return> <control structure> is implemented internally as a
 <command> and appears in the <commandNames>.
 
-References: return (constant), setProp (control structure),
+References: setProp (control structure),
 getProp (control structure), throw (control structure),
 if (control structure), pass (control structure),
 exit (control structure), on (control structure),
@@ -143,5 +143,5 @@ value (function), merge (function), object (glossary),
 message handler (glossary), call (glossary), property (glossary), 
 pass (glossary), execute (glossary), command (glossary), 
 control structure (glossary), message path (glossary), caller (glossary), 
-message (glossary), statement (glossary), handler (glossary)
+message (glossary), statement (glossary), handler (glossary), return (glossary)
 

--- a/docs/dictionary/control_st/return.lcdoc
+++ b/docs/dictionary/control_st/return.lcdoc
@@ -9,7 +9,8 @@ Stops the current <handler> and <return|returns> a <value> to the
 <handler> that <call|called> the current <handler>.
 
 Introduced: 1.0
-Changed:8.1.0
+
+Changed: 8.1.0
 
 OS: mac, windows, linux, ios, android
 
@@ -89,19 +90,19 @@ remaining <statement|statements> in the <handler> are skipped. Hence,
 the <return> <control structure> is usually used either at the end of a
 <handler> or within an <if> <control structure>.
 
-The plain form of the <return> <control structure> always sets
-<the result> to <value>. Additionally, if it is used within a <function>
+The plain form of the <return> <control structure> always sets the 
+<result> to <value>. Additionally, if it is used within a <function>
 or <getProp> <handler> then <value> is passed to the calling handler as
 the return value of the <function>, or value of the property.
 
-The value form of the <return> <control structure> always sets
-<the result> to empty. If it is used within a <command> or <message>
+The value form of the <return> <control structure> always sets the
+<result> to empty. If it is used within a <command> or <message>
 handler then the <it> variable in the calling handler will be set to
 <value>. If it is used within a <function> handler, then <value> is
 passed to the calling handler as the return value of the <function>,
 or value of the property. 
 
-The error form of the <return> <control structure> sets <the result> to
+The error form of the <return> <control structure> sets the <result> to
 <value>. If it is used within a <command> or <message> handler, then the
 <it> variable in the calling handler will be set to empty. If it is used
 within a <function> handler, then the return value of the <function> or
@@ -138,10 +139,9 @@ getProp (control structure), throw (control structure),
 if (control structure), pass (control structure),
 exit (control structure), on (control structure),
 function (control structure), result (function), commandNames (function),
-value (function), merge (function), the result (function),
-object (glossary), message handler (glossary), return (glossary),
-call (glossary), property (glossary), pass (glossary), execute (glossary),
-command (glossary), control structure (glossary), message path (glossary),
-caller (glossary), message (glossary), statement (glossary),
-handler (glossary)
+value (function), merge (function), object (glossary), 
+message handler (glossary), call (glossary), property (glossary), 
+pass (glossary), execute (glossary), command (glossary), 
+control structure (glossary), message path (glossary), caller (glossary), 
+message (glossary), statement (glossary), handler (glossary)
 

--- a/docs/dictionary/function/result.lcdoc
+++ b/docs/dictionary/function/result.lcdoc
@@ -72,9 +72,8 @@ finishes <execute|executing>.
 
 References: find (command), on (control structure),
 return (control structure), function (control structure),
-sysError (function), value (function), return (glossary),
-variable (glossary), handler (glossary), return value (glossary),
-execute (glossary), statement (glossary), error (glossary),
-control structure (glossary), command (glossary), string (keyword),
-catch (keyword)
+sysError (function), value (function), variable (glossary), 
+handler (glossary), return value (glossary), execute (glossary), 
+statement (glossary), error (glossary), control structure (glossary), 
+command (glossary), string (keyword), catch (keyword)
 

--- a/docs/dictionary/property/relayerGroupedControls.lcdoc
+++ b/docs/dictionary/property/relayerGroupedControls.lcdoc
@@ -26,11 +26,11 @@ By default, the <relayerGroupedControls> <property> is set to false.
 Description:
 Use the <relayerGroupedControls> <property> to change the <layer> of
 <grouped control|grouped controls> without being in 
-<group-editing mode>, or to move <control(object)|controls> out of a <group> by
-changing their <layer>.
+<group-editing mode>, or to move <control(glossary)|controls> out of a 
+<group> by changing their <layer>.
 
 The <layer> of a control is its order on the <card>. If two
-<control(object)|controls> overlap, the one whose <layer> is higher
+<control(glossary)|controls> overlap, the one whose <layer> is higher
 covers the one whose <layer> is lower.
 
 If the <relayerGroupedControls> is false, you can change the <layer> of
@@ -38,8 +38,8 @@ a <control(keyword)> that's part of a <group> only when editing the
 <group>. If the <relayerGroupedControls> is true, you can change the
 <layer> of a <grouped control> at any time.
 
->*Important:*  It is not possible for other <control(object)|controls>
-> to be interspersed between the <control(object)|controls> in a single
+>*Important:*  It is not possible for other <control(glossary)|controls>
+> to be interspersed between the <control(glossary)|controls> in a single
 > <group>, so changing a <grouped control|grouped control's> <layer> may
 > change its group membership if the <relayerGroupedControls> is true:
 
@@ -51,13 +51,13 @@ a <control(keyword)> that's part of a <group> only when editing the
 
 * Conversely, you can move a control into a group by setting the
   control's <layer> to a number between the bottom-most and topmost
-  <control(object)|controls> in the <group>.
+  <control(glossary)|controls> in the <group>.
 
 
-References: group (command), start editing (command), property (glossary),
-grouped control (glossary), group-editing mode (glossary), card (keyword),
-control (keyword), control (object), editBackground (property),
-layer (property)
+References: group (command), start editing (command), 
+control (glossary), property (glossary), grouped control (glossary), 
+group-editing mode (glossary), card (keyword), control (keyword), 
+editBackground (property), layer (property)
 
 Tags: ui
 

--- a/docs/dictionary/property/resizable.lcdoc
+++ b/docs/dictionary/property/resizable.lcdoc
@@ -33,10 +33,9 @@ Use the <resizable> <property> to control whether the user can change a
 window's size.
 
 References: modal (command), stacks (function), property (glossary),
-handler (glossary), command (glossary), stack window (glossary),
-rectangle (keyword), resizeStack (message), stack (object),
-control (object), minHeight (property), properties (property),
-maxWidth (property)
+handler (glossary), command (glossary), stack window (glossary), 
+rectangle (keyword), resizeStack (message), stack (object), 
+minHeight (property), properties (property), maxWidth (property)
 
 Tags: windowing
 

--- a/docs/dictionary/property/resizeQuality.lcdoc
+++ b/docs/dictionary/property/resizeQuality.lcdoc
@@ -24,13 +24,13 @@ set the resizeQuality of the templateImage to "best"
 Description:
 The <resizeQuality> of an image takes one of three values:
 
-"normal": uses a "nearest" filter- i.e. no interpolation. This is the
-fastest scaling method and is the default for new images "good": uses a
-bilinear filter- i.e. interpolation is done between the four nearest
-pixels using bilinearity. "best" : uses a bicubic filter-
-i.e.interpolation is done using cubic approximation from near pixels.
-This is the slowest scaling method but produces the best quality
-scaling. 
+- "normal": uses a "nearest" filter- i.e. no interpolation. This is the
+fastest scaling method and is the default for new images 
+- "good": uses a bilinear filter- i.e. interpolation is done between the 
+four nearest pixels using bilinearity. 
+- "best" : uses a bicubic filter- i.e. interpolation is done using cubic 
+approximation from near pixels. This is the slowest scaling method but 
+produces the best quality scaling. 
 
 The default value of the <resizeQuality> for new images is "normal"
 

--- a/docs/dictionary/property/retainImage.lcdoc
+++ b/docs/dictionary/property/retainImage.lcdoc
@@ -37,8 +37,8 @@ This property is supported only on Unix systems with Display PostScript
 installed. 
 
 References: property (glossary), EPS (glossary), bitmap (glossary),
-Display PostScript (glossary), image (keyword), file (keyword),
-retainPostScript (property), postScript (property)
+Display PostScript (glossary), PostScript (gloassry), image (keyword),
+file (keyword), retainPostScript (property), postScript (property)
 
 Tags: multimedia
 

--- a/docs/dictionary/property/retainPostScript.lcdoc
+++ b/docs/dictionary/property/retainPostScript.lcdoc
@@ -36,8 +36,8 @@ deleted once the <object(glossary)> has been drawn.
 This property is supported only on Unix systems with Display PostScript
 installed. 
 
-References: EPS (glossary), property (glossary), object (glossary),
-postScript (property), retainImage (property)
+References: EPS (glossary), PostScript (glossary), property (glossary), 
+object (glossary), postScript (property), retainImage (property)
 
 Tags: multimedia
 

--- a/docs/glossary/r/ResEdit.lcdoc
+++ b/docs/glossary/r/ResEdit.lcdoc
@@ -5,7 +5,7 @@ Synonyms: resedit
 Type: glossary
 
 Description:
-<Resource> editor for <Mac OS|Mac OS systems>, published by Apple
+<resource|Resource> editor for <Mac OS|Mac OS systems>, published by Apple
 Computer. 
 
 References: Mac OS (glossary), resource (glossary)


### PR DESCRIPTION
relayerGroupedControls (property): Changed all reference to control (object) to control (glossary).
reply (command): Fixed broken link. Changed external link to a more current one.
request-appleEvent (command): Fixed broken links. Changed external link to a more current one.
request (command): Fixed broken links. Changed external link to a more current one.
ResEdit (glossary): Fixed broken link.
resizable (property): Removed non-existent reference.
resizeQuality (property): Corrected formatting of unordered list
result (function): Removed reference creating links to a less relevant entry.
retainImage (property): Added missing reference.
retainPostScript (property): Added missing reference.
return (control structure): Removed reference creating links to a less relevant entry. Fixed broken links. Removed non-existent reference.