### PR TITLE
[[ Engine ]] Tweak passing of script text for parsing purposes

### DIFF
--- a/engine/src/hndlrlst.cpp
+++ b/engine/src/hndlrlst.cpp
@@ -416,7 +416,7 @@ void MCHandlerlist::newglobal(MCNameRef p_name)
 	globals[nglobals++] = gptr;
 }
 
-Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
+Parse_stat MCHandlerlist::parse(MCObject *objptr, MCDataRef script_utf8)
 {
 	Parse_stat status = PS_NORMAL;
 
@@ -425,7 +425,7 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 	if (!MCperror -> isempty())
 		MCperror -> clear();
 
-	MCScriptPoint sp(objptr, this, script);
+	MCScriptPoint sp(objptr, this, script_utf8);
 
 	// MW-2008-11-02: Its possible for the objptr to be NULL if this is inert execution
 	//   (for example 'getdefaultprinter()' on Linux) so don't indirect in this case.
@@ -610,6 +610,16 @@ Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef script)
 	}
 
 	return status;
+}
+
+Parse_stat MCHandlerlist::parse(MCObject *objptr, MCStringRef p_script)
+{
+    MCAutoDataRef t_utf16_script;
+    unichar_t *t_unicode_string;
+    uint32_t t_length;
+    /* UNCHECKED */ MCStringConvertToUnicode(p_script, t_unicode_string, t_length);
+    /* UNCHECKED */ MCDataCreateWithBytesAndRelease((byte_t *)t_unicode_string, (t_length + 1) * 2, &t_utf16_script);
+    return parse(objptr, *t_utf16_script);
 }
 
 Exec_stat MCHandlerlist::findhandler(Handler_type type, MCNameRef name, MCHandler *&handret)

--- a/engine/src/hndlrlst.h
+++ b/engine/src/hndlrlst.h
@@ -127,7 +127,8 @@ public:
     void appendglobalnames(MCStringRef& r_string, bool first);
 	void newglobal(MCNameRef name);
 	
-	Parse_stat parse(MCObject *, MCStringRef);
+    Parse_stat parse(MCObject *, MCDataRef);
+    Parse_stat parse(MCObject *, MCStringRef);
 	
 	Exec_stat findhandler(Handler_type, MCNameRef name, MCHandler *&);
 	bool hashandler(Handler_type type, MCNameRef name);

--- a/engine/src/mcio.cpp
+++ b/engine/src/mcio.cpp
@@ -621,16 +621,8 @@ IO_stat IO_read_stringref_new(MCStringRef& r_string, IO_handle p_stream, bool p_
 	if (IO_read_uint2or4(&t_length, p_stream) != IO_NORMAL)
 		return IO_ERROR;
 	
-	MCAutoArray<byte_t> t_utf8_string;
-	if (!t_utf8_string.New(t_length))
-		return IO_ERROR;
-	
-	if (MCStackSecurityRead(reinterpret_cast<char *>(t_utf8_string.Ptr()),
-	                        t_length, p_stream) != IO_NORMAL)
-		return IO_ERROR;
-	
-	if (!MCStringCreateWithBytes(t_utf8_string.Ptr(), t_length, kMCStringEncodingUTF8, false, r_string))
-		return IO_ERROR;
+    if (MCStackSecurityReadUTF8StringRef(r_string, t_length, p_stream) != IO_NORMAL)
+        return IO_ERROR;
 	
 	return IO_NORMAL;
 }

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -2507,14 +2507,22 @@ Boolean MCObject::parsescript(Boolean report, Boolean force)
 			hashandlers = 0;
 			if (hlist == NULL)
 				hlist = new (nothrow) MCHandlerlist;
-			
-			getstack() -> unsecurescript(this);
-			
-			Parse_stat t_stat;
-			t_stat = hlist -> parse(this, _script);
-			
-			getstack() -> securescript(this);
-			
+            
+            Parse_stat t_stat;
+            if (_getscript() != nullptr)
+            {
+                MCDataRef t_utf8_script;
+                getstack()->startparsingscript(this, t_utf8_script);
+                
+                t_stat = hlist->parse(this, t_utf8_script);
+            
+                getstack()->stopparsingscript(this, t_utf8_script);
+            }
+            else
+            {
+                t_stat = hlist->parse(this, kMCEmptyString);
+            }
+            
 			if (t_stat != PS_NORMAL)
 			{
 				hashandlers |= HH_DEAD_SCRIPT;

--- a/engine/src/scriptpt.h
+++ b/engine/src/scriptpt.h
@@ -120,7 +120,8 @@ class MCScriptPoint
 
 public:
 	MCScriptPoint(MCScriptPoint &sp);
-	MCScriptPoint(MCObject *, MCHandlerlist *, MCStringRef script);
+    MCScriptPoint(MCObject *, MCHandlerlist *, MCDataRef utf8_script);
+    MCScriptPoint(MCObject *, MCHandlerlist *, MCStringRef utf8_script);
     MCScriptPoint(MCExecContext &ctxt);
     MCScriptPoint(MCExecContext &ctxt, MCStringRef p_string);
 	MCScriptPoint(MCStringRef p_string);

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -2160,3 +2160,16 @@ bool MCStack::geteffectiveshowinvisibleobjects()
 			return false;
 	}
 }
+
+void MCStack::startparsingscript(MCObject *p_object, MCDataRef& r_data)
+{
+    unichar_t *t_unicode_string;
+    uint32_t t_length;
+    /* UNCHECKED */ MCStringConvertToUnicode(p_object->_getscript(), t_unicode_string, t_length);
+    /* UNCHECKED */ MCDataCreateWithBytesAndRelease((byte_t *)t_unicode_string, (t_length + 1) * 2, r_data);
+}
+
+void MCStack::stopparsingscript(MCObject *p_object, MCDataRef p_data)
+{
+    MCValueRelease(p_data);
+}

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -637,6 +637,8 @@ public:
 	virtual bool iskeyed() { return true; }
 	virtual void securescript(MCObject *) { }
 	virtual void unsecurescript(MCObject *) { }
+    virtual void startparsingscript(MCObject*, MCDataRef&);
+    virtual void stopparsingscript(MCObject*, MCDataRef);
 	
 	Boolean islocked();
 	Boolean isiconic();

--- a/engine/src/stacksecurity.cpp
+++ b/engine/src/stacksecurity.cpp
@@ -103,6 +103,27 @@ IO_stat MCStackSecurityRead(char *r_string, uint32_t p_length, IO_handle p_strea
 	return t_stat;
 }
 
+IO_stat MCStackSecurityReadUTF8StringRef(MCStringRef& r_string, uint32_t p_length, IO_handle p_stream)
+{
+    MCAutoArray<byte_t> t_utf8_string;
+    if (!t_utf8_string.New(p_length))
+        return IO_ERROR;
+    
+    if (MCStackSecurityRead(reinterpret_cast<char *>(t_utf8_string.Ptr()),
+                            p_length,
+                            p_stream) != IO_NORMAL)
+        return IO_ERROR;
+    
+    if (!MCStringCreateWithBytes(t_utf8_string.Ptr(),
+                                 p_length,
+                                 kMCStringEncodingUTF8,
+                                 false,
+                                 r_string))
+        return IO_ERROR;
+    
+    return IO_NORMAL;
+}
+
 ///////////
 
 void MCStackSecurityProcessCapsule(void *p_start, void *p_finish)

--- a/engine/src/stacksecurity.h
+++ b/engine/src/stacksecurity.h
@@ -45,6 +45,7 @@ void MCStackSecuritySetIOEncryptionEnabled(bool p_encrypted);
 
 IO_stat MCStackSecurityWrite(const char *p_string, uint32_t p_length, IO_handle p_stream);
 IO_stat MCStackSecurityRead(char *r_string, uint32_t p_length, IO_handle p_stream);
+IO_stat MCStackSecurityReadUTF8StringRef(MCStringRef& r_string, uint32_t p_length, IO_handle p_stream);
 
 //////////
 

--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -2180,6 +2180,10 @@ MC_DLLEXPORT bool MCStringCreateWithBytesAndRelease(byte_t *bytes, uindex_t byte
 MC_DLLEXPORT bool MCStringCreateWithChars(const unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
 MC_DLLEXPORT bool MCStringCreateWithCharsAndRelease(unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
 
+// Create an immutable string from the given unicode char sequence and force it
+// to be unicode.
+MC_DLLEXPORT bool MCStringCreateUnicodeWithChars(const unichar_t *chars, uindex_t char_count, MCStringRef& r_string);
+
 // Create an immutable string from the given NUL terminated unicode char sequence.
 MC_DLLEXPORT bool MCStringCreateWithWString(const unichar_t *wstring, MCStringRef& r_string);
 MC_DLLEXPORT bool MCStringCreateWithWStringAndRelease(unichar_t *wstring, MCStringRef& r_string);

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -558,6 +558,50 @@ bool MCStringCreateWithCharsAndRelease(unichar_t *p_chars, uindex_t p_char_count
 }
 
 MC_DLLEXPORT_DEF
+bool MCStringCreateUnicodeWithChars(const unichar_t *p_chars, uindex_t p_char_count, MCStringRef& r_string)
+{
+    if (p_char_count == 0)
+    {
+        if (kMCEmptyString != nil)
+        {
+            r_string = MCValueRetain(kMCEmptyString);
+            return true;
+        }
+    }
+    else
+    {
+        MCAssert(nil != p_chars);
+    }
+    
+    bool t_success;
+    t_success = true;
+    
+    __MCString *self;
+    self = nil;
+    if (t_success)
+        t_success = __MCValueCreate(kMCValueTypeCodeString, self);
+    
+    if (t_success)
+        t_success = MCMemoryNewArray(p_char_count + 1, self -> chars);
+    
+    if (t_success)
+    {
+        MCStrCharsMapFromUnicode(p_chars, p_char_count, self -> chars, self -> char_count);
+        self -> flags |= kMCStringFlagIsNotNative;
+        r_string = self;
+    }
+    else
+    {
+        if (self != nil)
+            MCMemoryDeleteArray(self -> chars);
+        
+        MCMemoryDelete(self);
+    }
+    
+    return t_success;
+}
+
+MC_DLLEXPORT_DEF
 bool MCStringCreateWithWString(const unichar_t *p_wstring, MCStringRef& r_string)
 {
 	MCAssert(nil != p_wstring);


### PR DESCRIPTION
This patch adds overloaded parse/construction methods to MCHandlerlist
and MCScriptPoint. Scripts are always parsed as unicode, but could be
provided in native encoding. The new MCScriptPoint constructor takes
UTF-16 encoded data directly (which must include the terminating NUL),
and is used by the overloaded MCHandlerlist::parse method, allowing
the previously encoded data to be passed straight through without
conversion being required.