### PR TITLE
[[ Bug 17201 ]] Fix dictionary for ask/answer file with types

### DIFF
--- a/docs/dictionary/command/answer-file-with-type.lcdoc
+++ b/docs/dictionary/command/answer-file-with-type.lcdoc
@@ -29,7 +29,7 @@ Example:
 answer file (field "Prompt") with type "LiveCode Stacks|rev|RSTK"
 
 Example:
-answer files "Select the images you wish to view:" with type "JPEG Images|jpg|JPEG"
+answer files "Select the images you wish to view:" with type "JPEG Images|jpg|JPEG" or type "PNG Images|png|PNGf"
 
 Parameters:
 prompt (string):
@@ -42,7 +42,7 @@ the contents of the last folder you used with a file dialog box.
 
 types:
 Use the types parameter to specify which files should appear and be
-available for selection. Each set of types is a return-delimited list of
+available for selection. Each set of types is a pipe-delimited list of
 values of the form "tag|extensions|filetypes".
 
 windowTitle:

--- a/docs/dictionary/command/answer-file-with-type.lcdoc
+++ b/docs/dictionary/command/answer-file-with-type.lcdoc
@@ -31,6 +31,9 @@ answer file (field "Prompt") with type "LiveCode Stacks|rev|RSTK"
 Example:
 answer files "Select the images you wish to view:" with type "JPEG Images|jpg|JPEG" or type "PNG Images|png|PNGf"
 
+Example:
+answer files "Select the images you wish to view:" with type "Image file|jpg,png,gif|JPEG,JPEG,PNGf,GIFf"
+
 Parameters:
 prompt (string):
 If you specify empty, no prompt appears.
@@ -43,7 +46,9 @@ the contents of the last folder you used with a file dialog box.
 types:
 Use the types parameter to specify which files should appear and be
 available for selection. Each set of types is a pipe-delimited list of
-values of the form "tag|extensions|filetypes".
+values of the form "tag|extensions|filetypes". Extensions and filetypes
+can either be a single extension/filetype, or can be a comma-delimited
+list of extensions or filetypes.
 
 windowTitle:
 The windowTitle, if specified, appears in the title bar of the dialog

--- a/docs/dictionary/command/ask-file-with-type.lcdoc
+++ b/docs/dictionary/command/ask-file-with-type.lcdoc
@@ -44,7 +44,7 @@ the file name box.
 types:
 Use the types parameter to specify which files should appear and to
 prompt the user for the desired format to save in. Each set of types is
-a return-delimited list of values of the form
+a pipe-delimited list of values of the form
 "tag|extensions|filetypes". 
 
 It:
@@ -75,13 +75,15 @@ to true on <Mac OS> and <Windows|Windows systems>, and always on
 > COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6,
 > LPT7, LPT8 and LPT9. Also do not use these names followed by an
 > extension, for example, NUL.tx7.
+
 If more than one type is specified, a drop-down list containing the tags
 will be displayed allowing the user to select which types of files to
-display. (This list is always displayed on Windows systems). If the as
-sheet form is used, the dialog box appears as a sheet on OS X systems.
-On other systems, the as sheet form has no effect and the dialog box
-appears normally. Attempting to open a sheet from within another sheet
-displays the second stack as a <modal dialog box> instead.
+display. (This list is always displayed on Windows systems).
+
+If the as sheet form is used, the dialog box appears as a sheet on OS X
+systems. On other systems, the as sheet form has no effect and the
+<dialog box> appears normally. Attempting to open a sheet from within
+another sheet displays the second stack as a <modal dialog box> instead.
 
 If the systemFileSelector <property> is set to false, LiveCode's
 built-in <dialog box> is used instead of the operating system's 

--- a/docs/notes/bugfix-17201.md
+++ b/docs/notes/bugfix-17201.md
@@ -1,0 +1,1 @@
+# ask and answer file of type docs fixed


### PR DESCRIPTION
- Updated types parameter to say "pipe-delimited" instead of "return-delimited"
- Updated example to include "with type <types> or type <types>" form
- Updated "Ask file with type" description to fix formatting