### PR TITLE
[[ PlayerControl ]] Fix iOS9.2 build errors after update to AVKit player

### DIFF
--- a/engine/src/mbliphonevideo.mm
+++ b/engine/src/mbliphonevideo.mm
@@ -39,7 +39,14 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 #import <AVKit/AVKit.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 100000
+	typedef NSString *NSKeyValueChangeKey;
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This patch fixes build errors in the mobile player control source when targetting iOS9.2