### PR TITLE
[22401] Ensure iOS time picker always returns the displayed time

### DIFF
--- a/docs/notes/bugfix-22401.md
+++ b/docs/notes/bugfix-22401.md
@@ -1,0 +1,1 @@
+# Ensure the iOS time picker always returns the displayed (rounded) time 

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -419,12 +419,28 @@ UIViewController *MCIPhoneGetViewController(void);
 	NSLog(@"Date = %d\n", t_date);
 }
 
+- (NSInteger)getRoundedDate:(NSDate *)originalDate withStep:(NSInteger)step
+{
+    // The originalDate is not rounded down to the nearest "step" minutes.
+    NSInteger t_original_date_in_seconds = [originalDate timeIntervalSince1970];
+    
+    // Get the "extra" minutes and convert them to seconds
+    NSInteger t_extra_seconds = t_original_date_in_seconds % (step * 60);
+    
+    // Get the rounded date in seconds
+    NSInteger t_seconds_rounded_down_to_step = t_original_date_in_seconds - t_extra_seconds;
+        
+    return t_seconds_rounded_down_to_step;
+}
+
 // called when the action sheet is dispmissed (iPhone, iPod)
 - (void)dismissDatePickWheel:(NSObject *)controlButton
 {
 	// dismiss the action sheet programmatically
 	m_selection_made = true;
-	m_selected_date = [[datePicker date] timeIntervalSince1970];
+    
+    NSInteger t_step = [datePicker minuteInterval];
+    m_selected_date = [self getRoundedDate: datePicker.date withStep:t_step];
     
     if (iSiPad)
     {
@@ -527,7 +543,10 @@ UIViewController *MCIPhoneGetViewController(void);
 {
 	m_running = false;
 	m_selection_made = true;
-	m_selected_date = [[datePicker date] timeIntervalSince1970];
+    
+    NSInteger t_step = [datePicker minuteInterval];
+    m_selected_date = [self getRoundedDate: datePicker.date withStep:t_step];
+    
 	// MW-2011-08-16: [[ Wait ]] Tell the wait to exit (our wait has anyevent == True).
 	MCscreen -> pingwait();
 }


### PR DESCRIPTION
From SO: (https://stackoverflow.com/questions/7504060/uidatepicker-with-15m-interval-but-always-exact-time-as-return-value)
```
... the date stored in a date picker does not match the displayed value until the 
picker value is changed by the user. This mandates that pre-interval-clamped dates 
be fed into the picker otherwise the results will not be clamped if the user doesn't 
explicitly change the displayed value. The result is the output value will not be what
the user expects since it is not what they see.
```

This patch ensures the returned value always matches the displayed value, in both iPhone and iPad

Closes https://quality.livecode.com/show_bug.cgi?id=22401