### PR TITLE
[[Bugfix 22433]] Docs: Update selectionChanged

### DIFF
--- a/docs/dictionary/message/selectionChanged.lcdoc
+++ b/docs/dictionary/message/selectionChanged.lcdoc
@@ -29,6 +29,10 @@ The <selectionChanged> <message> is sent to a <field> whenever the user
 makes a text <selection> or moves the <insertion point> in the <field>,
 after the <selection> is changed.
 
+>*Note:* If the selection change is a result of the text being added or
+removed (for example, cut or paste over selected text),
+<selectionChanged> will not be sent, but rather <textChanged>.
+
 The <selectionChanged> <message> is sent to a <player(keyword)> whenever
 the user <select|selects> a portion of the sound or movie, or when a
 <handler> sets the <player(object)|player's> <startTime> or <endTime>

--- a/docs/notes/bugfix-22433.md
+++ b/docs/notes/bugfix-22433.md
@@ -1,0 +1,1 @@
+# Clarified that selectionChanged is not sent when the text changes


### PR DESCRIPTION
Clarified that selectionChanged is not sent when the text changes