### PR TITLE
[Bugfix-22341] Add note about non-ASCII chars to URLDecode entry

### DIFF
--- a/docs/dictionary/function/URLDecode.lcdoc
+++ b/docs/dictionary/function/URLDecode.lcdoc
@@ -43,8 +43,8 @@ number is converted to its <character> equivalent, using the
 
 >*Note:* Non-ASCII characters, such as Unicode, that appear in the URL 
 > string to be decoded will have been encoded as UTF-8 (as per standard 
-> convention) requiring the use of the <textDecode> <function> after 
-> urlDecode. For example, the following code:
+> convention), requiring the use of the <textDecode> <function(glossary)> 
+> after urlDecode. For example, the following code:
 
     local tEncodedText
     put "%D1%81%D0%BA%D0%BE%D1%80%D0%BE%D1%81%D1%88%D0%B8%D0" & \

--- a/docs/dictionary/function/URLDecode.lcdoc
+++ b/docs/dictionary/function/URLDecode.lcdoc
@@ -41,13 +41,25 @@ the next two characters as <hexadecimal> digits. (If one of the
 number is converted to its <character> equivalent, using the 
 <character set> currently in use.
 
+>*Note:* Non-ASCII characters, such as Unicode, that appear in the URL 
+> string to be decoded will have been encoded as UTF-8 (as per standard 
+> convention) and thus require the use of the <textDecode> <function>
+> after urlDecode. For example, the following code:
+
+    local tEncodedText
+    put "%D1%81%D0%BA%D0%BE%D1%80%D0%BE%D1%81%D1%88%D0%B8%D0" & \
+          "%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C" into tCodedText
+    put textDecode(urlDecode(tEncodedText),"UTF-8")
+
+> produces the word "скоросшиватель".
+
 References: post (command), function (control structure),
 decompress (function), macToISO (function), arrayDecode (function),
-charToNum (function), baseConvert (function), decode (glossary),
-return (glossary), sign (glossary), encode (glossary),
+charToNum (function), baseConvert (function), textDecode (function),
+decode (glossary), return (glossary), sign (glossary), encode (glossary),
 character set (glossary), hexadecimal (glossary), server (glossary),
-URL (keyword), characters (keyword), character (keyword), http (keyword),
-httpHeaders (property)
+function (glossary), URL (keyword), characters (keyword), 
+character (keyword), http (keyword), httpHeaders (property)
 
 Tags: networking
 

--- a/docs/dictionary/function/URLDecode.lcdoc
+++ b/docs/dictionary/function/URLDecode.lcdoc
@@ -43,8 +43,8 @@ number is converted to its <character> equivalent, using the
 
 >*Note:* Non-ASCII characters, such as Unicode, that appear in the URL 
 > string to be decoded will have been encoded as UTF-8 (as per standard 
-> convention) and thus require the use of the <textDecode> <function>
-> after urlDecode. For example, the following code:
+> convention) requiring the use of the <textDecode> <function> after 
+> urlDecode. For example, the following code:
 
     local tEncodedText
     put "%D1%81%D0%BA%D0%BE%D1%80%D0%BE%D1%81%D1%88%D0%B8%D0" & \

--- a/docs/notes/bugfix-22341.md
+++ b/docs/notes/bugfix-22341.md
@@ -1,0 +1,1 @@
+# Added a note to the URLDecode entry that non-ASCII output must be put through textDecode


### PR DESCRIPTION
Added a note explaining that whenever non-ASCII text is encoded into URL format, it will have been first encoded as UTF-8 and that the output of URLDecode must therefore be decoded that way afterwards.