### PR TITLE
[bugfix-21571] Add missing chunk types to read from file docs

### DIFF
--- a/docs/dictionary/command/read-from-file.lcdoc
+++ b/docs/dictionary/command/read-from-file.lcdoc
@@ -55,10 +55,11 @@ amount:
 A positive integer and specifies how much data to read.
 
 chunkType:
-One of chars, characters, words, items, lines, int1, uInt1, int2, uint2,
-int4, or uint4. The read from file command reads amount of the specified
-chunkType. If you don't specify a chunkType, amount characters are read
-from the file.
+One of bytes, chars, characters, words, items, lines, int1, uInt1, int2, uint2,
+int4, or uint4. Alternatively, one of codepoints or codeunits if <open file>
+was used in the for text read form. The read from file command reads amount 
+of the specified chunkType. If you don't specify a chunkType, amount 
+characters are read from the file.
 
 time:
 The time to wait for the read to be completed, in milliseconds, seconds,

--- a/docs/notes/bugfix-21571.md
+++ b/docs/notes/bugfix-21571.md
@@ -1,0 +1,1 @@
+# Added missing chunk type options to the documentation for read from file.


### PR DESCRIPTION
Included bytes to the list of valid chunk types for read from file for N [whatever].

Also included codepoints and codeunits as well as the circumstances under which they are valid.