### PR TITLE
[[ Bug 22322 ]] Fix graphical artefacts after removing focus from a group on mobile

### DIFF
--- a/docs/notes/bugfix-22322.md
+++ b/docs/notes/bugfix-22322.md
@@ -1,0 +1,1 @@
+# Fix graphical artefacts after removing focus from a group when using acceleratedRendering on mobile

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -956,6 +956,12 @@ Boolean MCGroup::doubleup(uint2 which)
 	return False;
 }
 
+uint2 MCGroup::gettransient(void) const
+{
+	// OVERRIDE - groups do not have a transient focus border
+	return 0;
+}
+
 void MCGroup::applyrect(const MCRectangle &nrect)
 {
 	bool t_size_changed;

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -90,6 +90,7 @@ public:
 	virtual Boolean mup(uint2 which, bool p_release);
 	virtual Boolean doubledown(uint2 which);
 	virtual Boolean doubleup(uint2 which);
+	virtual uint2 gettransient(void) const;
 	virtual void applyrect(const MCRectangle &nrect);
 
     virtual void removereferences(void);


### PR DESCRIPTION
This patch fixes bug 22322, where removing focus from a group could cause graphical artefacts when using acceleratedRendering in combination with the "Motif" lookandfeel