### PR TITLE
[Bugfix-21978] Add tsNet/libUrl conflict warning to urlProgress

### DIFF
--- a/docs/dictionary/message/urlProgress.lcdoc
+++ b/docs/dictionary/message/urlProgress.lcdoc
@@ -51,5 +51,16 @@ Description:
 Sent when updates on ongoing url requests are communicated. This message
 is periodically sent to the object whose script initiated the operation.
 
+>*Warning:* The <urlProgress> message is not part of the libUrl or tsNet 
+> libraries. It is instead implemented in the mobile engine, whose
+> network-related functionality can not be used together with those
+> libraries in a standalone. Adding either of the "Internet" or "tsNet"
+> Inclusions will result in overriding/replacing any network-related 
+> functionality that is implemented in the mobile engine, including the 
+> <urlProgress> message.
+> To use the <urlProgress> message in a mobile standalone, ensure that 
+> the "Internet" and "tsNet" Inclusions are not added in the standalone
+> settings.
+
 References: put (command), post (command), load (command)
 

--- a/docs/dictionary/message/urlProgress.lcdoc
+++ b/docs/dictionary/message/urlProgress.lcdoc
@@ -51,16 +51,16 @@ Description:
 Sent when updates on ongoing url requests are communicated. This message
 is periodically sent to the object whose script initiated the operation.
 
->*Warning:* The <urlProgress> message is not part of the libUrl or tsNet 
+>*Warning:* The <urlProgress> <message> is not part of the libUrl or tsNet 
 > libraries. It is instead implemented in the mobile engine, whose
 > network-related functionality can not be used together with those
 > libraries in a standalone. Adding either of the "Internet" or "tsNet"
-> Inclusions will result in overriding/replacing any network-related 
+> Inclusions will result in them overriding/replacing any network-related 
 > functionality that is implemented in the mobile engine, including the 
-> <urlProgress> message.
-> To use the <urlProgress> message in a mobile standalone, ensure that 
+> <urlProgress> <message>.
+> To use the <urlProgress> <message> in a mobile standalone, ensure that 
 > the "Internet" and "tsNet" Inclusions are not added in the standalone
 > settings.
 
-References: put (command), post (command), load (command)
+References: put (command), post (command), load (command), message (glossary)
 

--- a/docs/notes/bugfix-21978.md
+++ b/docs/notes/bugfix-21978.md
@@ -1,0 +1,1 @@
+# Added a warning to the urlProgress documentation that the libUrl and tsNet libraries disable it.


### PR DESCRIPTION
Added a warning to the urlProgress entry to explain that tsNet/libUrl will override network-related functionality of the mobile engine and must not be included in order to be able to handle that message.