### PR TITLE
[[ Bug 22483 ]] Fix web view not resizing on iOS after reconfiguration

### DIFF
--- a/docs/notes/bugfix-22483.md
+++ b/docs/notes/bugfix-22483.md
@@ -1,0 +1,6 @@
+# Fix iOS mobile browser controls not resizing after setting certain properties.
+
+Setting the mobile browser control 'dataDetectorTypes',
+'allowsInlineMediaPlayback', and 'mediaPlaybackRequiresUserAction' properties
+will no longer prevent the underlying view from resizing to fit the configured
+rect of the browser control.

--- a/libbrowser/src/libbrowser_wkwebview.mm
+++ b/libbrowser/src/libbrowser_wkwebview.mm
@@ -1097,9 +1097,9 @@ bool MCWKWebViewBrowser::Init(void)
 		{
 			[t_view setNavigationDelegate: t_delegate];
 			[t_view setHidden: NO];
+			[t_view setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
 
 			[t_container_view setAutoresizesSubviews:YES];
-			[t_view setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
 			[t_container_view addSubview:t_view];
 			[t_container_view setHidden: YES];
 
@@ -1171,6 +1171,7 @@ bool MCWKWebViewBrowser::Reconfigure()
 			
 			[t_view setNavigationDelegate: m_delegate];
 			[t_view setHidden: NO];
+			[t_view setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
 
 			[m_container_view addSubview:t_view];
 			


### PR DESCRIPTION
This patch fixes an issue where a reconfigured WKWebView browser would not
resize to fit its containing UIView.
