### PR TITLE
[[ Bug 22167 ]] Fix iOS standalone engine link issue

### DIFF
--- a/extensions/libraries/timezone/notes/22167.md
+++ b/extensions/libraries/timezone/notes/22167.md
@@ -1,0 +1,1 @@
+# [22167] Fix issue building an app for iOS device

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -311,18 +311,18 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
       set the itemDelimiter to "."
       put item 1 to -2 of tSourceFile into tSourceName
       
-      if there is a file tLib then
-         put tSourceFile into tCopiedExternals[tSourceName]["location"]
-      else
-         create folder (pAppBundle & "/Frameworks")
-         put "Frameworks/" & tSourceFile into tCopiedExternals[tSourceName]["location"]
-      end if
-
       -- hack to uniquify modules
       -- tCopiedExternals should be changed to be keyed on file path
       -- however that has consequences for external mappings
       if tSourceFile ends with ".lcm" then
          put uuid() into tSourceName
+      end if
+      
+      if there is a file tLib then
+         put tSourceFile into tCopiedExternals[tSourceName]["location"]
+      else
+         create folder (pAppBundle & "/Frameworks")
+         put "Frameworks/" & tSourceFile into tCopiedExternals[tSourceName]["location"]
       end if
       
       if pTarget is "Device" then

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -437,6 +437,11 @@ private command __revSBCopyFile pSourceFile, pTargetFile, pCallback, pCallbackTa
       set the fileType to tOldFileType
    end if
    
+   /* WORKAROUND: BUG 22255 
+    *
+    * Multiple shell calls in a tight loop can cause a deadlock on macOS */
+   wait 0 with messages
+   
    return tResult
 end __revSBCopyFile
 


### PR DESCRIPTION
This patch fixes an issue where an extension with a module file in its code
resources for iOS was causing an empty argument to be added to the iOS link
script.