### PR TITLE
[[ Bug 22530 ]] Update Android text rendering

### DIFF
--- a/docs/notes/bugfix-22530.md
+++ b/docs/notes/bugfix-22530.md
@@ -1,0 +1,3 @@
+# Update Android text rendering
+
+This update resolves issues with incorrect spacing between characters when drawing text on Android.

--- a/engine/src/mblandroidtextlayout.cpp
+++ b/engine/src/mblandroidtextlayout.cpp
@@ -18,25 +18,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "textlayout.h"
 
-#include <ft2build.h>
-#include FT_FREETYPE_H
-#include FT_SIZES_H
-
-#include <hb.h>
-#include <hb-ft.h>
-#include <hb-icu.h>
-
-#include <SkTypeface.h>
-#include <SkFontMgr.h>
-#include <SkUtils.h>
 #include <SkTypeface_FreeType.h>
 
 #include "graphics.h"
-#include "mblandroidtypeface.h"
-
-////////////////////////////////////////////////////////////////////////////////
-
-#define HB_SCALE_FACTOR (64)
+#include "graphics_util.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -51,29 +36,7 @@ void MCTextLayoutFinalize(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static hb_script_t HBScriptFromText(const unichar_t *p_text, uindex_t p_count)
-{
-    UScriptCode t_script;
-    t_script = USCRIPT_COMMON;
-    
-    while (p_count && MCUnicodeIsWhitespace(*p_text))
-    {
-        p_text++;
-        p_count--;
-    }
-    
-    if (p_count)
-    {
-        UErrorCode t_error = U_ZERO_ERROR;
-        t_script = uscript_getScript((uint32_t)(*p_text), &t_error);
-        
-        //MCLog("script: %s", uscript_getShortName(t_script));
-    }
-    
-    return hb_icu_script_to_script(t_script);
-}
-
-bool make_textlayout_glyphs(hb_glyph_info_t *p_glyph_infos, hb_glyph_position_t *p_glyph_positions, uindex_t p_start, uindex_t p_length, MCGPoint &x_location, MCTextLayoutGlyph *&r_glyphs)
+bool make_textlayout_glyphs(const MCGGlyphInfo *p_glyph_infos, uindex_t p_glyph_count, MCGPoint &x_location, MCTextLayoutGlyph *&r_glyphs)
 {
 	bool t_success;
 	t_success = true;
@@ -81,18 +44,18 @@ bool make_textlayout_glyphs(hb_glyph_info_t *p_glyph_infos, hb_glyph_position_t 
 	MCTextLayoutGlyph *t_glyphs;
 	t_glyphs = nil;
 	if (t_success)
-		t_success = MCMemoryNewArray(p_length, t_glyphs);
+		t_success = MCMemoryNewArray(p_glyph_count, t_glyphs);
 	
 	if (t_success)
 	{
-		for (uindex_t i = 0; i < p_length; i++)
+		for (uindex_t i = 0; i < p_glyph_count; i++)
 		{
-			t_glyphs[i].index = p_glyph_infos[p_start + i].codepoint;
-			t_glyphs[i].x = x_location.x + ((float)p_glyph_positions[p_start + i].x_offset / HB_SCALE_FACTOR);
-			t_glyphs[i].y = x_location.y + ((float)p_glyph_positions[p_start + i].y_offset / HB_SCALE_FACTOR);
+			t_glyphs[i].index = p_glyph_infos[i].codepoint;
+			t_glyphs[i].x = x_location.x + p_glyph_infos[i].x_offset;
+			t_glyphs[i].y = x_location.y + p_glyph_infos[i].y_offset;
 			
-			x_location.x += ((float)p_glyph_positions[p_start + i].x_advance / HB_SCALE_FACTOR);
-			x_location.y += ((float)p_glyph_positions[p_start + i].y_advance / HB_SCALE_FACTOR);
+			x_location.x += p_glyph_infos[i].x_advance;
+			x_location.y += p_glyph_infos[i].y_advance;
 		}
 		
 		r_glyphs = t_glyphs;
@@ -106,7 +69,7 @@ bool make_textlayout_glyphs(hb_glyph_info_t *p_glyph_infos, hb_glyph_position_t 
 	return t_success;
 }
 
-bool make_textlayout_clusters(hb_glyph_info_t *p_glyph_infos, uindex_t p_start, uindex_t p_length, uindex_t p_char_count, uint16_t *&r_clusters)
+bool make_textlayout_clusters(const MCGGlyphInfo *p_glyph_infos, uindex_t p_glyph_count, uindex_t p_char_count, uint16_t *&r_clusters)
 {
 	bool t_success;
 	t_success = true;
@@ -122,7 +85,7 @@ bool make_textlayout_clusters(hb_glyph_info_t *p_glyph_infos, uindex_t p_start, 
 		t_current_glyph = 0;
 		
 		uindex_t t_current_cluster;
-		t_current_cluster = p_glyph_infos[p_start].cluster;
+		t_current_cluster = p_glyph_infos[0].cluster;
 		
 		uindex_t i;
 		i = 0;
@@ -138,8 +101,8 @@ bool make_textlayout_clusters(hb_glyph_info_t *p_glyph_infos, uindex_t p_start, 
 			while (t_next_cluster == t_current_cluster)
 			{
 				t_next_glyph++;
-				if (t_next_glyph < p_length)
-					t_next_cluster = p_glyph_infos[p_start + t_next_glyph].cluster;
+				if (t_next_glyph < p_glyph_count)
+					t_next_cluster = p_glyph_infos[t_next_glyph].cluster;
 				else
 					t_next_cluster = UINDEX_MAX;
 			}
@@ -166,269 +129,77 @@ bool make_textlayout_clusters(hb_glyph_info_t *p_glyph_infos, uindex_t p_start, 
 	return t_success;
 }
 
-// Check if the font supports all glyphs in a given cluster from shape info
-static bool cluster_is_supported(hb_glyph_info_t* p_info, uindex_t p_index, uindex_t p_count, uindex_t& r_cluster_end)
-{
-    bool t_supported = true;
-    uindex_t t_cluster = p_info[p_index] . cluster;
-    while (p_index < p_count &&
-           p_info[p_index] . cluster == t_cluster)
-    {
-        if (p_info[p_index] . codepoint == 0)
-        {
-            // If any of these glyphs' codepoints are 0 then the
-            // whole cluster is unsupported
-            t_supported = false;
-        }
-        p_index++;
-    }
-    
-    r_cluster_end = p_index;
-    return t_supported;
-}
+//////////
 
-bool shape(const unichar_t *p_chars, uint32_t p_char_count, MCFontStruct *p_font, MCGPoint &x_location, bool p_use_fallback, MCTextLayoutCallback p_callback, void *p_context)
+struct _layout_context_t
 {
+	MCTextLayoutCallback callback;
+	void *context;
+	MCGPoint location;
+	bool success;
+};
+
+static bool _layout_callback(void *p_context, const MCGFont &p_font, const MCGGlyphInfo *p_glyphs, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count)
+{
+	_layout_context_t *self;
+	self = (_layout_context_t*)p_context;
+
 	bool t_success;
 	t_success = true;
-	
-	SkTypeface *t_sk_typeface;
-	t_sk_typeface = nil;
-	
-	if (p_use_fallback)
-	{
-        // If we're to use a fallback font, use Skia's font manager to find a
-        // font that has glyphs for the first char in the string.
-        const unichar_t* t_text = p_chars;
-        SkUnichar t_uni_char = SkUTF16_NextUnichar(&t_text);
-        sk_sp<SkFontMgr> t_fnt_mgr(SkFontMgr::RefDefault());
-        t_sk_typeface = t_fnt_mgr -> matchFamilyStyleCharacter(nil, ((SkTypeface *)p_font -> fid) -> fontStyle(), nil, 0, t_uni_char);
-	}
-	
-	// If there is no fallback font for the char, use the replacement glyph
-	// in the original font.
-	if (t_sk_typeface == nil)
-	{
-		MCAndroidFont *t_android_font;
-		t_android_font = (MCAndroidFont*)p_font->fid;
-		
-		t_sk_typeface = (SkTypeface*)t_android_font->typeface;
-		t_sk_typeface->ref();
-	}
-	
-	// Make the font
-	
-	FT_Face t_ft_face;
-	t_ft_face = nil;
-	if (t_success)
-	{
-		t_ft_face = SkTypeface_GetFTFace(t_sk_typeface);
-		t_success = (t_ft_face != nil);
-	}
-	
-	// Make sure the face has the required size. Use a new FT_Size object so
-	// that the previous size settings can be restored after shaping.
-	FT_Size t_old_ft_size;
-	t_old_ft_size = nil;
-	
-	FT_Size t_ft_size;
-	t_ft_size = nil;
-	if (t_success)
-	{
-		t_old_ft_size = t_ft_face->size;
-		
-		t_success = FT_Err_Ok == FT_New_Size(t_ft_face, &t_ft_size);
-	}
-	
-	if (t_success)
-		t_success = FT_Err_Ok == FT_Activate_Size(t_ft_size);
-	
-	if (t_success)
-		t_success = FT_Err_Ok == FT_Set_Char_Size(t_ft_face, p_font->size * 64, 0, 0, 0);
-	
-	hb_font_t *t_hb_font;
-	t_hb_font = nil;
-	if (t_success)
-	{
-		t_hb_font = hb_ft_font_create(t_ft_face, nil);
-		t_success = (t_hb_font != nil);
-	}
-	
-	// Scale font for sub-pixel precision
-	if (t_success)
-		hb_font_set_scale(t_hb_font, HB_SCALE_FACTOR, HB_SCALE_FACTOR);
-	
-	hb_buffer_t *t_hb_buffer;
-	t_hb_buffer = nil;
-	if (t_success)
-	{
-		t_hb_buffer = hb_buffer_create();
-		t_success = hb_buffer_allocation_successful(t_hb_buffer);
-	}
-	
-	if (t_success)
-	{
-		hb_buffer_set_unicode_funcs(t_hb_buffer, hb_icu_get_unicode_funcs());
-		hb_buffer_set_direction(t_hb_buffer, HB_DIRECTION_LTR);
-		hb_buffer_set_script(t_hb_buffer, HBScriptFromText(p_chars, p_char_count));
-		
-		hb_buffer_add_utf16(t_hb_buffer, p_chars, p_char_count, 0, p_char_count);
-		
-		hb_shape(t_hb_font, t_hb_buffer, NULL, 0);
-	}
-	
-	uindex_t t_glyph_count;
-	t_glyph_count = 0;
-	hb_glyph_info_t *t_glyph_infos;
-	t_glyph_infos = nil;
-	hb_glyph_position_t *t_glyph_positions;
-	t_glyph_positions = nil;
-	if (t_success)
-	{
-		t_glyph_count = hb_buffer_get_length(t_hb_buffer);
-		t_glyph_infos = hb_buffer_get_glyph_infos(t_hb_buffer, nil);
-		t_glyph_positions = hb_buffer_get_glyph_positions(t_hb_buffer, nil);
-	}
-	
-	if (t_hb_font != nil)
-		hb_font_destroy(t_hb_font);
-	
-	if (t_old_ft_size != nil)
-		FT_Activate_Size(t_old_ft_size);
-	if (t_ft_size != nil)
-		FT_Done_Size(t_ft_size);
+	bool t_continue;
+	t_continue = true;
 
-    uindex_t t_cur_glyph;
-    t_cur_glyph = 0;
-    
-    // deal with runs of supported and unsupported glyphs
-    while (t_cur_glyph < t_glyph_count)
-	{
-		uindex_t t_start, t_cluster_end;
-		t_start = t_cur_glyph;
-		t_cluster_end = 0;
-		
-		// Run of glyphs in successfully shaped clusters
-		while (t_cur_glyph < t_glyph_count && cluster_is_supported(t_glyph_infos, t_cur_glyph, t_glyph_count, t_cluster_end))
-			t_cur_glyph = t_cluster_end;
-		
-		if (t_start != t_cur_glyph)
-		{
-			uindex_t t_char_start, t_char_end;
-			t_char_start = t_glyph_infos[t_start].cluster;
-			
-			t_char_end = p_char_count;
-			if (t_cur_glyph != t_glyph_count)
-				t_char_end = t_glyph_infos[t_cur_glyph].cluster;
-
-			MCTextLayoutGlyph *t_glyphs;
-			t_glyphs = nil;
-			if (t_success)
-				t_success = make_textlayout_glyphs(t_glyph_infos, t_glyph_positions, t_start, t_cur_glyph - t_start, x_location, t_glyphs);
-			
-			uint16_t *t_clusters;
-			t_clusters = nil;
-			if (t_success)
-				t_success = make_textlayout_clusters(t_glyph_infos, t_start, t_cur_glyph - t_start, t_char_end - t_char_start, t_clusters);
-			
-			if (t_success)
-			{
-				MCTextLayoutSpan t_span;
-				t_span.chars = p_chars + t_char_start;
-				t_span.char_count = t_char_end - t_char_start;
-				t_span.clusters = t_clusters;
-				t_span.glyphs = t_glyphs;
-				t_span.glyph_count = t_cur_glyph - t_start;
-				t_span.font = t_ft_face;
-				
-				t_success = p_callback(p_context, &t_span);
-			}
-			
-			if (t_glyphs != nil)
-				MCMemoryDeleteArray(t_glyphs);
-			if (t_clusters != nil)
-				MCMemoryDeleteArray(t_clusters);
-			
-			t_start = t_cur_glyph;
-		}
-		
-		// If the first cluster is unsupported and we're already using the fallback
-		// font for that cluster, assume there is no support and use a replacement.
-		if (t_cur_glyph == 0 && p_use_fallback)
-		{
-			t_cur_glyph = t_cluster_end;
-			
-            // Enforce a replacement glyph for the whole cluster by passing a 0
-            // codepoint and only adding a single glyph to the run
-            MCTextLayoutGlyph t_glyph;
-            t_glyph.index = 0;
-            t_glyph.x = x_location.x + ((float)t_glyph_positions[0].x_offset / HB_SCALE_FACTOR);
-            t_glyph.y = x_location.y + ((float)t_glyph_positions[0].y_offset / HB_SCALE_FACTOR);
-            x_location.x += ((float)t_glyph_positions[0].x_advance / HB_SCALE_FACTOR);
-            x_location.y += ((float)t_glyph_positions[0].y_advance / HB_SCALE_FACTOR);
-            
-            uint16_t t_cluster;
-            t_cluster = t_glyph_infos[0].cluster;
+	MCTextLayoutGlyph *t_glyphs;
+	t_glyphs = nil;
+	if (t_success)
+		t_success = make_textlayout_glyphs(p_glyphs, p_glyph_count, self->location, t_glyphs);
 	
-			uindex_t t_char_start, t_char_end;
-			t_char_start = t_glyph_infos[t_start].cluster;
-			
-			t_char_end = p_char_count;
-			if (t_cur_glyph != t_glyph_count)
-				t_char_end = t_glyph_infos[t_cur_glyph].cluster;
+	uint16_t *t_clusters;
+	t_clusters = nil;
+	if (t_success)
+		t_success = make_textlayout_clusters(p_glyphs, p_glyph_count, p_char_count, t_clusters);
+	
+	if (t_success)
+	{
+		// Android-specific - get freetype font face
+		FT_Face t_face;
+		t_face = SkTypeface_GetFTFace((SkTypeface*)p_font.fid);
 
-			MCTextLayoutSpan t_span;
-			t_span.chars = p_chars + t_char_start;
-			t_span.char_count = t_char_end - t_char_start;
-			t_span.clusters = &t_cluster;
-			t_span.glyphs = &t_glyph;
-			t_span.glyph_count = 1;
-			t_span.font = t_ft_face;
-			
-			t_success = p_callback(p_context, &t_span);
-			
-			t_start = t_cur_glyph;
-		}
+		MCTextLayoutSpan t_span;
+		t_span.chars = p_chars;
+		t_span.char_count = p_char_count;
+		t_span.clusters = t_clusters;
+		t_span.glyphs = t_glyphs;
+		t_span.glyph_count = p_glyph_count;
+		t_span.font = t_face;
 		
-		// Deal with run of unsupported clusters for this font.
-		while (t_cur_glyph < t_glyph_count && !cluster_is_supported(t_glyph_infos, t_cur_glyph, t_glyph_count, t_cluster_end))
-			t_cur_glyph = t_cluster_end;
-		
-        // For the run of unsupported clusters, shape using a fallback font.
-		if (t_start != t_cur_glyph)
-		{
-            // Reshape from the beginning of the unsupported cluster run
-            // to the beginning of the cluster containing t_cur_glyph.
-            // At this point, t_cur_glyph might be equal to glyph_count,
-            // in which case compute the reshape char count using the old char
-            // count.
-			uindex_t t_char_start, t_char_end;
-			t_char_start = t_glyph_infos[t_start].cluster;
-			
-			t_char_end = p_char_count;
-			if (t_cur_glyph != t_glyph_count)
-				t_char_end = t_glyph_infos[t_cur_glyph].cluster;
+		t_continue = self->callback(self->context, &t_span);
 
-			t_success = shape(p_chars + t_char_start, t_char_end - t_char_start, p_font, x_location, true, p_callback, p_context);
-		}
+		FT_Done_Face(t_face);
 	}
 	
-	if (t_hb_buffer != nil)
-		hb_buffer_destroy(t_hb_buffer);
+	if (t_glyphs != nil)
+		MCMemoryDeleteArray(t_glyphs);
+	if (t_clusters != nil)
+		MCMemoryDeleteArray(t_clusters);
 	
-	if (t_ft_face != nil)
-		FT_Done_Face(t_ft_face);
-	if (t_sk_typeface != nil)
-		t_sk_typeface->unref();
-	
-	return t_success;
+	self->success = t_success;
+
+	return t_success && t_continue;
 }
 
 bool MCTextLayout(const unichar_t *p_chars, uint32_t p_char_count, MCFontStruct *p_font, MCTextLayoutCallback p_callback, void *p_context)
 {
-	MCGPoint t_loc;
-	t_loc = MCGPointMake(0.0, 0.0);
-	return shape(p_chars, p_char_count, p_font, t_loc, false, p_callback, p_context);
+	_layout_context_t t_context;
+	t_context.callback = p_callback;
+	t_context.context = p_context;
+	t_context.location = MCGPointMake(0.0, 0.0);
+	t_context.success = true;
+
+	bool t_success;
+	t_success = MCGFontLayoutText(MCFontStructToMCGFont(p_font), p_chars, p_char_count, false, _layout_callback, &t_context);
+
+	return t_success && t_context.success;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libgraphics/include/graphics.h
+++ b/libgraphics/include/graphics.h
@@ -581,6 +581,23 @@ bool MCGFontGetPlatformFontList(MCProperListRef &r_fonts);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct MCGGlyphInfo
+{
+	uindex_t codepoint;
+	uindex_t cluster;
+
+	MCGFloat x_offset;
+	MCGFloat y_offset;
+	MCGFloat x_advance;
+	MCGFloat y_advance;
+};
+
+typedef bool (*MCGFontLayoutTextCallback)(void *context, const MCGFont &p_font, const MCGGlyphInfo *p_glyphs, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count);
+
+bool MCGFontLayoutText(const MCGFont &p_font, const unichar_t *p_text, uindex_t p_char_count, bool p_rtl, MCGFontLayoutTextCallback p_callback, void *p_context);
+
+////////////////////////////////////////////////////////////////////////////////
+
 inline bool MCGPointIsEqual(const MCGPoint &p_a, const MCGPoint &p_b)
 {
 	return p_a.x == p_b.x && p_a.y == p_b.y;

--- a/libgraphics/libgraphics.gyp
+++ b/libgraphics/libgraphics.gyp
@@ -65,6 +65,11 @@
 				'src/legacygradients.cpp',
 				'src/drawing.cpp',
 			],
+
+			'sources!':
+			[
+				'src/hb-sk.cpp',
+			],
 			
 			'target_conditions':
 			[
@@ -92,7 +97,6 @@
 						'sources!':
 						[
 							'src/harfbuzztext.cpp',
-							'src/hb-sk.cpp',
 						],
 					},
 				],

--- a/libgraphics/src/harfbuzztext.cpp
+++ b/libgraphics/src/harfbuzztext.cpp
@@ -39,26 +39,60 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 ////////////////////////////////////////////////////////////////////////////////
 
+typedef bool (*MCHarfbuzzShapeCallback)(void *context, const hb_glyph_info_t *p_infos, const hb_glyph_position_t *p_positions, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count, const MCGFont &p_font);
+
 extern bool MCCStringFromUnicodeSubstring(const unichar_t * p_text, uindex_t p_length, char*& r_text);
 extern void MCCStringFree(char *p_string);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static void skia_get_replacement_glyph(uint16_t p_size, sk_sp<SkTypeface> p_typeface, uint16_t& glyph, MCGFloat& advance)
+static MCGFont MCGFontFromSkTypeface(SkTypeface *p_typeface, uindex_t p_size)
 {
-    SkPaint paint;
-    paint . setTextEncoding(SkPaint::kUTF16_TextEncoding);
-    paint . setTextSize(p_size);
-    paint . setTypeface(p_typeface);
-    
-    codepoint_t t_replacement = 0xFFFD;
-    
-    SkScalar skWidth;
-    SkRect skBounds;
-    paint . textToGlyphs(&t_replacement, 2, &glyph);
-    paint . getTextWidths(&t_replacement, 2, &skWidth, &skBounds);
-    
-    advance = (MCGFloat)skWidth;
+	MCGFont t_font;
+	MCMemoryClear(t_font);
+	t_font.fid = p_typeface;
+	t_font.size = p_size;
+
+	sk_sp<SkTypeface> t_typeface = sk_ref_sp<SkTypeface>(p_typeface);
+
+	SkPaint t_paint;
+	t_paint.setTypeface(t_typeface);
+	t_paint.setTextSize(p_size);
+
+	SkPaint::FontMetrics t_metrics;
+
+	t_paint.getFontMetrics(&t_metrics);
+
+	// SkPaint::FontMetrics gives the ascent value as a negative offset from the baseline, where we expect the (positive) distance.
+	t_font.m_ascent = -t_metrics.fAscent;
+	t_font.m_descent = t_metrics.fDescent;
+	t_font.m_leading = t_metrics.fLeading;
+
+	return t_font;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+static void skia_get_replacement_glyph(const MCGFont &p_font , uint16_t &glyph, hb_glyph_position_t &r_position)
+{
+	sk_sp<SkTypeface> t_typeface = sk_ref_sp<SkTypeface>((SkTypeface*)p_font.fid);
+
+	SkPaint paint;
+	paint . setTextEncoding(SkPaint::kUTF16_TextEncoding);
+	paint . setTextSize(p_font.size);
+	paint . setTypeface(t_typeface);
+
+	codepoint_t t_replacement = 0xFFFD;
+
+	SkScalar skWidth;
+	SkRect skBounds;
+	paint . textToGlyphs(&t_replacement, 2, &glyph);
+	paint . getTextWidths(&t_replacement, 2, &skWidth, &skBounds);
+
+	r_position.x_offset = skBounds.fLeft;
+	r_position.y_offset = 0;
+	r_position.x_advance = skWidth;
+	r_position.y_advance = 0;
 }
 
 struct MCGlyphRun
@@ -66,63 +100,43 @@ struct MCGlyphRun
     uindex_t count;
     SkPoint *positions;
     uint16_t *glyphs;
-    sk_sp<SkTypeface> typeface;
 };
 
-void MCGlyphRunMake(hb_glyph_info_t *p_infos, hb_glyph_position_t *p_positions, MCGPoint* x_location, uindex_t p_start, uindex_t p_end, SkTypeface* p_typeface, uint16_t p_size, MCGlyphRun& r_run)
+bool MCGlyphRunMake(const hb_glyph_info_t *p_infos, const hb_glyph_position_t *p_positions, uindex_t p_count, MCGPoint &x_location, MCGlyphRun& r_run)
 {
-    // Skia APIs expect typefaces to be passed as shared pointers
-    sk_sp<SkTypeface> t_typeface(p_typeface);
-    t_typeface->ref();
-    
-    uindex_t t_count = p_end - p_start;
-    MCMemoryNewArray(t_count, r_run.glyphs);
-    MCMemoryNewArray(t_count, r_run.positions);
-    
-	// IM-2016-03-31: [[ Bug 17281 ]] positions may have negative values, so we need to use signed offsets.
-	MCGFloat x_offset, y_offset;
-	
-    uindex_t run_index = 0;
-    MCGFloat advance_y = 0;
-    MCGFloat advance_x = 0;
-    
-    for (uindex_t i = p_start; i < p_end; i++)
-    {
-        x_offset = x_location -> x + (MCGFloat)p_positions[i] . x_offset / (MCGFloat)HB_SCALE_FACTOR + advance_x;
-        y_offset = x_location -> y + (MCGFloat)p_positions[i] . y_offset / (MCGFloat)HB_SCALE_FACTOR + advance_y;
-        r_run . positions[run_index] = SkPoint::Make(x_offset, y_offset);
-        
-        uint16_t t_glyph = p_infos[i] . codepoint;
-        if (t_glyph)
-        {
-            r_run . glyphs[run_index] = t_glyph;
+	bool t_success;
+	t_success = true;
 
-            advance_x += (MCGFloat)p_positions[i] . x_advance / (MCGFloat)HB_SCALE_FACTOR;
-            advance_y += (MCGFloat)p_positions[i] . y_advance / (MCGFloat)HB_SCALE_FACTOR;
-        }
-        else
-        {
-            MCGFloat advance;
-            skia_get_replacement_glyph(p_size, t_typeface, r_run . glyphs[run_index], advance);
-            advance_x += advance;
-        }
-            
-        run_index++;
-    }
-    
-    x_location -> x += advance_x;
-    x_location -> y += advance_y;
-    
-    r_run.typeface = t_typeface;
-    
-    r_run . count = t_count;
+	MCAutoArray<uint16_t> t_glyphs;
+	MCAutoArray<SkPoint> t_positions;
+
+	if (!t_glyphs.New(p_count) || !t_positions.New(p_count))
+		return false;
+
+	for (uindex_t i = 0; i < p_count; i++)
+	{
+		MCGFloat x_offset, y_offset;
+
+		x_offset = x_location.x + (MCGFloat)p_positions[i].x_offset / (MCGFloat)HB_SCALE_FACTOR;
+		y_offset = x_location.y + (MCGFloat)p_positions[i].y_offset / (MCGFloat)HB_SCALE_FACTOR;
+
+		x_location.x += (MCGFloat)p_positions[i].x_advance / (MCGFloat)HB_SCALE_FACTOR;
+		x_location.y += (MCGFloat)p_positions[i].y_advance / (MCGFloat)HB_SCALE_FACTOR;
+
+		t_glyphs[i] = p_infos[i].codepoint;
+		t_positions[i] = SkPoint::Make(x_offset, y_offset);
+	}
+	
+	t_glyphs.Take(r_run.glyphs, r_run.count);
+	t_positions.Take(r_run.positions, r_run.count);
+
+	return true;
 }
 
 void MCGlyphRunDestroy(MCGlyphRun& p_run)
 {
     MCMemoryDeleteArray(p_run.glyphs);
     MCMemoryDeleteArray(p_run.positions);
-    p_run.typeface.reset();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -310,258 +324,336 @@ static bool cluster_is_supported(hb_glyph_info_t* p_info, uindex_t p_index, uind
     return t_supported;
 }
 
-static uindex_t shape_text_and_add_to_glyph_array(const unichar_t* p_text, uindex_t p_char_count, bool p_rtl, const MCGFont &p_font, bool p_use_fallback, MCGPoint* x_location, MCAutoArray<MCGlyphRun>& x_runs)
+////////////////////////////////////////////////////////////////////////////////
+
+inline void cluster_to_char_bounds(uindex_t p_start, uindex_t p_end, const hb_glyph_info_t *p_infos, uindex_t p_glyph_count, uindex_t p_char_count, bool p_rtl, uindex_t &r_char_start, uindex_t &r_char_end)
 {
-    if (p_font . fid == nil)
-        return 0;
-    
-    SkTypeface *t_typeface = nil;
-    if (p_use_fallback)
-    {
-        // If we're to use a fallback font, use Skia's font manager to find a
-        // font that has glyphs for the first char in the string.
-        const unichar_t* t_text = p_text;
-        SkUnichar t_uni_char = SkUTF16_NextUnichar(&t_text);
-        sk_sp<SkFontMgr> t_fnt_mgr(SkFontMgr::RefDefault());
-        t_typeface = t_fnt_mgr -> matchFamilyStyleCharacter(nil, ((SkTypeface *)p_font . fid) -> fontStyle(), nil, 0, t_uni_char);
-        
-        // If there is no fallback font for the char, use the replacement glyph
-        // in the original font.
-        if (t_typeface == nil)
-            t_typeface = (SkTypeface *)p_font . fid;
-    }
-    else
-        t_typeface = (SkTypeface *)p_font . fid;
-    
-    if (t_typeface == nil)
-        return 0;
-    
-    MCHarfbuzzSkiaFace *t_hb_sk_face;
-    t_hb_sk_face = MCHarfbuzzGetFaceForSkiaTypeface(t_typeface);
-    
-    if (t_hb_sk_face == nil)
-        return 0;
-    
-    hb_font_t *t_hb_font;
-    t_hb_font = nil;
-    /* UNCHECKED */ MCHarfbuzzLockFont(t_hb_sk_face, p_font.size, t_hb_font);
-
-    // Set up the HarfBuzz buffer
-    hb_buffer_t *buffer = hb_buffer_create();
-    hb_buffer_set_unicode_funcs(buffer, hb_icu_get_unicode_funcs());
-    hb_buffer_set_direction(buffer, p_rtl ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
-    
-    hb_buffer_set_script(buffer, HBScriptFromText(p_text, p_char_count));
-    
-    hb_buffer_add_utf16(buffer, p_text, p_char_count, 0, p_char_count);
-    
-    hb_shape(t_hb_font, buffer, NULL, 0);
-    
-    uindex_t glyph_count = hb_buffer_get_length(buffer);
-    hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(buffer, 0);
-    hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(buffer, 0);
-    
-    uindex_t t_cur_glyph = 0, t_start = 0, t_run_count = 0;
-    uindex_t t_cluster_end = 0;
-    
-    // deal with runs of supported and unsupported glyphs
-    while (t_cur_glyph < glyph_count)
-    {
-        MCGlyphRun t_run;
-        t_start = t_cur_glyph;
-        
-        // Run of glyphs in successfully shaped clusters
-        while (t_cur_glyph < glyph_count &&
-               cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end))
-        {
-            t_cur_glyph = t_cluster_end;
-        }
-
-        if (t_start != t_cur_glyph)
-        {
-            MCGlyphRunMake(glyph_info, glyph_pos, x_location, t_start, t_cur_glyph, t_typeface, p_font . size, t_run);
-            x_runs . Push(t_run);
-            t_start = t_cur_glyph;
-            t_run_count++;
-        }
-        
-        // If the first cluster is unsupported and we're already using the fallback
-        // font for that cluster, assume there is no support and use a replacement.
-        if (t_cur_glyph == 0 &&
-            !cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end)
-            && p_use_fallback)
-        {
-            // Enforce a replacement glyph for the whole cluster by passing a 0
-            // codepoint and only adding a single glyph to the run
-            glyph_info[t_cur_glyph].codepoint = 0;
-            MCGlyphRunMake(glyph_info, glyph_pos, x_location, t_start, t_start + 1, (SkTypeface *)p_font . fid, p_font . size, t_run);
-            x_runs . Push(t_run);
-            t_cur_glyph = t_cluster_end;
-            t_start = t_cur_glyph;
-            t_run_count++;
-        }
-        
-        // Deal with run of unsupported clusters for this font.
-        while (t_cur_glyph < glyph_count &&
-               !cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end))
-        {
-            t_cur_glyph = t_cluster_end;
-        }
-        
-        // For the run of unsupported clusters, shape using a fallback font.
-        if (t_start != t_cur_glyph)
-        {
-            // Reshape from the beginning of the unsupported cluster run
-            // to the beginning of the cluster containing t_cur_glyph.
-            // At this point, t_cur_glyph might be equal to glyph_count,
-            // in which case compute the reshape char count using the old char
-            // count.
-            uindex_t t_end_index = p_char_count;
-            if (t_cur_glyph != glyph_count)
-                t_end_index = glyph_info[t_cur_glyph] . cluster;
-
-            t_run_count += shape_text_and_add_to_glyph_array(
-                p_text + glyph_info[t_start] . cluster,
-                t_end_index - glyph_info[t_start] . cluster,
-                p_rtl,
-                p_font,
-                true,
-                x_location,
-                x_runs
-            );
-        }
-    }
-    
-    hb_buffer_destroy(buffer);
-
-    MCHarfbuzzUnlockFont(t_hb_sk_face);
-
-    return t_run_count;
+	if (p_rtl)
+	{
+		r_char_start = p_infos[p_end - 1].cluster;
+		r_char_end = p_char_count;
+		if (p_start > 0)
+			r_char_end = p_infos[p_start - 1].cluster;
+	}
+	else
+	{
+		r_char_start = p_infos[p_start].cluster;
+		r_char_end = p_char_count;
+		if (p_end < p_glyph_count)
+			r_char_end = p_infos[p_end].cluster;
+	}
 }
 
-void shape(const unichar_t* p_text, uindex_t p_char_count, MCGPoint p_location, bool p_rtl, const MCGFont &p_font, MCGlyphRun*& r_runs, uindex_t& r_run_count)
+static bool MCHarfbuzzShape(const unichar_t* p_text, uindex_t p_char_count, bool p_rtl, const MCGFont &p_font, bool p_use_fallback, MCHarfbuzzShapeCallback p_callback, void *p_context)
 {
-    MCAutoArray<MCGlyphRun> t_runs;
-    uindex_t t_run_count = shape_text_and_add_to_glyph_array(p_text, p_char_count, p_rtl, p_font, false, &p_location, t_runs);
+	bool t_success;
+	t_success = true;
 
-    if (t_run_count == 0)
-    {
-        r_run_count = 0;
-        r_runs = nil;
-    }
-    else
-    {
-        r_run_count = t_run_count;
-        t_runs . Take(r_runs, r_run_count);
-    }
+	sk_sp<SkTypeface> t_typeface;
+
+	MCGFont t_fallback_font;
+
+	const MCGFont *t_font;
+	t_font = nil;
+
+	if (p_use_fallback)
+	{
+		// If we're to use a fallback font, use Skia's font manager to find a
+		// font that has glyphs for the first char in the string.
+		const unichar_t* t_text = p_text;
+		SkUnichar t_uni_char = SkUTF16_NextUnichar(&t_text);
+		sk_sp<SkFontMgr> t_fnt_mgr(SkFontMgr::RefDefault());
+		t_typeface = sk_ref_sp<SkTypeface>(t_fnt_mgr -> matchFamilyStyleCharacter(nil, ((SkTypeface *)p_font . fid) -> fontStyle(), nil, 0, t_uni_char));
+	}
+
+	if (t_typeface != nil)
+	{
+		t_fallback_font = MCGFontFromSkTypeface(t_typeface.get(), p_font.size);
+		t_font = &t_fallback_font;
+	}
+	else
+	{
+		// If there is no fallback font for the char, use the replacement glyph
+		// in the original font.
+		t_typeface = sk_ref_sp<SkTypeface>((SkTypeface *)p_font . fid);
+		t_font = &p_font;
+	}
+	
+	t_success = t_typeface != nil;
+	
+	MCHarfbuzzSkiaFace *t_hb_sk_face;
+	t_hb_sk_face = nil;
+	if (t_success)
+	{
+		t_hb_sk_face = MCHarfbuzzGetFaceForSkiaTypeface(t_typeface.get());
+		t_success = t_hb_sk_face != nil;
+	}
+	
+	hb_font_t *t_hb_font;
+	t_hb_font = nil;
+	if (t_success)
+		t_success = MCHarfbuzzLockFont(t_hb_sk_face, p_font.size, t_hb_font);
+
+	// Set up the HarfBuzz buffer
+	hb_buffer_t *buffer;
+	buffer = nil;
+	uindex_t glyph_count;
+	glyph_count = 0;
+	hb_glyph_info_t *glyph_info;
+	glyph_info = nil;
+	hb_glyph_position_t *glyph_pos;
+	glyph_pos = nil;
+
+	if (t_success)
+	{
+		buffer = hb_buffer_create();
+
+		hb_buffer_set_unicode_funcs(buffer, hb_icu_get_unicode_funcs());
+		hb_buffer_set_direction(buffer, p_rtl ? HB_DIRECTION_RTL : HB_DIRECTION_LTR);
+		hb_buffer_set_script(buffer, HBScriptFromText(p_text, p_char_count));
+
+		hb_buffer_add_utf16(buffer, p_text, p_char_count, 0, p_char_count);
+		hb_shape(t_hb_font, buffer, NULL, 0);
+
+		glyph_count = hb_buffer_get_length(buffer);
+		glyph_info = hb_buffer_get_glyph_infos(buffer, 0);
+		glyph_pos = hb_buffer_get_glyph_positions(buffer, 0);
+	}
+	
+	if (t_hb_sk_face != nil && t_hb_font != nil)
+		MCHarfbuzzUnlockFont(t_hb_sk_face);
+
+	uindex_t t_cur_glyph = 0;
+	
+	bool t_continue;
+	t_continue = true;
+
+	// deal with runs of supported and unsupported glyphs
+	while (t_continue && t_success && t_cur_glyph < glyph_count)
+	{
+		uindex_t t_start;
+		t_start = t_cur_glyph;
+
+		uindex_t t_cluster_end;
+		t_cluster_end = 0;
+		
+		if (cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end))
+		{
+			// Run of glyphs in successfully shaped clusters
+			t_cur_glyph = t_cluster_end;
+			while (t_cur_glyph < glyph_count && cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end))
+				t_cur_glyph = t_cluster_end;
+
+			uindex_t t_char_start, t_char_end;
+			cluster_to_char_bounds(t_start, t_cur_glyph, glyph_info, glyph_count, p_char_count, p_rtl, t_char_start, t_char_end);
+
+			t_continue = p_callback(p_context,
+				glyph_info + t_start,
+				glyph_pos + t_start,
+				t_cur_glyph - t_start,
+				p_text + t_char_start,
+				t_char_end - t_char_start,
+				*t_font);
+		}
+		else if (t_cur_glyph == 0 && p_use_fallback)
+		{
+			// If the first cluster is unsupported and we're already using the fallback
+			// font for that cluster, assume there is no support and use a replacement.
+			t_cur_glyph = t_cluster_end;
+
+			uindex_t t_char_start, t_char_end;
+			cluster_to_char_bounds(t_start, t_cur_glyph, glyph_info, glyph_count, p_char_count, p_rtl, t_char_start, t_char_end);
+
+			// Use a replacement glyph for the whole cluster
+			hb_glyph_info_t t_replacement_info;
+			t_replacement_info = glyph_info[t_start];
+
+			hb_glyph_position_t t_replacement_position;
+			t_replacement_position = glyph_pos[t_start];
+
+			uint16_t t_replacement_glyph;
+			skia_get_replacement_glyph(p_font, t_replacement_glyph, t_replacement_position);
+
+			t_replacement_info.codepoint = t_replacement_glyph;
+
+			t_continue = p_callback(p_context,
+				&t_replacement_info,
+				&t_replacement_position,
+				1,
+				p_text + t_char_start,
+				t_char_end - t_char_start,
+				p_font);
+		}
+		else
+		{
+			// Deal with run of unsupported clusters for this font.
+			t_cur_glyph = t_cluster_end;
+			while (t_cur_glyph < glyph_count && !cluster_is_supported(glyph_info, t_cur_glyph, glyph_count, t_cluster_end))
+				t_cur_glyph = t_cluster_end;
+
+			uindex_t t_char_start, t_char_end;
+			cluster_to_char_bounds(t_start, t_cur_glyph, glyph_info, glyph_count, p_char_count, p_rtl, t_char_start, t_char_end);
+
+			// For the run of unsupported clusters, shape using a fallback font.
+			t_success = MCHarfbuzzShape(
+				p_text + t_char_start,
+				t_char_end - t_char_start,
+				p_rtl,
+				p_font,
+				true,
+				p_callback,
+				p_context
+			);
+		}
+	}
+	
+	if (buffer != nil)
+		hb_buffer_destroy(buffer);
+
+	return t_success;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct _draw_text_context_t
+{
+	SkCanvas *canvas;
+	SkPaint paint;
+	MCGPoint location;
+};
+
+static bool _draw_text_callback(void *context, const hb_glyph_info_t *p_infos, const hb_glyph_position_t *p_positions, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count, const MCGFont &p_font)
+{
+	_draw_text_context_t *self;
+	self = (_draw_text_context_t*)context;
+
+	sk_sp<SkTypeface> t_typeface = sk_ref_sp<SkTypeface>((SkTypeface*)p_font.fid);
+
+	MCGlyphRun t_run;
+	MCMemoryClear(t_run);
+	if (MCGlyphRunMake(p_infos, p_positions, p_glyph_count, self->location, t_run))
+	{
+		self->paint.setTypeface(t_typeface);
+		self->canvas->drawPosText(t_run.glyphs, t_run.count * 2, t_run.positions, self->paint);
+		MCGlyphRunDestroy(t_run);
+	}
+
+	return true;
+}
+
 void MCGContextDrawPlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, MCGPoint p_location, const MCGFont &p_font, bool p_rtl)
 {
-    if (!MCGContextIsValid(self))
+	if (!MCGContextIsValid(self))
 		return;	
-    
-    SkPaint t_paint;
-    if (!MCGContextSetupFill(self, t_paint))
-    {
-        self->is_valid = false;
-        return;
-    }
-    
-    // Force skia to render text with antialiasing enabled.
-    t_paint . setAntiAlias(true);
+	
+	SkPaint t_paint;
+	if (!MCGContextSetupFill(self, t_paint))
+	{
+		self->is_valid = false;
+		return;
+	}
+	
+	// Force skia to render text with antialiasing enabled.
+	t_paint . setAntiAlias(true);
 
-    t_paint . setTextSize(p_font . size);
-    t_paint . setTextEncoding(SkPaint::kGlyphID_TextEncoding);
-    
-    MCGlyphRun *t_glyph_runs;
-    uindex_t t_count;
+	t_paint . setTextSize(p_font . size);
+	t_paint . setTextEncoding(SkPaint::kGlyphID_TextEncoding);
+	
+	_draw_text_context_t t_context;
+	t_context.canvas = self->layer->canvas;
+	t_context.paint = t_paint;
+	t_context.location = p_location;
 
-    shape(p_text, p_length/2, p_location, p_rtl, p_font, t_glyph_runs, t_count);
-    
-    for (uindex_t i = 0; i < t_count; i++)
-    {
-        t_paint . setTypeface(t_glyph_runs[i] . typeface);
-        self -> layer -> canvas -> drawPosText(&(t_glyph_runs[i] . glyphs[0]), t_glyph_runs[i] . count * 2, &(t_glyph_runs[i] . positions[0]), t_paint);
-        
-        MCGlyphRunDestroy(t_glyph_runs[i]);
-    }
-    
-    MCMemoryDeleteArray(t_glyph_runs);
-    
+	/* UNCHECKED */ MCHarfbuzzShape(p_text, p_length / 2, p_rtl, p_font, false, _draw_text_callback, &t_context);
+
 	self -> is_valid = true;
+}
+
+//////////
+
+static bool _measure_text_callback(void *context, const hb_glyph_info_t *p_infos, const hb_glyph_position_t *p_positions, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count, const MCGFont &p_font)
+{
+	MCGFloat *t_width;
+	t_width = (MCGFloat*)context;
+
+	for (uindex_t i = 0; i < p_glyph_count; i++)
+	{
+		MCGFloat x_advance;
+		x_advance = (MCGFloat)p_positions[i].x_advance / (MCGFloat)HB_SCALE_FACTOR;
+
+		*t_width += x_advance;
+	}
+
+	return true;
 }
 
 MCGFloat __MCGContextMeasurePlatformText(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform)
 {	
 	//if (!MCGContextIsValid(self))
 	//	return 0.0;
-    
+	
 	MCGFloat t_width;
 	t_width = 0.0;
-    
-    SkPaint t_paint;
-    t_paint . setTextSize(p_font . size);
-    t_paint . setTextEncoding(SkPaint::kGlyphID_TextEncoding);
-    
-    MCGlyphRun *t_glyph_runs;
-    uindex_t t_count;
-    
-    MCGPoint t_dummy = MCGPointMake(0,0);
-    shape(p_text, p_length/2, t_dummy, false, p_font, t_glyph_runs, t_count);
-    
-    for (uindex_t i = 0; i < t_count; i++)
-    {
-        t_paint . setTypeface(t_glyph_runs[i] . typeface);
-        t_width +=  (MCGFloat) t_paint . measureText(&(t_glyph_runs[i] . glyphs[0]), t_glyph_runs[i] . count * 2);
-        
-        MCGlyphRunDestroy(t_glyph_runs[i]);
-    }
-    
-    MCMemoryDeleteArray(t_glyph_runs);
+	
+	/* UNCHECKED */ MCHarfbuzzShape(p_text, p_length / 2, false, p_font, false, _measure_text_callback, &t_width);
 
-	//self -> is_valid = t_success;
 	return t_width;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+struct _measure_image_bounds_context_t
+{
+	SkPaint paint;
+	MCGPoint location;
+	SkRect bounds;
+};
+
+static bool _measure_image_bounds_callback(void *context, const hb_glyph_info_t *p_infos, const hb_glyph_position_t *p_positions, uindex_t p_glyph_count, const unichar_t *p_chars, uindex_t p_char_count, const MCGFont &p_font)
+{
+	_measure_image_bounds_context_t *self;
+	self = (_measure_image_bounds_context_t*)context;
+
+	sk_sp<SkTypeface> t_typeface = sk_ref_sp<SkTypeface>((SkTypeface*)p_font.fid);
+
+	MCAutoArray<SkRect> t_glyph_bounds;
+
+	MCGlyphRun t_run;
+	MCMemoryClear(t_run);
+	if (MCGlyphRunMake(p_infos, p_positions, p_glyph_count, self->location, t_run))
+	{
+		/* UNCHECKED */ t_glyph_bounds.New(t_run.count);
+		self->paint.setTypeface(t_typeface);
+		self->paint.getTextWidths(t_run.glyphs, p_glyph_count * 2, nil, t_glyph_bounds.Ptr());
+
+		for (uindex_t i = 0; i < t_run.count; i++)
+		{
+			t_glyph_bounds[i].offset(t_run.positions[i]);
+			self->bounds.join(t_glyph_bounds[i]);
+		}
+		MCGlyphRunDestroy(t_run);
+	}
+
+	return true;
+}
 
 bool MCGContextMeasurePlatformTextImageBounds(MCGContextRef self, const unichar_t *p_text, uindex_t p_length, const MCGFont &p_font, const MCGAffineTransform &p_transform, MCGRectangle &r_bounds)
 {
 	//if (!MCGContextIsValid(self))
 	//	return 0.0;
 	
-	SkRect t_bounds;
-	t_bounds = SkRect::MakeEmpty();
-	
 	SkPaint t_paint;
 	t_paint . setTextSize(p_font . size);
 	t_paint . setTextEncoding(SkPaint::kGlyphID_TextEncoding);
 	
-	MCGlyphRun *t_glyph_runs;
-	uindex_t t_count;
-	
-	MCGPoint t_dummy = MCGPointMake(0,0);
-	shape(p_text, p_length/2, t_dummy, false, p_font, t_glyph_runs, t_count);
-	
-	for (uindex_t i = 0; i < t_count; i++)
-	{
-		SkRect t_glyph_bounds;
-		t_paint . setTypeface(t_glyph_runs[i] . typeface);
-		t_paint . measureText(&(t_glyph_runs[i] . glyphs[0]), t_glyph_runs[i] . count * 2, &t_glyph_bounds);
-		
-		if (!t_bounds.isEmpty())
-			t_glyph_bounds.offsetTo(t_bounds.right(), t_glyph_bounds.y());
-		t_bounds.join(t_glyph_bounds);
-		
-		MCGlyphRunDestroy(t_glyph_runs[i]);
-	}
-	
-	MCMemoryDeleteArray(t_glyph_runs);
-	
-	r_bounds = MCGRectangleFromSkRect(t_bounds);
+	_measure_image_bounds_context_t t_context;
+	t_context.paint = t_paint;
+	t_context.location = MCGPointMake(0,0);
+	t_context.bounds = SkRect::MakeEmpty();
+
+	/* UNCHECKED */ MCHarfbuzzShape(p_text, p_length / 2, false, p_font, false, _measure_image_bounds_callback, &t_context);
+
+	r_bounds = MCGRectangleFromSkRect(t_context.bounds);
 	return true;
 }
 


### PR DESCRIPTION
This patch removes the harfbuzz skia font wrapper used when shaping text
instead using the underlying FreeType face object obtained from SkTypeface.
This resolves an issue with incorrect spacing between glyphs when rendering
text on Android.