### PR TITLE
[Bug 22509] Tree View Widget crash

### DIFF
--- a/extensions/widgets/treeview/notes/22509.md
+++ b/extensions/widgets/treeview/notes/22509.md
@@ -1,0 +1,1 @@
+# [22509] Ensure null `mEllipsisLength` does not cause widget to crash

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -1542,6 +1542,7 @@ end handler
 -- This happens when the separator is moved, font/icon sizes change,
 -- and when the ReadOnly property changes.
 private handler updateSeparator() returns nothing
+	ensureEllipsis()
 	if mReadOnly then
 		put 2 * kItemPadding + mIconWidth into mRightIconMargin
 	else
@@ -2632,8 +2633,6 @@ end handler
 -- the portion of the string that can fit, and sets rTrimmed if the string was trimmed.
 -- There should always be space for an ellipsis after a key when there is a value.
 private handler displayWidth(in pText as String, in pSpace as Real, out rText as String, out rTrimmed as Boolean) returns Real		
-	ensureEllipsis()
-	
 	variable tCount as Number
 	variable tCurrentString as String
 	variable tChar as String


### PR DESCRIPTION
Ensure null `mEllipsisLength` does not cause widget crash

The tree view widget was crashing when performing an initial draw when
the `updateSeparator` handler encountered a null `mEllipsisLength` in
certain circumstances.  This change moves the `ensureEllipsis` call from
`displayWidth` to `updateSeparator`.  This will actually result in the
handler being called fewer times per paint cycle.