### PR TITLE
[[ Bug 22498 ]] Fix compiling of rotate(<pAngle>) in SVG elements

### DIFF
--- a/extensions/script-libraries/drawing/drawing.livecodescript
+++ b/extensions/script-libraries/drawing/drawing.livecodescript
@@ -801,9 +801,9 @@ private command _svgCompileTransform @xContext, pTransform, pBBox, @rCompiledTra
 			put _svgTransformScale(tTransform[2], tTransform[3]) into tNextMatrix
 			break
 		case "rotate"
-			put _svgTransformTranslate(-tTransform[3], -tTransform[4]) into tNextMatrix
+			put _svgTransformTranslate(tTransform[3], tTransform[4]) into tNextMatrix
 			put _svgTransformConcat(tNextMatrix, _svgTransformRotate(tTransform[2])) into tNextMatrix
-			put _svgTransformConcat(tNextMatrix, _svgTransformTranslate(tTransform[3], tTransform[4])) into tNextMatrix
+			put _svgTransformConcat(tNextMatrix, _svgTransformTranslate(-tTransform[3], -tTransform[4])) into tNextMatrix
 			break
 		case "skewX"
 			put _svgTransformSkew(tTransform[2], 0) into tNextMatrix

--- a/extensions/script-libraries/drawing/notes/22498.md
+++ b/extensions/script-libraries/drawing/notes/22498.md
@@ -1,0 +1,1 @@
+# [22498] Fixed a bug in the compilation of SVG 'rotate()' transforms


### PR DESCRIPTION
This patch fixes a bug where an incorrect transform would be created when
compiling 'rotate(<pAngle>)' in the list of transforms of an SVG element.