### PR TITLE
[Bugfix-22340] Add note about non-ASCII chars to URLEncode entry

### DIFF
--- a/docs/dictionary/function/URLEncode.lcdoc
+++ b/docs/dictionary/function/URLEncode.lcdoc
@@ -62,7 +62,13 @@ appears in the formString, it is converted to "%7E".
         return pString
     end urlEncodeRFC
 
+>*Note:* Non-ASCII characters, such as Unicode, that appear in the string
+> to be encoded must first be encoded as UTF-8 (as per standard 
+> convention), requiring the use of the <textEncode> <function(glossary)>.
+> The code example given above can perform this task.
+
 References: post (command), function (control structure),
+textEncode (function), function (glossary),
 hexadecimal (glossary), encode (glossary), ASCII (glossary), 
 return (glossary), server (glossary), URL (keyword), 
 character (keyword), http (keyword), string (keyword)

--- a/docs/notes/bugfix-22340.md
+++ b/docs/notes/bugfix-22340.md
@@ -1,0 +1,1 @@
+# Added a note to the URLEncode entry that non-ASCII input must have first been put through textEncode


### PR DESCRIPTION
Added a note explaining that whenever non-ASCII text is to be encoded into URL format, it must first be encoded as UTF-8.