### PR TITLE
[[ Bug 22499 ]] Don't recalculate scaled width & height if widget dimensions are unchanged

### DIFF
--- a/extensions/widgets/svgpath/notes/feature-fewer-recalculations.md
+++ b/extensions/widgets/svgpath/notes/feature-fewer-recalculations.md
@@ -1,0 +1,4 @@
+# Implementation
+
+The svgpath widget will now only perform costly scaledWidth and scaledHeight
+recalculations when the widget width or height changes.

--- a/extensions/widgets/svgpath/svgpath.lcb
+++ b/extensions/widgets/svgpath/svgpath.lcb
@@ -47,6 +47,8 @@ private variable mAngle as Real
 private variable mFillRule as String
 private variable mScaledWidth as Real
 private variable mScaledHeight as Real
+private variable mWidth as Real
+private variable mHeight as Real
 
 
 /**
@@ -303,7 +305,11 @@ end handler
 ----------
 -- this handler is called when the widget is resized
 public handler OnGeometryChanged()
-	CalculateScaledSizes()
+    if my width is not mWidth or my height is not mHeight then
+        CalculateScaledSizes()
+        put my width into mWidth
+        put my height into mHeight
+    end if
 end handler
 ----------
 


### PR DESCRIPTION
This patch reduces the work done by the svgpath widget's OnGeometryChanged
handler by checking first if the width or height of the widget has changed before
recalculating the scaled dimensions of the svg path