### PR TITLE
[Dictionary] showController to tabGroupBehaviour

### DIFF
--- a/docs/dictionary/command/start-session.lcdoc
+++ b/docs/dictionary/command/start-session.lcdoc
@@ -21,7 +21,7 @@ start session
 put "jack" into $_SESSION['user']
 
 Example:
-set the sessionLifeTime to 360 -- 10 minutes
+set the sessionLifeTime to 360 -- 6 minutes
 start session
 
 Description:
@@ -37,7 +37,7 @@ The location where the <$_SESSION(keyword)> array is stored on the
 server is configured using the <sessionSavePath> <property>.
 
 A session is stored until it expires or is deleted using the 
-<delete session command>. The maximum age of a session is configured 
+<delete session> <command>. The maximum age of a session is configured 
 using the <sessionLifetime> <property>.
 
 >*Note:* You do not need to alter any of the session properties in order

--- a/docs/dictionary/property/showController.lcdoc
+++ b/docs/dictionary/property/showController.lcdoc
@@ -35,8 +35,8 @@ Set a player's <showController> <property> to false if you are providing
 these capabilities in the stack already, or if you do not want the user
 to be able to control playback of the movie or sound.
 
-References: property (glossary), controller bar (glossary),
-player (keyword), control (object), player (object),
+References: property (glossary), control (glossary),
+controller bar (glossary), player (keyword), player (object),
 movieControllerID (property), showSelection (property)
 
 Tags: multimedia

--- a/docs/dictionary/property/startAngle.lcdoc
+++ b/docs/dictionary/property/startAngle.lcdoc
@@ -34,8 +34,8 @@ specify that only a portion of the oval, forming an arc, should be
 drawn. 
 
 The <startAngle> determines the starting <point> of the arc. The
-<angleInDegrees> zero is at the right edge, 3 o'clock. Increasing the
-<angleInDegrees> moves the starting <point> counter-clockwise around the
+*angleInDegrees* zero is at the right edge, 3 o'clock. Increasing the
+*angleInDegrees* moves the starting <point> counter-clockwise around the
 arc. 
 
 The global setting of the <arcAngle> <property> <control|controls> the
@@ -47,7 +47,7 @@ For a graphic oval, the angle is the same as the <startAngle>. Changing
 one changes the other.
 
 References: global (command), property (glossary), paint tool (glossary),
-integer (keyword), point (keyword), graphic (keyword), control (object),
+control (glossary), integer (keyword), point (keyword), graphic (keyword),
 properties (property), arcAngle (property), startAngle (property)
 
 Tags: ui

--- a/docs/dictionary/property/strokeGradient.lcdoc
+++ b/docs/dictionary/property/strokeGradient.lcdoc
@@ -71,7 +71,7 @@ end points. This property is 1 by default.
 alternating repetitions of the ramp are reversed. This property is false 
 by default.
 
-*strokeGradient["wrap"] - A boolean value specifying whether the ramp is 
+* strokeGradient["wrap"] - A boolean value specifying whether the ramp is 
 repeated to fill the entire graphic a object. This property is false by 
 default.
 

--- a/docs/dictionary/property/styledText.lcdoc
+++ b/docs/dictionary/property/styledText.lcdoc
@@ -61,9 +61,9 @@ The <styledText> property returns a numerically-indexed array of
 paragraphs, each index representing each paragraph in the field in
 order: 
 
-tStyledTextArray[1] = &lt;first paragraph array&gt;
-...
-tStyledTextArray[&lt;n&gt;] = &lt;last paragraph array&gt; 
+   tStyledTextArray[1] = &lt;first paragraph array&gt;
+   ...
+   tStyledTextArray[&lt;n&gt;] = &lt;last paragraph array&gt; 
 
 Each paragraph array has up to two keys:
 
@@ -79,9 +79,9 @@ borderColor, hGrid, vGrid, dontWrap, padding and hidden.
 The paragraph content array is a numerically-indexed array of runs, each
 index representing each run in the paragraph in order:
 
-tParagraphContentArray[1] = &lt;first paragraph run array&gt;
-...
-tParagraphContentArray[&lt;n&gt;] = &lt;last paragraph run array&gt;
+   tParagraphContentArray[1] = &lt;first paragraph run array&gt;
+   ...
+   tParagraphContentArray[&lt;n&gt;] = &lt;last paragraph run array&gt;
 
 Each paragraph run array has up to three keys:
 
@@ -102,11 +102,12 @@ encoding.
 
 For example, take the following content consisting of two paragraphs:
 
-Centered Hello World
+<p style="text-align: center">Centered **Hello** World</p>
 
-Left-aligned Hello unicodeString
+Left-aligned <span style="color: rgb(255,0,0)">Hello</span> unicodeString
 
 This would transpire as the following array:
+
     1 =
       style = { textAlign = center }
       runs =

--- a/docs/dictionary/property/styledText.lcdoc
+++ b/docs/dictionary/property/styledText.lcdoc
@@ -102,9 +102,9 @@ encoding.
 
 For example, take the following content consisting of two paragraphs:
 
-<p style="text-align: center">Centered **Hello** World</p>
+Centered Hello World
 
-Left-aligned <span style="color: rgb(255,0,0)">Hello</span> unicodeString
+Left-aligned Hello unicodeString
 
 This would transpire as the following array:
 

--- a/docs/dictionary/property/tabGroupBehavior.lcdoc
+++ b/docs/dictionary/property/tabGroupBehavior.lcdoc
@@ -26,7 +26,7 @@ is set to false.
 
 Description:
 Use the <tabGroupBehavior> <property> to enable using the arrow keys to
-tab through a <group(glossary)|group's> <control(object)|controls>.
+tab through a <group(glossary)|group's> <control(glossary)|controls>.
 
 If a group's <tabGroupBehavior> <property> is set to true, pressing the
 Tab key moves to the first <unlock|unlocked> <field(keyword)> in the
@@ -54,8 +54,8 @@ arrow keys to move around in any of the <field(object)|fields> in the
 <control(keyword)> instead.
 
 References: group (command), property (glossary), unlock (glossary),
-group (glossary), field (keyword), control (keyword), tabKey (message),
-field (object), control (object), tabStops (property),
+group (glossary), control (glossary), field (keyword), control (keyword), 
+tabKey (message), field (object), tabStops (property),
 textArrows (property), traversalOn (property), radioBehavior (property),
 layer (property)
 

--- a/docs/glossary/s/SOAP.lcdoc
+++ b/docs/glossary/s/SOAP.lcdoc
@@ -5,7 +5,7 @@ Synonyms: soap, simple object access protocol
 Type: glossary
 
 Description:
-Simple Object Access <Protocol>. An <XML> -based set of rules for
+Simple Object Access <protocol|Protocol>. An <XML>-based set of rules for
 applications to access and use web services.
 
 References: protocol (glossary), XML (glossary)

--- a/docs/glossary/s/stack-version.lcdoc
+++ b/docs/glossary/s/stack-version.lcdoc
@@ -36,7 +36,7 @@ When saving in the **5.5 format**, all <Unicode> text will be lost
 unless it is stored in a container that has a Unicode variant. For
 example, this means that Unicode text in <field|fields> and <button>
 labels will be saved, but any Unicode text in <script|scripts> or
-<custom properties> will be lost.
+<custom property|custom properties> will be lost.
 
 When saving in the **2.7 format**, the following properties or property
 aspects will also be lost:
@@ -63,7 +63,7 @@ lost or altered:
 References: save (command), version (function), stack file (glossary),
 stack (glossary), Unicode (glossary), field (glossary), button (glossary),
 script (glossary), custom property (glossary), card (glossary),
-widget (object), blendLevel (property), ink (property), 
+command (glossary), widget (object), blendLevel (property), ink (property), 
 textFont (property), textStyle (property), textSize (property),
 unicodeToolTip (property), antialiased (property), opaque (property),
 minStackFileVersion (property)


### PR DESCRIPTION
showController (property): Changed reference type to stop it pointing to nothing.
SOAP (glossary): Fixed broken link.
stack version (glossary): Fixed broken link. Added missing reference.
start session (command): Fixed broken link. Corrected claim that 360 seconds is 10 minutes.
startAngle (property): Changed markdown for use of parameter outside syntax. Changed reference type to stop it pointing to nothing.
strokeGradient (property): Corrected bullet point markdown.
styledText (property): Various formatting changes. Added style to the styledText example to approximately mirror the output.
tabGroupBehaviour (property): Changed reference type to stop it pointing to nothing.