### PR TITLE
[Bugfix-20472] Add missing info to fullClipboardData docs

### DIFF
--- a/docs/dictionary/property/fullClipboardData.lcdoc
+++ b/docs/dictionary/property/fullClipboardData.lcdoc
@@ -40,10 +40,14 @@ Use the <fullClipboardData> to gain access to the system
   - "rtftext": LiveCode rich text format data
   - "htmltext": LiveCode HTML text
   - "styledtext": array of LiveCode styled text
-  - "image": any of PNG, GIF or JPEG image
+  - "image": any of PNG, GIF or JPEG image. If on Windows, 
+  additionally BMP image.
   - "png": PNG image
   - "gif": GIF image
   - "jpeg": JPEG image
+  - "windows bitmap": BMP image (Windows only)
+  - "windows metafile": Windows native vector graphics image (Windows 
+  only)
   - "rtf": Rich Text Format data
   - "html": HTML
   - "styles": LiveCode styled text data

--- a/docs/notes/Bugfix-20472.md
+++ b/docs/notes/Bugfix-20472.md
@@ -1,0 +1,1 @@
+# Added missing keys to the fullClipboardData entry


### PR DESCRIPTION
Added to the fullClipboardData entry to account for how bitmap may be present in the clipboard on Windows.