### PR TITLE
[[ Canvas ]] Add 'device transform' property of 'canvas' objects

### DIFF
--- a/docs/lcb/notes/feature-canvas_device_transform.md
+++ b/docs/lcb/notes/feature-canvas_device_transform.md
@@ -1,0 +1,7 @@
+# LiveCode Builder Host Library
+## Canvas library
+
+New syntax has been added to enable getting the current transform of a canvas.
+
+The canvas 'device transform' property returns the affine transform from logical
+units to backing device pixels.

--- a/engine/src/canvas.lcb
+++ b/engine/src/canvas.lcb
@@ -4009,6 +4009,7 @@ public foreign handler MCCanvasGetDashPhase(in pCanvas as Canvas, out rPhase as 
 public foreign handler MCCanvasSetDashPhase(in pPhase as CanvasFloat, in pCanvas as Canvas) returns nothing binds to "<builtin>"
 
 public foreign handler MCCanvasGetClipBounds(in pCanvas as Canvas, out rBounds as Rectangle) returns nothing binds to "<builtin>"
+public foreign handler MCCanvasGetDeviceTransform(in pCanvas as Canvas, out rTransform as Transform) returns nothing binds to "<builtin>"
 
 //////////
 
@@ -4377,6 +4378,32 @@ syntax CanvasPropertyClippingBounds is prefix operator with property precedence
 	"the" "clipping" "bounds" "of" <mCanvas: Expression>
 begin
 	MCCanvasGetClipBounds(mCanvas, output)
+end syntax
+
+//////////
+
+/**
+Summary:	The current device transform of the canvas.
+
+mCanvas:	An expression which evaluates to a canvas.
+
+Description:	The device transform of the canvas. Drawing operations on <mCanvas> will be modified by the transform before rendering to the underlying pixel buffer.
+
+Example:
+	// Modify the canvas transform
+	translate this canvas by [50, 100]
+
+	// Get the resulting transform
+	variable tTransform as Transform
+	put the device transform of this canvas into tTransform
+
+Tags:	Canvas
+*/
+
+syntax CanvasPropertyDeviceTransform is prefix operator with property precedence
+	"the" "device" "transform" "of" <mCanvas: Expression>
+begin
+	MCCanvasGetDeviceTransform(mCanvas, output)
 end syntax
 
 //////////

--- a/engine/src/module-canvas.cpp
+++ b/engine/src/module-canvas.cpp
@@ -5392,6 +5392,20 @@ void MCCanvasGetClipBounds(MCCanvasRef p_canvas, MCCanvasRectangleRef &r_bounds)
 
 //////////
 
+MC_DLLEXPORT_DEF
+void MCCanvasGetDeviceTransform(MCCanvasRef p_canvas, MCCanvasTransformRef &r_transform)
+{
+	__MCCanvasImpl *t_canvas;
+	t_canvas = MCCanvasGet(p_canvas);
+
+	MCGAffineTransform t_transform;
+	t_transform = MCGContextGetDeviceTransform(t_canvas->context);
+
+	/* UNCHECKED */ MCCanvasTransformCreateWithMCGAffineTransform(t_transform, r_transform);
+}
+
+//////////
+
 void MCCanvasCreateSolidPaint(__MCCanvasImpl &x_canvas, MCCanvasSolidPaintRef p_paint, MCGPaintRef& r_paint)
 {
     __MCCanvasColorImpl *t_color;

--- a/engine/src/module-canvas.h
+++ b/engine/src/module-canvas.h
@@ -556,6 +556,7 @@ extern "C" MC_DLLEXPORT void MCCanvasSetDashes(MCProperListRef p_dashes, MCCanva
 extern "C" MC_DLLEXPORT void MCCanvasGetDashPhase(MCCanvasRef p_canvas, MCCanvasFloat &r_phase);
 extern "C" MC_DLLEXPORT void MCCanvasSetDashPhase(MCCanvasFloat p_phase, MCCanvasRef p_canvas);
 extern "C" MC_DLLEXPORT void MCCanvasGetClipBounds(MCCanvasRef p_canvas, MCCanvasRectangleRef &r_bounds);
+extern "C" MC_DLLEXPORT void MCCanvasGetDeviceTransform(MCCanvasRef p_canvas, MCCanvasTransformRef &r_transform);
 
 // Operations
 extern "C" MC_DLLEXPORT void MCCanvasTransform(MCCanvasRef p_canvas, MCCanvasTransformRef p_transform);


### PR DESCRIPTION
This patch adds the syntax 'the device transform of <canvas>' to retrieve the transform
between logical coordinates and the backing device pixels of the canvas.