### PR TITLE
weak link glib not needed here

### DIFF
--- a/engine/src/lnxdcs.cpp
+++ b/engine/src/lnxdcs.cpp
@@ -77,7 +77,6 @@ GdkDisplay *MCdpy;
 ////////////////////////////////////////////////////////////////////////////////
 
 extern "C" int initialise_required_weak_link_X11();
-extern "C" int initialise_required_weak_link_glib();
 extern "C" int initialise_required_weak_link_gobject();
 extern "C" int initialise_required_weak_link_gdk();
 extern "C" int initialise_required_weak_link_gdk_pixbuf();


### PR DESCRIPTION
Removed an unused extern declaration here. Also, the correct return value should be void if it were actually used here. The correct declaration is in dsklnxmain.cpp.