### PR TITLE
[[Bug 22363 ]] Ensure Windows player shows correct frame for currentTime when paused

### DIFF
--- a/docs/notes/bugfix-22363.md
+++ b/docs/notes/bugfix-22363.md
@@ -1,0 +1,1 @@
+# Windows Player now shows the correct video frame when the currentTime is changed while playback is paused.


### PR DESCRIPTION
This patch fixes bug 22363, where the windows player would sometimes show the wrong video frame when the currentTime property was changed while paused.

Closes https://quality.livecode.com/show_bug.cgi?id=22363