### PR TITLE
[[ Bug 18655 ]] Make ScreenOrientationEventListener public

### DIFF
--- a/engine/src/java/com/runrev/android/ScreenOrientationEventListener.java
+++ b/engine/src/java/com/runrev/android/ScreenOrientationEventListener.java
@@ -20,7 +20,7 @@ import android.view.*;
 import android.content.*;
 import android.util.*;
 
-abstract class ScreenOrientationEventListener extends OrientationEventListener
+public abstract class ScreenOrientationEventListener extends OrientationEventListener
 {
 	int m_orientation = 0;
 	boolean m_orientation_known = false;


### PR DESCRIPTION
This patch changes the `ScreenOrientationEventListener` to public so it is
visible in the `com.runrev.android.nativecontrol` package.