### PR TITLE
[Bugfix-19377] Edit version comparison example to work beyond LC 9

### DIFF
--- a/docs/dictionary/function/version.lcdoc
+++ b/docs/dictionary/function/version.lcdoc
@@ -20,7 +20,7 @@ put the version into field "Version" of me
 
 Example:
 set the itemDelimiter to "."
-if item 1 of the version < 8 then
+if item 1 of the version &lt; 8 then
   answer "Widgets are not available"
 end if
 

--- a/docs/dictionary/function/version.lcdoc
+++ b/docs/dictionary/function/version.lcdoc
@@ -19,8 +19,9 @@ Example:
 put the version into field "Version" of me
 
 Example:
-if item 1 of the version &lt; 3 then
-  answer "Not all features will be available"
+set the itemDelimiter to "."
+if item 1 of the version < 8 then
+  answer "Widgets are not available"
 end if
 
 Returns:

--- a/docs/notes/bugfix-19377.md
+++ b/docs/notes/bugfix-19377.md
@@ -1,0 +1,1 @@
+# Changed an example in the version entry to not operate on alphabetical comparison.

--- a/docs/notes/bugfix-19377.md
+++ b/docs/notes/bugfix-19377.md
@@ -1,1 +1,1 @@
-# Changed an example in the version entry to not operate on alphabetical comparison.
+# Updated example in the version dictionary entry


### PR DESCRIPTION
Changed the version comparison example to be numeric rather than alphabetical, provided the format of the output remains the same.