### PR TITLE
[[ Bug 22213 ]] Implement detailed-utf8 files & folders

### DIFF
--- a/docs/dictionary/function/files.lcdoc
+++ b/docs/dictionary/function/files.lcdoc
@@ -41,7 +41,9 @@ The folder path to search.
 
 outputKind (enum):
 - empty: Use the short form
-- "detailed": Use the long/detailed form
+- "detailed": Use the long/detailed form (deprecated)
+- "detailed-utf8": Use the long/detailed form encoding file names as UTF8 before
+URL-encoding.
 
 Returns (String):
 A list of file names or file information, with one
@@ -84,8 +86,9 @@ value is a list of files with detailed file attributes.
 Each line in the return value is a comma-separated list of file
 attributes, as follows:
 
-1. **Name**.  The file name is URL-encoded.  To obtain the name as
-   plain text, use the <URLDecode> function.
+1. **Name**.  The file name is URL-encoded. To reliably obtain the name use the
+   `detailed-utf8` <outputKind> and decode using the <URLDecode> function followed
+   by <textDecode>. For example, `textDecode(URLDecode(item 1 of tLine), "utf8")`.
 2. **Size**, in bytes.  On OS X systems, this is the size of the 
    <data fork>.
 3. **Resource fork size**, in bytes.  (OS X only).
@@ -111,13 +114,14 @@ Changes:
 The <long> form was introduced in version 1.1.
 The optional <targetFolder> argument for the function call form was
 introduced in version 8.1.
+The `detailed-utf8` form was introduced in version 9.6.
 
 References: sort (command), return (constant), folders (function),
 specialFolderPath (function), alias (glossary), current folder (glossary),
 data fork (glossary), folder (glossary), function (glossary),
 platform (glossary), return (glossary), resource fork (glossary),
 shortcut (glossary), symbolic link (glossary), defaultFolder (property),
-umask (property), long (keyword)
+umask (property), long (keyword), URLDecode (function), textDecode (function)
 
 Tags: file system
 

--- a/docs/dictionary/function/folders.lcdoc
+++ b/docs/dictionary/function/folders.lcdoc
@@ -35,7 +35,9 @@ The folder path to search.
 
 outputKind (enum):
 - empty: Use the short form
-- "detailed": Use the long/detailed form
+- "detailed": Use the long/detailed form (deprecated)
+- "detailed-utf8": Use the long/detailed form encoding folder names as UTF8
+before URL-encoding.
 
 Returns (String):
 A list of folder names or folder information, with
@@ -91,8 +93,10 @@ the attributes are provided only for compatibility with the <files>
 Each line in the return value is a comma-separated list of file
 attributes, as follows:
 
-1. **Name**.  The folder name is URL-encoded.  To obtain the name as
-   plain text, use the <URLDecode> function.
+1. **Name**.  The folder name is URL-encoded. To reliably obtain the name use
+   the `detailed-utf8` <outputKind> and decode using the <URLDecode> function
+   followed by <textDecode>. For example,
+   `textDecode(URLDecode(item 1 of tLine), "utf8")`.
 2. **Size**, in bytes.  This is always 0.
 3. **Resource fork size**, in bytes.  This is always 0.
 4. **Creation date**, in seconds.  (OS X and Windows only).
@@ -119,13 +123,15 @@ Changes:
 The <long> form was introduced in version 1.1.
 The optional <targetFolder> argument for the function call form was
 introduced in version 8.1.
+The `detailed-utf8` form was introduced in version 9.6.
 
 References: sort (command), return (constant), folders (function),
 specialFolderPath (function), alias (glossary), current folder (glossary),
 data fork (glossary), folder (glossary), function (glossary),
 platform (glossary), return (glossary), resource fork (glossary),
 shortcut (glossary), subfolder (glossary), symbolic link (glossary),
-defaultFolder (property), umask (property), long (keyword)
+defaultFolder (property), umask (property), long (keyword),
+URLDecode (function), textDecode (function)
 
 Tags: file system
 

--- a/docs/notes/bugfix-22213.md
+++ b/docs/notes/bugfix-22213.md
@@ -1,0 +1,11 @@
+# A new output kind `detailed-utf8` has been added to the `files` and `folders` functions
+
+The `{ long | detailed } { files | folders } of <folder>`,
+`files(<folder>, "detailed")`, and `folders(<folder>, "detailed")` suffer from
+an anomaly bug where file and folder names are native encoded before being
+URL encoded to add to the list. The native encoding is can not represent
+many unicode codepoints and is therefore lossy.
+
+The new `detailed-utf8` output kind encodes file and folder names as utf8 before
+URL encoding them. This allows the names to be decoded via
+`textDecode(URLDecode(<name>), "utf8")`.

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -58,6 +58,7 @@ MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt,
                                 MCStringRef p_directory,
                                 bool p_files,
                                 bool p_detailed,
+                                bool p_utf8,
                                 MCStringRef& r_string)
 {
 	if (MCsecuremode & MC_SECUREMODE_DISK)
@@ -66,7 +67,7 @@ MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt,
 		return;
 	}
 	MCAutoListRef t_list;
-	if (MCS_getentries(p_directory, p_files, p_detailed, &t_list))
+	if (MCS_getentries(p_directory, p_files, p_detailed, p_utf8, &t_list))
 	{
 		MCListCopyAsString(*t_list, r_string);
 	}
@@ -2716,7 +2717,7 @@ void MCFilesGetFiles(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(nil, true, false, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, true, false, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2728,7 +2729,7 @@ void MCFilesGetDetailedFiles(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(nil, true, true, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, true, true, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2740,7 +2741,7 @@ void MCFilesGetFolders(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(nil, false, false, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, false, false, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();
@@ -2752,7 +2753,7 @@ void MCFilesGetDetailedFolders(MCExecContext& ctxt, MCStringRef& r_value)
 	if (ctxt . EnsureDiskAccessIsAllowed())
 	{
 		MCAutoListRef t_list;
-		if (MCS_getentries(nil, false, true, &t_list) && MCListCopyAsString(*t_list, r_value))
+		if (MCS_getentries(nil, false, true, false, &t_list) && MCListCopyAsString(*t_list, r_value))
 			return;
 
 		ctxt . Throw();

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3158,7 +3158,7 @@ void MCEngineSetRevLibraryMappingByKey(MCExecContext& ctxt, MCNameRef p_library,
 
 ///////////
 
-void MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, bool p_files, bool p_detailed, MCStringRef& r_string);
+void MCFilesEvalFileItemsOfDirectory(MCExecContext& ctxt, MCStringRef p_directory, bool p_files, bool p_detailed, bool p_utf8, MCStringRef& r_string);
 void MCFilesEvalDiskSpace(MCExecContext& ctxt, real64_t& r_result);
 void MCFilesEvalDriverNames(MCExecContext& ctxt, MCStringRef& r_string);
 void MCFilesEvalDrives(MCExecContext& ctxt, MCStringRef& r_string);

--- a/engine/src/funcs.cpp
+++ b/engine/src/funcs.cpp
@@ -546,7 +546,8 @@ MCFileItems::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
 {
     MCAutoStringRef t_folder;
     bool t_is_detailed = false;
-	if (m_folder)
+    bool t_is_utf8 = false;
+    if (m_folder)
     {
 		if (!ctxt.EvalExprAsStringRef(m_folder, m_files ? EE_FILES_BADFOLDER : EE_FOLDERS_BADFOLDER, &t_folder))
 			return;
@@ -560,18 +561,26 @@ MCFileItems::eval_ctxt(MCExecContext & ctxt, MCExecValue & r_value)
             }
             if (!MCStringIsEmpty(*t_kind))
             {
-                if (!MCStringIsEqualToCString(*t_kind, "detailed", kMCStringOptionCompareCaseless))
+                if (MCStringIsEqualToCString(*t_kind, "detailed", kMCStringOptionCompareCaseless))
+                {
+                    t_is_detailed = true;
+                }
+                else if (MCStringIsEqualToCString(*t_kind, "detailed-utf8", kMCStringOptionCompareCaseless))
+                {
+                    t_is_detailed = true;
+                    t_is_utf8 = true;
+                }
+                else
                 {
                     ctxt.LegacyThrow(m_files ? EE_FILES_BADKIND : EE_FOLDERS_BADKIND);
                     return;
                 }
-                t_is_detailed = true;
             }
         }
     }
     
     r_value.type = kMCExecValueTypeStringRef;
-    MCFilesEvalFileItemsOfDirectory(ctxt, *t_folder, m_files, t_is_detailed, r_value.stringref_value);
+    MCFilesEvalFileItemsOfDirectory(ctxt, *t_folder, m_files, t_is_detailed, t_is_utf8, r_value.stringref_value);
 }
 
 

--- a/engine/src/osspec.h
+++ b/engine/src/osspec.h
@@ -81,7 +81,7 @@ extern bool MCS_resolvepath(MCStringRef p_path, MCStringRef& r_resolved_path);
 extern void MCS_getcurdir(MCStringRef& r_path);
 /* LEGACY */ extern char *MCS_getcurdir();
 extern Boolean MCS_setcurdir(MCStringRef p_path);
-extern bool MCS_getentries(MCStringRef p_folder, bool p_files, bool p_detailed, MCListRef& r_list);
+extern bool MCS_getentries(MCStringRef p_folder, bool p_files, bool p_detailed, bool p_utf8, MCListRef& r_list);
 
 extern bool MCS_getDNSservers(MCListRef& r_list);
 extern Boolean MCS_getdevices(MCStringRef& r_list);

--- a/engine/src/sysspec.cpp
+++ b/engine/src/sysspec.cpp
@@ -904,6 +904,7 @@ struct MCS_getentries_state
 {
 	bool files;
 	bool details;
+    bool utf8;
 	MCListRef list;
 };
 
@@ -939,7 +940,7 @@ static bool MCS_getentries_callback(void *p_context, const MCSystemFolderEntry *
         // SN-2015-01-22: [[ Bug 14412 ]] the detailed files should return
         //   URL-encoded filenames
         MCAutoStringRef t_url_encoded;
-        if (!MCU_urlencode(*t_normalized, false, &t_url_encoded))
+        if (!MCU_urlencode(*t_normalized, t_state -> utf8, &t_url_encoded))
 			return false;
         
 #ifdef _WIN32
@@ -996,6 +997,7 @@ static bool MCS_getentries_callback(void *p_context, const MCSystemFolderEntry *
 bool MCS_getentries(MCStringRef p_folder,
                     bool p_files,
                     bool p_detailed,
+                    bool p_utf8,
                     MCListRef& r_list)
 {
 	MCAutoStringRef t_resolved_folder;
@@ -1014,6 +1016,7 @@ bool MCS_getentries(MCStringRef p_folder,
 	MCS_getentries_state t_state;	
 	t_state.files = p_files;
 	t_state.details = p_detailed;
+    t_state.utf8 = p_utf8;
 	t_state.list = *t_list;
 	
     // SN-2015-11-09: [[ Bug 16223 ]] Make sure that the list starts with ..

--- a/tests/lcs/core/files/folders.livecodescript
+++ b/tests/lcs/core/files/folders.livecodescript
@@ -46,6 +46,8 @@ on TestFilesOfFolder
 
    TestAssert "list non-current directory (detailed)", the number of items in line 1 of files(tFolder, "detailed") > 1
 
+   TestAssert "list non-current directory (detailed-utf8)", the number of items in line 1 of files(tFolder, "detailed-utf8") > 1
+
    local tOldFolder
    put the defaultFolder into tOldFolder
    set the defaultFolder to tFolder
@@ -67,6 +69,8 @@ on TestFoldersOfFolder
    TestAssert "list non-current directory", tTestFolder is among the lines of folders(tFolder)
 
    TestAssert "list non-current directory (detailed)", the number of items in line 2 of folders(tFolder, "detailed") > 1
+
+   TestAssert "list non-current directory (detailed-utf8)", the number of items in line 2 of folders(tFolder, "detailed-utf8") > 1
 
    local tOldFolder
    put the defaultFolder into tOldFolder
@@ -126,6 +130,7 @@ on TestEmptyFolder
    TestAssert "An empty non-current folder returns '..'", folders(tNewFolder) is ".."
    TestAssert "An empty non-current folder returns empty files", files(tNewFolder) is empty
    TestAssert "An empty non-current folder returns empty detailed files", files(tNewFolder, "detailed") is empty
+   TestAssert "An empty non-current folder returns empty detailed-utf8 files", files(tNewFolder, "detailed-utf8") is empty
    
    set the defaultFolder to tNewFolder
    
@@ -177,4 +182,42 @@ on TestNonExistentFolder
     TestAssert "The folders of non-existent folder", folders(tUUID) is empty
     TestAssert "The files of non-existent folder", files(tUUID) is empty
     TestAssert "The detailed files of non-existent folder", files(tUUID, "detailed") is empty
+    TestAssert "The detailed-utf8 files of non-existent folder", files(tUUID, "detailed-utf8") is empty
 end TestNonExistentFolder
+
+on TestBugfix22213
+   local tTestFolder
+   // Create a new, empty folder
+   put specialFolderPath("temporary") & "/TestUTF8" into tTestFolder
+   create folder tTestFolder
+
+   put empty into url ("file:" & tTestFolder & "/😊.txt")
+   local tFiles, tFile
+   put files(tTestFolder, "detailed") into tFiles
+   put item 1 of line 1 of tFiles into tFile
+   TestAssertBroken "The detailed files are native encoded before urlEncoding", \
+      textDecode(urlDecode(tFile), "native") is "😊.txt", "Bug 22213"
+
+   put files(tTestFolder, "detailed-utf8") into tFiles
+   put item 1 of line 1 of tFiles into tFile
+   TestAssert "The detailed-utf8 files are utf8 encoded before urlEncoding", \
+      textDecode(urlDecode(tFile), "utf8") is "😊.txt"
+
+   delete file (tTestFolder & "/😊.txt")
+
+   local tFolders, tFolder
+   create folder (tTestFolder & "/😊")
+   put folders(tTestFolder, "detailed") into tFolders
+   put item 1 of line 2 of tFolders into tFolder
+   TestAssertBroken "The detailed folders are native encoded before urlEncoding", \
+      textDecode(urlDecode(tFolder), "native") is "😊", "Bug 22213"
+
+   put folders(tTestFolder, "detailed-utf8") into tFolders
+   TestDiagnostic tFolders
+   put item 1 of line 2 of tFolders into tFolder
+   TestAssert "The detailed-utf8 folders are utf8 encoded before urlEncoding", \
+      textDecode(urlDecode(tFolder), "utf8") is "😊"
+
+   delete folder (tTestFolder & "/😊")
+   delete folder tTestFolder
+end TestBugfix22213


### PR DESCRIPTION
This patch implements an additional output kind for the files and folders
functions which will utf8 encode file and folder names prior to url encoding
them. This is a workaround for the anomaly bug that the url encoding in
in LiveCode native encodes instead of utf8 encodes.