### PR TITLE
[[ Bug 22256 ]] Use correct user info key to obtain keyboard size

### DIFF
--- a/docs/notes/bugfix-22256.md
+++ b/docs/notes/bugfix-22256.md
@@ -1,0 +1,1 @@
+# Fix mobileSetKeyboardDisplay panning incorrect amount on second and subsequent keyboard activation

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -822,8 +822,8 @@ void MCiOSFilePostProtectedDataUnavailableEvent();
 	t_info = [notification userInfo];
 	
     CGSize t_size;
-	t_size = [[t_info objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
-
+	t_size = [[t_info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
+    
     // MM-2012-02-26: [[ Bug 10677 ]] Keyboard dimensions do not take into account orientation.
     //  We want height here, so assume the keyboard is always wider than it is taller and take the min of the two.
     CGFloat t_height = MCMin(t_size . height, t_size . width);


### PR DESCRIPTION
This patch changes our use of `UIKeyboardFrameBeginUserInfoKey` which is the
keyboard frame prior to animating into place to `UIKeyboardFrameEndUserInfoKey`
which is the final keyboard frame. This resolves a bug where the height of the
keyboard changes during the animation.