### PR TITLE
[Dictionary] revXMLRootNode to screenColors

### DIFF
--- a/docs/dictionary/command/revXMLRPC_SetSocket.lcdoc
+++ b/docs/dictionary/command/revXMLRPC_SetSocket.lcdoc
@@ -52,6 +52,6 @@ revXMLRPC_CreateRequest (function), return (glossary),
 XML-RPC (glossary), Standalone Application Settings (glossary),
 socket (glossary), standalone application (glossary), function (glossary),
 command (glossary), LiveCode custom library (glossary),
-XML-RPC document (library), XML-RPC library (library) 
+XML-RPC document (glossary), XML-RPC library (library) 
 
 Tags: networking

--- a/docs/dictionary/command/revXMLRPC_SetSocket.lcdoc
+++ b/docs/dictionary/command/revXMLRPC_SetSocket.lcdoc
@@ -52,6 +52,6 @@ revXMLRPC_CreateRequest (function), return (glossary),
 XML-RPC (glossary), Standalone Application Settings (glossary),
 socket (glossary), standalone application (glossary), function (glossary),
 command (glossary), LiveCode custom library (glossary),
-XML-RPC library (library), XML-RPC document (library)
+XML-RPC document (library), XML-RPC library (library) 
 
 Tags: networking

--- a/docs/dictionary/command/rotate.lcdoc
+++ b/docs/dictionary/command/rotate.lcdoc
@@ -62,14 +62,15 @@ the <angle> <property> affects only the screen display of the
 <image(keyword)>, not the actual picture data in it, so setting it
 repeatedly does not introduce distortion.
 
->*Note:*Rotating an image using good or best <resizeQuality> might
+>*Note:* Rotating an image using good or best <resizeQuality> might
 > cause the mask to be promoted to an alpha channel.
 
 >*Note:* As rotate is an image editing operation, the target image needs
 > to be on the currently visible card of an open stack to function.
 
->*Important:* The rotate <command> cannot be used on a <referenced
-> control|referenced image>. Doing so will cause an <execution error>.
+>*Important:* The rotate <command> cannot be used on a 
+> <referenced control|referenced image>. Doing so will cause an 
+> <execution error>.
 > To turn a <referenced control|referenced image>, set the
 > <image(object)|image's><angle (property)> <property> instead.
 

--- a/docs/dictionary/function/revXMLRPC_CreateRequest.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_CreateRequest.lcdoc
@@ -50,25 +50,25 @@ positive <integer>. If the function encounters an error while parsing
 the data, it returns an error message beginning with "xmlrpcerr".
 
 Description:
-Use the <revXMLRPC_CreateRequest> <function> to create an <XML-RPC
-document> that you can use with other <XML-RPC library>
+Use the <revXMLRPC_CreateRequest> <function> to create an 
+<XML-RPC document> that you can use with other <XML-RPC library>
 <command|commands> and <function|functions>. <XML-RPC> is a
 remote procedure call (RPC) protocol which uses XML to encode its
 calls via a <HTTP> transport mechanism.
 
-If the <host> is empty, the <revXMLRPC_CreateRequest> <function>
+If the <RPChost> is empty, the <revXMLRPC_CreateRequest> <function>
 defaults the request host to be the computer running the application,
 also known as "localhost"
 
-If the <port> is empty, the <revXMLRPC_CreateRequest> <function>
+If the <RPCport> is empty, the <revXMLRPC_CreateRequest> <function>
 defaults the request port to 80, which is the default port for <HTTP>
 connections.
 
-If the <path> is empty, the <revXMLRPC_CreateRequest> <function>
+If the <filePath> is empty, the <revXMLRPC_CreateRequest> <function>
 defaults the request path to "RPC2", which is the standard path for
 <XML-RPC> server resources.
 
-If the <protocol> is empty, the <revXMLRPC_CreateRequest> <function>
+If the <connProtocol> is empty, the <revXMLRPC_CreateRequest> <function>
 defaults the request protocol to <HTTP> connections.
 
 If the <revXMLRPC_CreateRequest> <function> encounters an error, it

--- a/docs/dictionary/function/revXMLRPC_GetRequest.lcdoc
+++ b/docs/dictionary/function/revXMLRPC_GetRequest.lcdoc
@@ -47,7 +47,7 @@ document.
 > library checkbox is checked.
 
 References: revXMLRPC_GetResponse (function),
-LiveCode custom library (glossary), revXMLRPC_Error (function)
+LiveCode custom library (glossary), revXMLRPC_Error (function),
 Standalone Application Settings (glossary),
 standalone application (glossary), function (glossary),
 XML-RPC (glossary), XML-RPC library (library),

--- a/docs/dictionary/function/revXMLRootNode.lcdoc
+++ b/docs/dictionary/function/revXMLRootNode.lcdoc
@@ -51,7 +51,7 @@ If the <revXMLRootNode> <function> encounters an error, it
 > checkbox is checked.
 
 References: revXMLDeleteNode (command), function (control structure),
-revXMLCreateFile (function), revXMLCreateFileFromTree (function),
+revXMLCreateTree (function), revXMLCreateTreeFromFile (function),
 revXMLNextSibling (function), revXMLPreviousSibling (function),
 revXMLParent (function), revXMLFirstChild (function),
 Standalone Application Settings (glossary), root node (glossary),

--- a/docs/dictionary/function/screenColors.lcdoc
+++ b/docs/dictionary/function/screenColors.lcdoc
@@ -39,7 +39,7 @@ The expression
 
 is equal to
 
-    the screenDepth^2
+    2 ^ (the screenDepth)
 
 
 The value returned by the <screenColors> <function> is updated only when

--- a/docs/dictionary/message/rotationRateChanged.lcdoc
+++ b/docs/dictionary/message/rotationRateChanged.lcdoc
@@ -28,7 +28,7 @@ pYRate:
 the rate of acceleration around the y axis, in radians/second
 
 pZRate:
-the rate of acceleration around the x axis, in radians/second
+the rate of acceleration around the z axis, in radians/second
 
 Description:
 Handle the <rotationRateChanged> message if you want to perform an

--- a/docs/dictionary/property/scale.lcdoc
+++ b/docs/dictionary/property/scale.lcdoc
@@ -28,8 +28,8 @@ or <video clip|video clips>.
 
 The <scale> is the natural size of the <object|object's> content divided
 by the size of the rectangle the content is placed in. For example, if
-the <ratio> is 1, a <video clip> plays at the movie's normal size; if
-the <ratio> is 2, the <video clip> is blown up by a <factor> of 2.
+the *ratio* is 1, a <video clip> plays at the movie's normal size; if
+the *ratio* is 2, the <video clip> is blown up by a <factor> of 2.
 
 For EPS objects, this property is supported only on Unix systems with
 Display PostScript installed.

--- a/docs/dictionary/property/screen.lcdoc
+++ b/docs/dictionary/property/screen.lcdoc
@@ -18,8 +18,8 @@ Platforms: desktop, server
 
 Example:
 on mouseUp
-  put line (the screen \
-        of stack "My Stack" ) of the screenRects into theRectOfScreenStackIsOn
+  put line (the screen of stack "My Stack" ) of \ 
+        the screenRects into theRectOfScreenStackIsOn
 end mouseUp
 
 Value (int):
@@ -29,6 +29,5 @@ Description:
 Use the <screen> property to determine which monitor the stack appears
 on or the pixel density of the monitor it is on.
 
-References: screenRects (function), screenPixelScales (function),
-stack (object),  (property)
-
+References: screenRect (function), stack (object),
+screenPixelScales (property)


### PR DESCRIPTION
revXMLRootNode (function): Fixed tree/file mixup in the references.
revXMLRPC_CreateRequest (function): Changed information on empty parameters to use the names that appear in the Syntax.
revXMLRPC_GetRequest (function): Added missing separator in references
revXMLRPC_SetSocket (command): Corrected reference type
rotate (command): Fixed broken link.
rotationRateChanged (message): Fixed typo.
scale (property): Changed markdown for the ratio parameter in Description as it was not displaying. (Crude band-aid; I don't understand the underlying problem)
screen (property): Corrected references. Moved line break character in example such that the following part of the line doesn't still wrap anyway when the Dictionary is open at minimum width.
screenColors (function): Corrected mathematical error in equivalent expression.