### PR TITLE
[Dictionary] vScroll to [end]

### DIFF
--- a/docs/dictionary/function/within.lcdoc
+++ b/docs/dictionary/function/within.lcdoc
@@ -64,13 +64,13 @@ borders.
 
 The expression
 
-    <point> is within the rect of <object(glossary)> 
+    point is within the rect of object 
 
 is equivalent to
 
-    within(<object(glossary)>, <point>)
+    within(object, point)
 
-unless the <object(glossary)> <a/> is a graphic or image, or a tabbed
+unless the <object(glossary)> is a graphic or image, or a tabbed
 button. 
 
 References: function (control structure), intersect (function),

--- a/docs/dictionary/operator/wrap.lcdoc
+++ b/docs/dictionary/operator/wrap.lcdoc
@@ -47,7 +47,7 @@ The mathematical formula implemented by the wrap operator is:
 
     x wrap y       
     =       (x-1) mod abs(y) +1     if(x &gt;= 0)
-    =     -((x-1) mod abs(y) +1)    if(x &lt; 0)
+    =     -((-x-1) mod abs(y) +1)    if(x &lt; 0)
 
 
 If a math operation on finite inputs produces a non-finite output, an

--- a/docs/dictionary/operator/wrap.lcdoc
+++ b/docs/dictionary/operator/wrap.lcdoc
@@ -45,9 +45,9 @@ iteration ie. 1, 2, 3, 1, 2 . Therefore 5 wrap 3 is 2.
 
 The mathematical formula implemented by the wrap operator is:
 
-    x wraps y        =       ((x-1) mod abs(y)) +1 if (x &gt;= 0)
-
-    =      -((x-1) mod abs(y)) +1 if(x &lt; 0)
+    x wrap y       
+    =       (x-1) mod abs(y) +1     if(x &gt;= 0)
+    =     -((x-1) mod abs(y) +1)    if(x &lt; 0)
 
 
 If a math operation on finite inputs produces a non-finite output, an

--- a/docs/dictionary/property/vScroll.lcdoc
+++ b/docs/dictionary/property/vScroll.lcdoc
@@ -42,11 +42,11 @@ been scrolled.
 Setting the <vScroll> of a <field> or <group> causes a <scrollbarDrag>
 <message> to be sent to the <field> or <group>.
 
->*Cross-platform note:* On <Mac OS> and <OS X|OS X systems>, the <menu
-> bar> appears at the top of the screen, rather than inside the stack
-> window. If a <stack|stack's> <editMenus> <property> is set to false
-> and the <stack> contains a <menu bar>, the window is scrolled down and
-> resized so that the <menu bar> <group> is not visible in the window.
+>*Cross-platform note:* On <Mac OS> and <OS X|OS X systems>, the 
+> <menu bar> appears at the top of the screen, rather than inside the 
+> stack window. If a <stack|stack's> <editMenus> <property> is set to 
+> false and the <stack> contains a <menu bar>, the window is scrolled down 
+> and resized so that the <menu bar> <group> is not visible in the window.
 > Because of this, on <Mac OS> and <OS X|OS X systems>, the <vScroll> of
 > a <stack> reports the amount the <stack> has been scrolled down to
 > hide a <menu bar> <group>.

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -25,12 +25,13 @@ Use the <xScale> <property> to control an <EPS|EPS object's> screen
 appearance. 
 
 The <number> 1 indicates no scaling--that is, the <EPS|EPS object's>
-width is the same as the width specified by the <PostScript> code it
-contains. Numbers greater than one indicate that the <object|object's>
-width is less than the <PostScript> width; the screen <object(glossary)>
-is scaled down. Numbers less than one indicate that the
-<object|object's> width is greater than the <PostScript> width, and the
-screen <object(glossary)> is scaled up from the <PostScript>.
+width is the same as the width specified by the <postScript|PostScript> 
+code it contains. Numbers greater than one indicate that the 
+<object|object's> width is less than the <postScript|PostScript> width; 
+the screen <object(glossary)> is scaled down. Numbers less than one 
+indicate that the <object|object's> width is greater than the 
+<postScript|PostScript> width, and the screen <object(glossary)> is 
+scaled up from the <postScript|PostScript>.
 
 In geometric terms, xScale = xExtent/width.
 

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -25,13 +25,13 @@ Use the <xScale> <property> to control an <EPS|EPS object's> screen
 appearance. 
 
 The <number> 1 indicates no scaling--that is, the <EPS|EPS object's>
-width is the same as the width specified by the <postScript|PostScript> 
+width is the same as the width specified by the <postScript> 
 code it contains. Numbers greater than one indicate that the 
-<object|object's> width is less than the <postScript|PostScript> width; 
+<object|object's> width is less than the <postScript> width; 
 the screen <object(glossary)> is scaled down. Numbers less than one 
 indicate that the <object|object's> width is greater than the 
-<postScript|PostScript> width, and the screen <object(glossary)> is 
-scaled up from the <postScript|PostScript>.
+<postScript> width, and the screen <object(glossary)> is 
+scaled up from the <postScript>.
 
 In geometric terms, xScale = xExtent/width.
 

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the xScale of <EPSObject> to <number>
 
 Summary:
-Specifies the ratio of the width of an <EPS|EPS object's> <PostScript>
+Specifies the ratio of the width of an <EPS|EPS object's> <postScript>
 bounding box to the <object|object's> screen width.
 
 Introduced: 1.0

--- a/docs/glossary/x/XML-tree.lcdoc
+++ b/docs/glossary/x/XML-tree.lcdoc
@@ -7,11 +7,11 @@ Type: glossary
 Description:
 An <XML> document held in memory. An XML tree is a data structure
 containing all the content in an <XML document>, arranged to make it
-easy to traverse <owner|parent>, <sibling>, and <child> relationships
-between <node|nodes>.
+easy to traverse <owner|parent>, <sibling node|sibling>, 
+and <child node|child> relationships between <node|nodes>.
 
-References: node (glossary), owner (glossary), child (glossary),
-sibling (glossary), XML document (glossary), XML (glossary)
+References: node (glossary), owner (glossary), child node (glossary),
+sibling node (glossary), XML document (glossary), XML (glossary)
 
 Tags: text processing
 


### PR DESCRIPTION
vScroll (property) - Fix broken link.
within (function) - Removed link markdown from code snippets to have them interpreted correctly.
wrap (operator) - Corrected mathematical equivalent section
XML tree (glossary) - Corrected references.
xScale (property) - Fix broken links.