### PR TITLE
 [Bugfix-22428] Update release notes for Linux

### DIFF
--- a/docs/notes-base/platforms.md
+++ b/docs/notes-base/platforms.md
@@ -17,8 +17,8 @@ LiveCode supports the following versions of Windows:
 LiveCode supports the following Linux distributions, on 32-bit or
 64-bit Intel/AMD or compatible processors:
 
-* Ubuntu 14.04 and 16.04
-* Fedora 23 & 24
+* Ubuntu 16.04, 18.04 and 19.x
+* Fedora 30 & 31
 * Debian 7 (Wheezy) and 8 (Jessie) [server]
 * CentOS 7 [server]
 

--- a/docs/notes/Bugfix-22428.md
+++ b/docs/notes/Bugfix-22428.md
@@ -1,0 +1,1 @@
+# Updated Linux platform support details in the release notes


### PR DESCRIPTION
Updated the release notes to be more up to date, in accordance with LiveCode's platform support policy.

(Note: While Fedora 31 is the current version, its release was about a week ago)