### PR TITLE
Fix error when deploying to iOS 13.x simulator

### DIFF
--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -15,7 +15,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>${BUNDLE_BUILD}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${BUNDLE_VERSION}</string>
 	${URL_TYPES}
 	${BUNDLE_ICONS}
 	${DISABLE_ATS}


### PR DESCRIPTION
From the release notes of Xcode 11: 
```
Bundles without a CFBundleVersion are invalid and can't be properly installed on devices or simulators. CoreSimulator now checks and rejects such bundles earlier in the process with a clearer error message.
```

However, it seems including a `CFBundleVersion` key is not enough, and a `CFBundleShortVersionString` is needed as well.