### PR TITLE
[Bugfix-19631] Note in docs that mobile player controller requires correct filename to display

### DIFF
--- a/docs/dictionary/command/mobileControlCreate.lcdoc
+++ b/docs/dictionary/command/mobileControlCreate.lcdoc
@@ -71,6 +71,14 @@ To read a property of a native control use: <mobileControlGet>
 
 To control the behavior of a native control use: <mobileControlDo> 
 
+>*Note:* If a player is created with an invalid filename or if the file is
+> missing, the video controller will display incorrectly. To check if a 
+> player is set up correctly, the following code could be used:
+
+    if mobileControlGet(sPlayerID, "duration") < 0 then
+        answer "Player is not initialised correctly"
+    end if
+
 References: mobileControlDelete (command), mobileControlDo (command),
 mobileControlSet (command),
 mobileControlGet (function), mobileControlTarget (function),

--- a/docs/dictionary/command/mobileControlSet.lcdoc
+++ b/docs/dictionary/command/mobileControlSet.lcdoc
@@ -191,6 +191,14 @@ directionalLockEnabled property). This is a boolean value.
 - "filename": The filename of URL of the media to play. Setting the
 filename of the player automatically 'prepares' the movie for playback.
 
+>*Note:* If the filename set for a player is invalid or the file is missing, 
+> the video controller will display incorrectly. To check if a player is 
+> set up correctly, the following code could be used:
+
+    if mobileControlGet(sPlayerID, "duration") < 0 then
+        answer "Player is not initialised correctly"
+    end if
+
 - "showController": Determines whether the controller is displayed over
 the content. This is a boolean value.
 

--- a/docs/notes/bugfix-19631.md
+++ b/docs/notes/bugfix-19631.md
@@ -1,0 +1,1 @@
+# Added notes in mobile control documentation that the video controller only displays when its filename is correct.


### PR DESCRIPTION
Added notes to the docs that the video controller can be shown/hidden only if the filename is valid. 