### PR TITLE
[[ Bug 22346 ]] Add tests for sqlite error with sprintf format specifier

### DIFF
--- a/docs/notes/bugfix-22346.md
+++ b/docs/notes/bugfix-22346.md
@@ -1,0 +1,1 @@
+# Fix crash when an error occurs in a SQLite query

--- a/tests/lcs/core/database/sqlite_error.livecodescript
+++ b/tests/lcs/core/database/sqlite_error.livecodescript
@@ -1,0 +1,28 @@
+script "TestSQLiteError"
+local sDatabaseID, sDatabaseFile
+
+on TestSetup
+	TestSkipIfNot "database", "sqlite"
+	TestSkipIfNot "external", "revsecurity"
+
+	TestLoadExternal "revdb"
+
+	put the tempname into sDatabaseFile
+	put revOpenDatabase("sqlite",sDatabaseFile,,,,) into sDatabaseID
+	revExecuteSQL sDatabaseID, \
+		"CREATE TABLE FOO (ROWID INTEGER PRIMARY KEY, VALUE TEXT);"
+end TestSetup
+
+on TestTeardown
+	revCloseDatabase sDatabaseID
+	delete file sDatabaseFile
+end TestTeardown
+
+on TestErrorWithPercentInQuery
+	revExecuteSQL sDatabaseID, "INSERT INTO FOO VALUES (1, 'oh look a %s');"
+	-- use query here because the error message includes the query
+	get revDataFromQuery(comma, return, sDatabaseID, \
+		"INSERT INTO FOO VALUES (1, 'oh look a %s');")
+	TestAssert "check error with '%s' in query", \
+		the result contains "'oh look a %s'"
+end TestErrorWithPercentInQuery


### PR DESCRIPTION
This patch adds a test of the sqlite driver to ensure that when a query
contains a valid sprintf format specifier and causes an error to be thrown an
abort due to accessing invalid memory or an error message containing garbage
does not occur.