### PR TITLE
[[ Bug 22130 ]] Disable deleted object pool creation whilst debugging

### DIFF
--- a/docs/notes/bugfix-22130.md
+++ b/docs/notes/bugfix-22130.md
@@ -1,0 +1,1 @@
+# Improve stability of breakpoint manipulation in the S/E whilst debugging

--- a/engine/src/debug.cpp
+++ b/engine/src/debug.cpp
@@ -284,7 +284,9 @@ void MCB_prepmessage(MCExecContext &ctxt, MCNameRef mess, uint2 line, uint2 pos,
 		p3.setnext(&p4);
 		p4.setvalueref_argument(p_info);
 	}
-	MCB_message(ctxt, mess, &p1);
+    MCDeletedObjectsFreezePool();
+    MCB_message(ctxt, mess, &p1);
+    MCDeletedObjectsThawPool();
 	if (id != 0)
 		MCeerror->clear();
 	if (added)

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -506,6 +506,8 @@ struct MCExecValue;
 struct MCDeletedObjectPool;
 void MCDeletedObjectsSetup(void);
 void MCDeletedObjectsTeardown(void);
+void MCDeletedObjectsFreezePool(void);
+void MCDeletedObjectsThawPool(void);
 void MCDeletedObjectsEnterWait(bool p_dispatching);
 void MCDeletedObjectsLeaveWait(bool p_dispatching);
 void MCDeletedObjectsOnObjectCreated(MCObject *object);


### PR DESCRIPTION
This patch adds a 'freeze' count to the deleted object pool logic. When the current
pool is frozen, no new pools will be created until it is thawed again. This means
that all objects that are deleted during that period are accumulated in the frozen
pool.

This ability is used inside MCB_prepmessage, which is the handler which causes the
engine to enter debug mode and send a message. Doing this prevents corruption of
the deleted object pools stack which appears to occur when the script editor
manipulates menus in the context of a debug-related message.

As the use of freezing the current object pool is only used in this one place it
has no effect on normal running code, only on code which runs in the context of
a debug-related message.
