### PR TITLE
[[ Bug 21566 ]] Fix crash when opening and closing modal windows

### DIFF
--- a/docs/notes/bugfix-21566.md
+++ b/docs/notes/bugfix-21566.md
@@ -1,0 +1,1 @@
+# Fix crash when opening and closing modal windows under some circumstances

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -868,7 +868,7 @@ void MCMacPlatformEndModalSession(MCMacPlatformWindow *p_window)
 			return;
 		
 		[NSApp endModalSession: s_modal_sessions[t_final_index - 1] . session];
-		[s_modal_sessions[t_final_index - 1] . window -> GetHandle() orderOut: nil];
+		[s_modal_sessions[t_final_index - 1] . window -> GetHandle() performSelector:@selector(orderOut:) withObject:nil afterDelay:0];
 		s_modal_sessions[t_final_index - 1] . window -> Release();
 		s_modal_session_count -= 1;
 	}


### PR DESCRIPTION
Problem:

When opening and closing modal windows continuously in a specific stack, at some point this error was thrown:

```
[NSApplication runModalSession:] may not be invoked inside of transaction begin/commit pair, or inside of transaction commit (usually this means it was invoked inside of a view's -drawRect: method.) The modal dialog has been suppressed to avoid deadlock.
```

After that, a crash occurred in a random place each time.

The previous error was thrown when this line was executed, in MCMacPlatformEndModalSession():

`[s_modal_sessions[t_final_index - 1] . window -> GetHandle() orderOut: nil];`

Solution:

It looks like in this case the suggested approach is to defer the operation until the next iteration of the main run loop:

https://forums.developer.apple.com/thread/74394
https://forums.developer.apple.com/thread/88825

So wrapping this line with:

`[performSelector: withObject: afterDelay:]`

causes the error to disappear, and I can no longer get the app to crash.

Note the crash occurred only in a specific (fairly large) project. I was not able to reproduce the crash in a simple stack, just by opening and closing modal substacks. So I guess the specific stack does some sort of a draw operation before/while the modal window is shown, so this error is thrown. It is not so easy to find out exactly where/when this draw operation occurs, as the project is more than 100.000 lines of code. 

Closes https://quality.livecode.com/show_bug.cgi?id=21566