### PR TITLE
[22261] Fix S/B error on Windows if Android Barcode widget is included

### DIFF
--- a/docs/notes/bugfix-22261.md
+++ b/docs/notes/bugfix-22261.md
@@ -1,0 +1,1 @@
+# Fix error when building an Android standalone on Windows and the barcode scanner widget is included

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1145,7 +1145,7 @@ private command generateResourceClasses pBuildFolder, pResBuildFolder, \
    repeat with x = 1 to the number of lines in xSettings["aarFiles"]
       put pBuildFolder & "/" & x & "/AndroidManifest.xml" into tManifest
       executeShellCommand pathToAapt(), "package", "-f", "-M", tManifest, \
-            "-I", pathToRootClasses(), "-S", pBuildFolder & slash & x & "/res/", "-J", \
+            "-I", pathToRootClasses(), "-S", pBuildFolder & slash & x & "/res", "-J", \
             tOutputFolder & "/", "-m"
       put the result into tAaptResult
       processAaptResult tAaptResult


### PR DESCRIPTION
The `aapt` command on Windows does not like a trailing slash at the param passed to `-S`.

On Mac this is not an issue - `aapt` works both with and without a trailing slash. 