### PR TITLE
[[ mergExt ]] Update pointer

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2019-9-23"
+constant kMergExtVersion = "2020-1-13"
 constant kTSNetVersion = "1.4.0"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer to builds that include iOS 13.2 binaries.