### PR TITLE
[Bugfix-20303] Add variable example to URL entry

### DIFF
--- a/docs/dictionary/keyword/URL.lcdoc
+++ b/docs/dictionary/keyword/URL.lcdoc
@@ -26,7 +26,9 @@ Example:
 post field "Results" to URL "http://www.example.org/current.txt"
 
 Example:
-get URL "http://www.xworlds.com/index.html"
+local tURL
+put "http://www.xworlds.com/index.html" into tURL
+get URL tURL
 
 Example:
 put "Hello World" into URL "file:/Users/myuser/Documents/sample.txt"

--- a/docs/notes/bugfix-20303.md
+++ b/docs/notes/bugfix-20303.md
@@ -1,0 +1,1 @@
+# Added example to the URL keyword entry to demonstrate how it is used with variables.


### PR DESCRIPTION
Added an example where a URL is placed into a variable and that variable is used with `get URL` to clarify how that is done.