### PR TITLE
[[ Bug 22414 ]] Fix crash coalescing window reshape events

### DIFF
--- a/docs/notes/bugfix-22414.md
+++ b/docs/notes/bugfix-22414.md
@@ -1,0 +1,1 @@
+# Fix crash on Android coalescing window reshape events

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -952,11 +952,10 @@ bool MCEventQueuePostWindowReshape(MCStack *p_stack, MCGFloat p_backing_scale)
 	t_event = nil;
 	for(MCEvent *t_new_event = s_first_event; t_new_event != nil; t_new_event = t_new_event -> next)
     {
-        MCStackHandle t_stack = t_new_event->window.stack;
-        if (t_stack.IsValid())
+        if (t_new_event -> type == kMCEventTypeWindowReshape)
         {
-            if (t_new_event -> type == kMCEventTypeWindowReshape
-                && t_stack == p_stack)
+            MCStackHandle t_stack = t_new_event->window.stack;
+            if (t_stack.IsValid() && t_stack == p_stack)
             {
                 t_event = t_new_event;
             }


### PR DESCRIPTION
This patch fixes a crash trying to set an MCStackHandle to an invalid stack
when iterating the event queue to find window reshape events for the stack.