### PR TITLE
[Bugfix-19892] Clarify reverse play behaviour for playStopped

### DIFF
--- a/docs/dictionary/message/playStopped.lcdoc
+++ b/docs/dictionary/message/playStopped.lcdoc
@@ -26,7 +26,7 @@ Handle the <playStopped> <message> if you want to perform a task when a
 movie or sound finishes playing.
 
 The <playStopped> <message> is sent when the movie or sound reaches its
-end when playing forwards, the movie of sound reaches its beginning if it 
+end when playing forwards, the movie or sound reaches its beginning if it 
 is playing backwards, or when a play stop <command> <execute|executes>. 
 If the user pauses the movie or sound, the <playPaused> <message> is sent 
 instead.

--- a/docs/dictionary/message/playStopped.lcdoc
+++ b/docs/dictionary/message/playStopped.lcdoc
@@ -26,8 +26,10 @@ Handle the <playStopped> <message> if you want to perform a task when a
 movie or sound finishes playing.
 
 The <playStopped> <message> is sent when the movie or sound reaches its
-end, or when a play stop <command> <execute|executes>. If the user
-pauses the movie or sound, the <playPaused> <message> is sent instead.
+end when playing forwards, the movie of sound reaches its beginning if it 
+is playing backwards, or when a play stop <command> <execute|executes>. 
+If the user pauses the movie or sound, the <playPaused> <message> is sent 
+instead.
 
 When an audio clip or video clip is playing, a temporary player is
 created for it. When the clip is finished, the <playStopped> <message>

--- a/docs/notes/bugfix-19892.md
+++ b/docs/notes/bugfix-19892.md
@@ -1,0 +1,1 @@
+# Clarified in the playStopped entry that it is sent when a clip plays backwards to the beginning.


### PR DESCRIPTION
Added that playStopped is also sent when playing backwards to the beginning.