### PR TITLE
[[ Bug 22412 ]] Save tabAlign when tabStops is not set

### DIFF
--- a/docs/notes/bugfix-22412.md
+++ b/docs/notes/bugfix-22412.md
@@ -1,0 +1,1 @@
+# Fix `tabAlign` property not saving when `tabStops` is not set

--- a/engine/src/field.cpp
+++ b/engine/src/field.cpp
@@ -2586,7 +2586,7 @@ IO_stat MCField::extendedsave(MCObjectOutputStream& p_stream, uint4 p_part, uint
     }
     
     // SN-2015-04-30: [[ Bug 15175 ]] Save the tabalign property of the field
-    if (ntabs != 0)
+    if (nalignments != 0)
     {
         t_flags |= FIELD_EXTRA_TABALIGN;
         // Save number of tab alignments, and then each of them.

--- a/tests/_testlib.livecodescript
+++ b/tests/_testlib.livecodescript
@@ -750,7 +750,7 @@ command TestEnsureJVM
    end if
 end TestEnsureJVM
 
-command TestEnumPropRoundTrip pObjectType, pProperty, pValues
+command TestPropRoundTrip pObjectType, pProperty, pValues
    local tStack
    put "TestRoundTrip" & pProperty into tStack
    create stack tStack
@@ -766,20 +766,23 @@ command TestEnumPropRoundTrip pObjectType, pProperty, pValues
       put the long id of stack tStack into tObject
    end if
 
-   repeat for each item tValue in pValues
-      set the pProperty of tObject to tValue
-      TestAssert format("round trip %s '%s'", pProperty, tValue), \
-            the pProperty of tObject is tValue
-      TestDiagnostic format("%s is '%s'", pProperty, the pProperty of tObject)
-   
-      save stack tStack
-      delete stack tStack
-      TestAssert format("round trip to disk %s '%s'", pProperty, tValue), \
-            the pProperty of tObject is tValue
-      TestDiagnostic format("%s is '%s'", pProperty, the pProperty of tObject)
+   repeat for each element tValue in pValues
+      _TestPropRoundTrip tStack, tObject, pProperty, tValue
    end repeat
 
    delete file the filename of stack tStack
    delete stack tStack
-end TestEnumPropRoundTrip
+end TestPropRoundTrip
 
+private command _TestPropRoundTrip pStack, pObject, pProperty, pValue
+	set the pProperty of pObject to pValue
+	TestAssert format("round trip %s '%s'", pProperty, pValue), \
+			the pProperty of pObject is pValue
+	TestDiagnostic format("%s is '%s'", pProperty, the pProperty of pObject)
+
+	save stack pStack
+	delete stack pStack
+	TestAssert format("round trip to disk %s '%s'", pProperty, pValue), \
+			the pProperty of pObject is pValue
+	TestDiagnostic format("%s is '%s'", pProperty, the pProperty of pObject)
+end _TestPropRoundTrip

--- a/tests/lcs/core/field/line-properties.livecodescript
+++ b/tests/lcs/core/field/line-properties.livecodescript
@@ -191,3 +191,17 @@ on _TestMixedEffectiveLineProperties pProp, pValue1, pValue2
 
 	delete field "Test"
 end _TestMixedEffectiveLineProperties
+
+on TestLinePropertyRoundTrip
+	repeat for each element tTest in sTests
+		if not tTest["effective"] then
+			next repeat
+		end if
+
+		local tValues
+		put tTest["value-1"] into tValues[1]
+		put tTest["value-2"] into tValues[2]
+
+		TestPropRoundTrip "field", tTest["property"], tValues
+	end repeat
+end TestLinePropertyRoundTrip

--- a/tests/lcs/core/field/softkeyboardproperties.livecodescript
+++ b/tests/lcs/core/field/softkeyboardproperties.livecodescript
@@ -17,10 +17,16 @@ You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 on TestKeyboardTypeRoundTrip
-	TestEnumPropRoundTrip "field", "keyboardType", ",default,numeric,url,number,phone,contact,email"
+	local tValues
+	put ",default,numeric,url,number,phone,contact,email" into tValues
+	split tValues by comma
+	TestPropRoundTrip "field", "keyboardType", tValues
 end TestKeyboardTypeRoundTrip
 
 on TestReturnKeyTypeRoundTrip
-	TestEnumPropRoundTrip "field", "returnKeyType", ",default,go,google,join,next,route,search,send,yahoo,done,emergency call"
+	local tValues
+	put ",default,go,google,join,next,route,search,send,yahoo,done,emergency call" into tValues
+	split tValues by comma
+	TestPropRoundTrip "field", "returnKeyType", tValues
 end TestReturnKeyTypeRoundTrip
 


### PR DESCRIPTION
This patch ensures that if the `tabAlign` property of a field is set but the
`tabStops` is not then it will still be saved.