### PR TITLE
[22457] Prevent crash when calling binarayDecode with wrong data input

### DIFF
--- a/docs/notes/bugfix-22457.md
+++ b/docs/notes/bugfix-22457.md
@@ -1,0 +1,1 @@
+# Prevent crash when calling binarayDecode with wrong data input

--- a/engine/src/exec-filters.cpp
+++ b/engine/src/exec-filters.cpp
@@ -701,7 +701,8 @@ void MCFiltersEvalBinaryDecode(MCExecContext& ctxt, MCStringRef p_format, MCData
                     
                     while (!t_space_skipped)
                     {
-                        if (offset > offset + t_temp_size - t_space_length)
+                        // stop looking for spaces when an encoded space char won't fit within the remaining data
+                        if (t_space_length > t_temp_size)
                         {
                             // No char remaining
                             t_space_skipped = true;


### PR DESCRIPTION
Prevent crash when calling binarayDecode with wrong data input