### PR TITLE
[[ Bug 22536 ]] Don't fail MCStringFindAndReplace if replacement not possible

### DIFF
--- a/docs/notes/bugfix-22536.md
+++ b/docs/notes/bugfix-22536.md
@@ -1,0 +1,2 @@
+# The replace command will no longer fail incorrectly in some cases where there are no possible replacements to be made
+

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5748,7 +5748,7 @@ bool MCStringFindAndReplace(MCStringRef self, MCStringRef p_pattern, MCStringRef
                 return MCStringFindAndReplaceNative(self, p_pattern, p_replacement, p_options);
         }
         else if (MCStringCantBeEqualToNative(p_pattern, p_options))
-            return false;
+            return true;
     }
 
 	if (!__MCStringUnnativize(self))

--- a/tests/lcs/core/strings/replace.livecodescript
+++ b/tests/lcs/core/strings/replace.livecodescript
@@ -42,3 +42,18 @@ on TestReplace
    replace tNeedle with tNewNeedle in tHaystack
    TestAssert "replace decomposed with base in decomposed", tHaystack is "hello"
 end TestReplace
+
+on TestReplace_Bug22536
+   try
+      local tPattern
+      put "и" into tPattern
+      put tPattern after tPattern
+      get the number of chars in tPattern
+      get textDecode("foobardsdadadasdasd", "native")
+      if true then
+         replace tPattern with empty in it
+      end if
+   catch tError
+   end try
+   TestAssert "replace never-native unciode in native string", tError is empty
+end TestReplace_Bug22536


### PR DESCRIPTION
This patch ensures that MCStringFindAndReplace won't fail if it determines
that the target string is native and the pattern string cannot ever be
native (and thus not exist in the target). The case this optimization occurs
is not hugely common as it requires the pattern string to have been 'checked'
at some point. The method will now just exit early in this case.