### PR TITLE
fix the block comment markdown syntax

### DIFF
--- a/docs/guides/LiveCode Builder Language Reference.md
+++ b/docs/guides/LiveCode Builder Language Reference.md
@@ -68,7 +68,7 @@ comments, which begin with `/*` and end with `*/`, and can span
 multiple lines.
 
 - **Single-line comment**: (--|//)[^\n\r]*
-- **Block comment**: /\*([^*](\*[^/])?)*\*/
+- **Block comment**: /\*(\[^\*]\(\*\[^/])?)\*\*/
 
 > **Note:** A block comment that spans multiple lines terminates the
 > line of code that it begins on.


### PR DESCRIPTION
The block comment syntax string in the guide.html file was mangled by the markdown parser. This sets things right.