### PR TITLE
answer dialog should throw exception if no dialog stack exists

### DIFF
--- a/engine/src/exec-dialog.cpp
+++ b/engine/src/exec-dialog.cpp
@@ -432,6 +432,9 @@ void MCDialogExecCustomAnswerDialog(MCExecContext &ctxt, MCNameRef p_stack, MCNa
 	Boolean t_old_trace = MCtrace;
 	MCtrace = False;
 
+    // [[ 2019.09.06 mdw ensure an exception gets thrown if there's no answer dialog in a standalone ]]
+    if (nil == t_stack)
+        t_success = false;
 	if (t_success && t_stack != nil)
 	{
 		MCStack *t_parent_stack = nil;


### PR DESCRIPTION
If there is no ask or answer stack in a standalone and an ask or answer command is issued, the command is ignored silently. This patch fixes that situation so that an exception is thrown and can be caught in a try/catch construct. Currently at the point of this patch t_success is still true from the previous tests and t_stack is nil, thus the next section of code never gets executed, t_success never gets set to false, and so the function exits without throwing the exception.