### PR TITLE
[[ Debug ]] Docs and tweaks for android debugging

### DIFF
--- a/docs/development/build-android.md
+++ b/docs/development/build-android.md
@@ -133,3 +133,41 @@ The Linux build environment used for compiling LiveCode for Android is based on 
 * openjdk-7-jdk
 * flex
 * bison
+
+## Debugging & Profiling with Android Studio
+
+* Build a debug build of the android engine
+* Inside android-XXX-bin, create a symlink librevandroid.so -> Standalone-Community
+(or Standalone-Commercial; whichever you're using)
+* Build your standalone
+* Start Android Studio and select "Profile or Debug APK" on the main menu.
+* Select the APK you built
+* Studio will show you the contents of your APK and there will be a banner
+  along the top about being unable to find debug symbols. Click it and navigate
+  to the folder where you created the librevandroid.so symlink.
+* Set the paths to the source folders in the panel that appears if you want to
+do debugging rather than profiling
+* On the top right of the Android Studio toolbar, there are icons for running,
+debugging and profiling. Select the one you want.
+* If Android Studio complains about the SDK not being set, select the top-level
+project in the left-hand tree view, right-click and go to Module Settings. Hunt
+through those menus for SDK/API selections and make sure they're set properly
+(they may default to "Java 1.8" rather than an Android SDK).
+* If Android Studio complains about the app not having a default activity, quit
+Studio and restart it. Keep doing this until it stops being stupid.
+* If you selected "Profile", you'll see the profiler on the bottom of the
+window. Click the "CPU" portion of the graphs. To do a trace, select
+"Sample C++ methods" from the drop down and hit Record. Perform the action you
+want to profile then click "Stop".
+* If profiling says "Advanced profiling not available", you will likely need to
+play around with MinimumSDK settings and the like when building the app. In
+particular, make sure your device is at least API26 and that the minimum API
+level is set to API26 too.
+* The threads of interest are the one at the top of the list (the main Android
+thread) and one further down called "Thread-2" - this is the engine thread.
+
+> **Note:** When you import an APK into Android Studio, the IDE creates a new
+> project in your home directory under ApkProjects/, and makes a local copy of
+> the target APK there. This means that if you rebuild or update the original
+> APK, you need to manually import the updated version into Android Studio
+> again.

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -349,13 +349,13 @@
 						[
 							{
 								'action_name': 'copy_manifest',
-								'message': 'Copying manifest file',
+								'message': 'Copying and update debuggable in manifest file',
 								
 								'inputs':
 								[
 									'rsrc/android-manifest.xml',
 								],
-								
+
 								'outputs':
 								[
 									'<(PRODUCT_DIR)/Manifest.xml',
@@ -363,7 +363,9 @@
 								
 								'action':
 								[
-									'cp', '<@(_inputs)', '<@(_outputs)',
+									'../util/set_android_debuggable.sh',
+									'<@(_inputs)',
+									'<@(_outputs)',
 								],
 							},
 							{

--- a/tools/extract-debug-symbols.sh
+++ b/tools/extract-debug-symbols.sh
@@ -24,10 +24,14 @@ for input in "$@" ; do
 	# Extract a copy of the debugging information
 	$OBJCOPY --only-keep-debug "$input" "$output" 
 	
-	# Because we export symbols from the engine, only debug symbols
-	# should be stripped.
-	$STRIP -x --strip-debug "$input"
-	
+	if [ "$os" == "android" -a "$BUILDTYPE" == "Debug" ] ; then
+		echo Skipping strip-debug for ${input}
+	else
+		# Because we export symbols from the engine, only debug symbols
+		# should be stripped.
+		$STRIP -x --strip-debug "$input"
+	fi
+
 	# Add a hint for the debugger so it can find the debug info
 	$OBJCOPY --remove-section=.gnu_debuglink "$input"
 	$OBJCOPY --add-gnu-debuglink="$output" "$input"

--- a/util/set_android_debuggable.sh
+++ b/util/set_android_debuggable.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+INPUT="$1"
+OUTPUT="$2"
+
+if [ "$BUILDTYPE" == "Debug" ] ; then
+	sed 's/android:debuggable="false"/android:debuggable="true"/g' "${INPUT}" > "${OUTPUT}"
+else
+	cp "${INPUT}" "${OUTPUT}"
+fi


### PR DESCRIPTION
This patch documents how to debug and profile an android debug build using
Android Studio. It also makes some minor tweaks to our builds to take a
couple of steps that would need to be done each build out of the process.