### PR TITLE
[[ Bug 22463 ]] Fix compilation of SVG ellipses

### DIFF
--- a/docs/notes/bugfix-22463.md
+++ b/docs/notes/bugfix-22463.md
@@ -1,0 +1,1 @@
+# Fix compilation of ellipse elements in drawing svg compiler

--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -1144,7 +1144,7 @@ private command _svgCompileEllipse @xContext, pElement
 	put pElement["features"]["cx"] into tCx
 	put pElement["features"]["cy"] into tCy
 	put pElement["features"]["rx"] into tRx
-	put pElement["features"]["rx"] into tRy
+	put pElement["features"]["ry"] into tRy
 	_svgCompileShape xContext, "ellipse", _svgBoxEllipse(tCx, tCy, tRx, tRy), tCx, tCy, tRx, tRy
 end _svgCompileEllipse
 


### PR DESCRIPTION
This patch fixes the compilation of the ellipse element in the
SVG drawing compiler. Incorrect compilation occurred due to using
the rx attribute as both rx and ry in the compiled shape.