### PR TITLE
[[ Bug 22497 ]] List object ref for protected stacks in execContexts

### DIFF
--- a/docs/notes/bugfix-22497.md
+++ b/docs/notes/bugfix-22497.md
@@ -1,0 +1,1 @@
+# Fix listing the executing object's stack rather than the object in the `executionContexts` for password protected stacks

--- a/engine/src/exec-debugging.cpp
+++ b/engine/src/exec-debugging.cpp
@@ -330,9 +330,9 @@ void MCDebuggingGetExecutionContexts(MCExecContext& ctxt, MCStringRef& r_value)
             {
                 if (t_success)
                 {
-                    MCAutoValueRef t_stack_id;
-                    t_success = MCexecutioncontexts[i]->GetObject()->getstack()->names(P_LONG_ID, &t_stack_id)
-                                && MCListAppend(*t_context, *t_stack_id)
+                    MCAutoValueRef t_context_id;
+                    t_success = MCexecutioncontexts[i]->GetObject()->names(P_LONG_ID, &t_context_id)
+                                && MCListAppend(*t_context, *t_context_id)
                                 && MCListAppend(*t_context, MCNAME("<protected>"))
                                 && MCListAppendInteger(*t_context, 0);
                 }


### PR DESCRIPTION
This patch fixes an issue where the `executionContexts` was listing the stack
long id rather than the executing object long id when the stack is protected.