### PR TITLE
[[ mergExt ]] Update pointer

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2019-2-12"
+constant kMergExtVersion = "2019-9-23"
 constant kTSNetVersion = "1.3.9"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer to include iOS 13 builds.