### PR TITLE
[Dictionary] unicodeLabel to visible

### DIFF
--- a/docs/dictionary/command/unload.lcdoc
+++ b/docs/dictionary/command/unload.lcdoc
@@ -42,9 +42,9 @@ Use the <unload> <command> to release memory used by a <cache|cached>
 If the <cachedURL> is still being <download|downloaded> with the <load>
 <command>, the <unload> command cancels the <download>.
 
-The <unload> <command> can be used to cancel any <non-blocking> <FTP> or
-<HTTP> file transfer in progress, but it does not cancel file transfers
-that were initiated by using a <URL(keyword)> <container> in an
+The <unload> <command> can be used to cancel any <non-blocking> <ftp|FTP> 
+or <http|HTTP> file transfer in progress, but it does not cancel file 
+transfers that were initiated by using a <URL(keyword)> <container> in an
 <expression> or by putting something into a <URL(keyword)>.
 
 The <unload> <command> removes the <cachedURL> from the <URLStatus>

--- a/docs/dictionary/command/unlock-menus.lcdoc
+++ b/docs/dictionary/command/unlock-menus.lcdoc
@@ -24,7 +24,7 @@ Description:
 Use the <unlock menus> <command> to show changes in the <menu bar> to
 the user.
 
-The <unlock menus> <command> sets the <lockMenus> <property> to true.
+The <unlock menus> <command> sets the <lockMenus> <property> to false.
 
 When all pending handlers are finished executing, the <lockMenus>
 <property> is set to false, <undo|undoing> the <lock menus>

--- a/docs/dictionary/command/unlock-recent.lcdoc
+++ b/docs/dictionary/command/unlock-recent.lcdoc
@@ -28,7 +28,7 @@ When either the user or a handler navigates to a card, that card is
 placed on the recent cards list, and the user can return to it with the
 <go> command or by choosing View → Go Recent from the menubar.
 
-<unlock recent> <command> sets the <lockRecent> <property> to false.
+The <unlock recent> <command> sets the <lockRecent> <property> to false.
 When all pending <handler|handlers> are finished <execute|executing>,
 the <lockRecent> <property> is automatically set to false.
 

--- a/docs/dictionary/function/version.lcdoc
+++ b/docs/dictionary/function/version.lcdoc
@@ -7,7 +7,7 @@ Syntax: the version
 Syntax: version()
 
 Summary:
-<return|Returns> the <application engine's> version number.
+<return|Returns> the <engine|application engine's> version number.
 
 Introduced: 1.0
 
@@ -40,6 +40,5 @@ LiveCode that was used to create it.
 
 References: function (control structure), environment (function),
 libURLVersion (function), buildNumber (function), application (glossary),
-standalone application (glossary), return (glossary), engine (glossary),
-application engine (glossary)
+standalone application (glossary), return (glossary), engine (glossary)
 

--- a/docs/dictionary/property/unicodeLabel.lcdoc
+++ b/docs/dictionary/property/unicodeLabel.lcdoc
@@ -15,14 +15,7 @@ Introduced: 5.5
 Deprecated:
 In LiveCode 7.0 the language was changed to handle unicode
 transparently. This means that language functionality which previously
-aided unicode text manipulation is no longer required. This property
-should not be used in new code; simply set the label as normal.
-Assigning values other than those returned from uniEncode to this
-property will not produce the desired results.The following are now
-equivalent: 
-
-    set the unicodeLabel of button 1 to tText
-    set the label of button 1 to textDecode(tText, "UTF16")
+aided unicode text manipulation is no longer required. 
 
 OS: mac, windows, linux, ios, android
 
@@ -61,6 +54,14 @@ constant in the <unicodeLabel>.
 
 If an object's <unicodeLabel>  or label is empty, the object's name
 property is displayed instead.
+
+>*Important:* This property should not be used in new code; simply set 
+the label as normal. Assigning values other than those returned from 
+uniEncode to this property will not produce the desired results. The 
+following are now equivalent: 
+
+    set the unicodeLabel of button 1 to tText
+    set the label of button 1 to textDecode(tText, "UTF16")
 
 References: effective (keyword), label (property), encoding (property),
 menuHistory (property)

--- a/docs/dictionary/property/unicodePlainText.lcdoc
+++ b/docs/dictionary/property/unicodePlainText.lcdoc
@@ -16,12 +16,7 @@ Introduced: 4.6
 Deprecated:
 In LiveCode 7.0 the language was changed to handle unicode
 transparently. This means that language functionality which previously
-aided unicode text manipulation is no longer required. This property
-should not be used in new code; simply get the plainText as normal. The
-following are now equivalent:
-
-    get the unicodePlainText of field 1
-    get textEncode(the plainText of field 1, "UTF16")
+aided unicode text manipulation is no longer required.
 
 OS: mac, windows, linux
 
@@ -39,7 +34,7 @@ The <unicodePlainText> of a field is a string.
 Description:
 Use the <unicodePlainText> property to get the content of a field as
 plain text with any listStyle properties being converted appropriately
-into plain-text for the paragraphs the affect.
+into plain-text for the paragraphs they affect.
 
 When you get a field's <unicodePlainText>, the field's text is converted
 to plain text with any listStyle property being converted appropriately
@@ -48,6 +43,12 @@ into plain-text.
 Any paragraphs with listStyle set are prefixed by an appropriate
 plain-text form of the bullet or index. The property returns text
 encoded in UTF-16 in host byte-order.
+
+> Important: As this property is deprecated, it should not be used in new 
+> code; simply get the plainText as normal. The following are now equivalent:
+
+    get the unicodePlainText of field 1
+    get textEncode(the plainText of field 1, "UTF16")
 
 References: plainText (property), dontWrap (property),
 unicodeFormattedText (property), formattedText (property)

--- a/docs/dictionary/property/unicodeTitle.lcdoc
+++ b/docs/dictionary/property/unicodeTitle.lcdoc
@@ -15,14 +15,7 @@ Introduced: 2.9
 Deprecated:
 In LiveCode 7.0 the language was changed to handle unicode
 transparently. This means that language functionality which previously
-aided unicode text manipulation is no longer required. This property
-should not be used in new code; simply set the title as normal.
-Assigning values other than those returned from uniEncode to this
-property will not produce the desired results.The following are now
-equivalent: 
-
-    set the unicodeTitle of this stack to tText
-    set the title of this stack to textDecode(tText, "UTF16")
+aided unicode text manipulation is no longer required.
 
 OS: mac, windows, linux, ios, android
 
@@ -47,5 +40,14 @@ Windows 98SE and Windows ME do not support unicode window titles. On
 these systems, the string displayed in the title bar will be the closest
 approximation possible on the running system.
 
+>*Important:* As this property is deprecated, it should not be used in new 
+> code; simply set the title as normal. Assigning values other than those 
+> returned from uniEncode to this property will not produce the desired 
+> results. The following are now equivalent: 
+
+    set the unicodeTitle of this stack to tText
+    set the title of this stack to textDecode(tText, "UTF16")
+
 References: uniEncode (function), label (property)
+
 

--- a/docs/dictionary/property/unicodeTooltip.lcdoc
+++ b/docs/dictionary/property/unicodeTooltip.lcdoc
@@ -15,14 +15,7 @@ Introduced: 5.5
 Deprecated:
 In LiveCode 7.0 the language was changed to handle unicode
 transparently. This means that language functionality which previously
-aided unicode text manipulation is no longer required. This property
-should not be used in new code; simply set the tooltip as normal.
-Assigning values other than those returned from uniEncode to this
-property will not produce the desired results.The following are now
-equivalent: 
-
-    set the unicodeTooltip of button 1 to tText
-    set the tooltip of button 1 to textDecode(tText, "UTF16")
+aided unicode text manipulation is no longer required.
 
 OS: mac, windows, linux, ios, android
 
@@ -65,6 +58,14 @@ action of the control. They are best used as a short reminder or clue
 about what a control does.
 
 Tooltips appear only when the Browse tool is selected.
+
+> As this property is now deprecated, it should not be used in new code; 
+> simply set the tooltip as normal. Assigning values other than those 
+> returned from uniEncode to this property will not produce the desired 
+> results. The following are now equivalent: 
+
+    set the unicodeTooltip of button 1 to tText
+    set the tooltip of button 1 to textDecode(tText, "UTF16")
 
 References: tooltip (property), encoding (property), label (property)
 

--- a/docs/dictionary/property/visible.lcdoc
+++ b/docs/dictionary/property/visible.lcdoc
@@ -61,7 +61,7 @@ is false, and vice versa.
 
 References: show (command), group (command), hide (command),
 object (glossary), property (glossary), grouped control (glossary),
-group (glossary), card (keyword), card (object), control (object),
+group (glossary), control (glossary), card (keyword), card (object),
 showInvisibles (property), invisible (property)
 
 Tags: ui


### PR DESCRIPTION
unicodeLabel (property): Moved code snippet to Description to be formatted correctly.
unicodePlainText (property): Moved code snippet to Description to be formatted correctly.
unicodeTitle (property): Moved code snippet to Description to be formatted correctly.
unicodeTooltip (property): Moved code snippet to Description to be formatted correctly.
unload (command): Fixed broken links.
unlock menus (command): Corrected detail to match summary.
unlock recent (command): Corrected grammar.
version (function): Fixed broken link.
visible (property): Corrected incorrect reference type.
