### PR TITLE
make backslash appear in chrome browser

### DIFF
--- a/docs/dictionary/function/within.lcdoc
+++ b/docs/dictionary/function/within.lcdoc
@@ -64,13 +64,13 @@ borders.
 
 The expression
 
-    <point> is within the rect of <object(glossary)> 
+    point is within the rect of object 
 
 is equivalent to
 
-    within(<object(glossary)>, <point>)
+    within(object, point)
 
-unless the <object(glossary)> <a/> is a graphic or image, or a tabbed
+unless the <object(glossary)> is a graphic or image, or a tabbed
 button. 
 
 References: function (control structure), intersect (function),

--- a/docs/dictionary/operator/contains.lcdoc
+++ b/docs/dictionary/operator/contains.lcdoc
@@ -43,7 +43,7 @@ References: operator (glossary), operation (glossary),
 evaluate (glossary), string (glossary), string (keyword),
 characters (keyword), = (operator), &lt;&gt; (operator), is in (operator),
 is among (operator), is not among (operator), ends with (operator),
-is not in (operator)
+is not in (operator), caseSensitive (property)
 
 Tags: text processing
 

--- a/docs/dictionary/operator/is-among.lcdoc
+++ b/docs/dictionary/operator/is-among.lcdoc
@@ -44,7 +44,7 @@ contains the given bytes.
 
 References: wordOffset (function), contains (operator),
 is among the keys of (operator), is not among (operator),
-is in (operator), wholeMatches (property)
+is in (operator), caseSensitive (property), wholeMatches (property)
 
 Tags: text processing
 

--- a/docs/dictionary/operator/is-in.lcdoc
+++ b/docs/dictionary/operator/is-in.lcdoc
@@ -46,7 +46,7 @@ The <is in> <operator> is the logical inverse of the <is not in>
 
 References: evaluate (glossary), string (glossary), operator (glossary),
 string (keyword), is not in (operator), contains (operator),
-is among (operator)
+is among (operator), caseSensitive (property)
 
 Tags: text processing
 

--- a/docs/dictionary/operator/is-not-among.lcdoc
+++ b/docs/dictionary/operator/is-not-among.lcdoc
@@ -37,7 +37,7 @@ The <is not among> operator is the logical inverse of the is among
 operator. When one is true, the other is false.
 
 References: characters (keyword), is among the keys of (operator),
-contains (operator), is among (operator)
+contains (operator), is among (operator), caseSensitive (property)
 
 Tags: text processing
 

--- a/docs/dictionary/operator/is-not-in.lcdoc
+++ b/docs/dictionary/operator/is-not-in.lcdoc
@@ -30,7 +30,9 @@ Use the <is not in> <operator> to find out whether a <string> does not
 contain a substring.
 
 The expression
-firstString is not in secondString
+
+   firstString is not in secondString
+
 is equivalent to
 
     not (secondString contains firstString)
@@ -40,7 +42,8 @@ The <is not in> <operator> is the logical inverse of the <is in>
 <operator>. When one is true, the other is false.
 
 References: evaluate (glossary), string (glossary), operator (glossary),
-string (keyword), contains (operator), is in (operator)
+string (keyword), contains (operator), is in (operator), 
+caseSensitive (property)
 
 Tags: text processing
 

--- a/docs/dictionary/operator/less-than-or-greater-than.lcdoc
+++ b/docs/dictionary/operator/less-than-or-greater-than.lcdoc
@@ -28,7 +28,7 @@ field "Old Password" &lt;&gt; field "Password"
 Parameters:
 value1:
 The operands value1 and value2 can be numbers, literal strings of
-characters (delimited with double quotes), or any sources of value. :
+characters (delimited with double quotes), or any sources of value.
 
 value2:
 
@@ -39,14 +39,15 @@ compare two <string|strings>.
 
 When comparing strings, the  &lt;&gt; operator compares the two values
 character by character, using the ASCII value of each character. If the
-caseSensitive <property> is true, the comparison between two
+<caseSensitive> <property> is true, the comparison between two
 <string|strings> treats uppercase letters as coming before lowercase
-letters, so "A" &lt;&gt; "a". If the caseSensitive <property> is false,
+letters, so "A" &lt;&gt; "a". If the <caseSensitive> <property> is false,
 the comparison is not <case-sensitive>, so "a" is considered equivalent
 to "A".
 
 References: property (glossary), operator (glossary),
 case-sensitive (glossary), value (glossary), return (glossary),
 string (glossary), contains (operator), = (operator), &lt; (operator),
-&gt; (operator)
+&lt;= (operator), &gt; (operator), &gt;= (operator), 
+caseSensitive (property)
 

--- a/docs/dictionary/operator/less-than.lcdoc
+++ b/docs/dictionary/operator/less-than.lcdoc
@@ -48,10 +48,10 @@ other, the missing <characters> are considered to have lower
 
 If the two values are equal, firstValue  secondValue evaluates to false.
 
-If the caseSensitive <property> is true, the comparison between two
+If the <caseSensitive> <property> is true, the comparison between two
 <string(glossary)|strings> treats uppercase letters as coming before
-lowercase letters, so "A" &lt; "a". If the caseSensitive <property> is
-false, the comparison is not <case-sensitive>, so "a" is considered
+lowercase letters, so "A" &lt; "a". If the <caseSensitive> <property> 
+is false, the comparison is not <case-sensitive>, so "a" is considered
 equivalent to "A".
 
 References: min (function), value (function), property (glossary),
@@ -59,7 +59,7 @@ ASCII (glossary), value (glossary), return (glossary),
 operator (glossary), string (glossary), character set (glossary),
 case-sensitive (glossary), string (keyword), character (keyword),
 characters (keyword), &lt;&gt; (operator), &lt;= (operator),
-&gt; (operator)
+&gt; (operator), caseSensitive (property)
 
 Tags: math
 

--- a/docs/dictionary/operator/wrap.lcdoc
+++ b/docs/dictionary/operator/wrap.lcdoc
@@ -47,7 +47,7 @@ The mathematical formula implemented by the wrap operator is:
 
     x wrap y       
     =       (x-1) mod abs(y) +1     if(x &gt;= 0)
-    =     -((x-1) mod abs(y) +1)    if(x &lt; 0)
+    =     -((-x-1) mod abs(y) +1)    if(x &lt; 0)
 
 
 If a math operation on finite inputs produces a non-finite output, an

--- a/docs/dictionary/operator/wrap.lcdoc
+++ b/docs/dictionary/operator/wrap.lcdoc
@@ -45,9 +45,9 @@ iteration ie. 1, 2, 3, 1, 2 . Therefore 5 wrap 3 is 2.
 
 The mathematical formula implemented by the wrap operator is:
 
-    x wraps y        =       ((x-1) mod abs(y)) +1 if (x &gt;= 0)
-
-    =      -((x-1) mod abs(y)) +1 if(x &lt; 0)
+    x wrap y       
+    =       (x-1) mod abs(y) +1     if(x &gt;= 0)
+    =     -((x-1) mod abs(y) +1)    if(x &lt; 0)
 
 
 If a math operation on finite inputs produces a non-finite output, an

--- a/docs/dictionary/property/caseSensitive.lcdoc
+++ b/docs/dictionary/property/caseSensitive.lcdoc
@@ -27,9 +27,9 @@ comparisons.
 
 The <caseSensitive> <property> <control|controls> the <behavior> of the
 all <string> comparisons, including the comparison <operator|operators>
-<=>, <&gt;>, <&lt;>, <&gt;=>, <&lt;=>, <is in>, <is among>, 
-<is not among>,  and <contains>; the <command|commands> <filter>, 
-<find>, and <replace>; and the <function|functions> <offset>, 
+<=>, <&gt;>, <&lt;>, <&gt;=>, <&lt;=>, <&lt;&gt;> <is in>, <is not in>,
+<is among>, <is not among>, and <contains>; the <command|commands> 
+<filter>, <find>, and <replace>; and the <function|functions> <offset>, 
 <itemOffset>, <wordOffset>, <lineOffset>, and <replaceText>.
 
 If the <caseSensitive> <property> is set to true, all the <LiveCode>
@@ -74,8 +74,8 @@ LiveCode (glossary), custom property (glossary), key (glossary),
 message (glossary), handler (glossary), 
 string (keyword), = (operator), contains (operator), &gt; (operator),
 &gt;= (operator), is among (operator), is not among (operator), 
-&lt; (operator), &lt;= (operator), is in (operator), 
-wholeMatches (property)
+&lt; (operator), &lt;= (operator), &lt;&gt; (operator), is in (operator), 
+is not in (operator), wholeMatches (property)
 
 Tags: database
 

--- a/docs/dictionary/property/vScroll.lcdoc
+++ b/docs/dictionary/property/vScroll.lcdoc
@@ -42,11 +42,11 @@ been scrolled.
 Setting the <vScroll> of a <field> or <group> causes a <scrollbarDrag>
 <message> to be sent to the <field> or <group>.
 
->*Cross-platform note:* On <Mac OS> and <OS X|OS X systems>, the <menu
-> bar> appears at the top of the screen, rather than inside the stack
-> window. If a <stack|stack's> <editMenus> <property> is set to false
-> and the <stack> contains a <menu bar>, the window is scrolled down and
-> resized so that the <menu bar> <group> is not visible in the window.
+>*Cross-platform note:* On <Mac OS> and <OS X|OS X systems>, the 
+> <menu bar> appears at the top of the screen, rather than inside the 
+> stack window. If a <stack|stack's> <editMenus> <property> is set to 
+> false and the <stack> contains a <menu bar>, the window is scrolled down 
+> and resized so that the <menu bar> <group> is not visible in the window.
 > Because of this, on <Mac OS> and <OS X|OS X systems>, the <vScroll> of
 > a <stack> reports the amount the <stack> has been scrolled down to
 > hide a <menu bar> <group>.

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -25,12 +25,13 @@ Use the <xScale> <property> to control an <EPS|EPS object's> screen
 appearance. 
 
 The <number> 1 indicates no scaling--that is, the <EPS|EPS object's>
-width is the same as the width specified by the <PostScript> code it
-contains. Numbers greater than one indicate that the <object|object's>
-width is less than the <PostScript> width; the screen <object(glossary)>
-is scaled down. Numbers less than one indicate that the
-<object|object's> width is greater than the <PostScript> width, and the
-screen <object(glossary)> is scaled up from the <PostScript>.
+width is the same as the width specified by the <postScript|PostScript> 
+code it contains. Numbers greater than one indicate that the 
+<object|object's> width is less than the <postScript|PostScript> width; 
+the screen <object(glossary)> is scaled down. Numbers less than one 
+indicate that the <object|object's> width is greater than the 
+<postScript|PostScript> width, and the screen <object(glossary)> is 
+scaled up from the <postScript|PostScript>.
 
 In geometric terms, xScale = xExtent/width.
 

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -25,13 +25,13 @@ Use the <xScale> <property> to control an <EPS|EPS object's> screen
 appearance. 
 
 The <number> 1 indicates no scaling--that is, the <EPS|EPS object's>
-width is the same as the width specified by the <postScript|PostScript> 
+width is the same as the width specified by the <postScript> 
 code it contains. Numbers greater than one indicate that the 
-<object|object's> width is less than the <postScript|PostScript> width; 
+<object|object's> width is less than the <postScript> width; 
 the screen <object(glossary)> is scaled down. Numbers less than one 
 indicate that the <object|object's> width is greater than the 
-<postScript|PostScript> width, and the screen <object(glossary)> is 
-scaled up from the <postScript|PostScript>.
+<postScript> width, and the screen <object(glossary)> is 
+scaled up from the <postScript>.
 
 In geometric terms, xScale = xExtent/width.
 

--- a/docs/dictionary/property/xScale.lcdoc
+++ b/docs/dictionary/property/xScale.lcdoc
@@ -5,7 +5,7 @@ Type: property
 Syntax: set the xScale of <EPSObject> to <number>
 
 Summary:
-Specifies the ratio of the width of an <EPS|EPS object's> <PostScript>
+Specifies the ratio of the width of an <EPS|EPS object's> <postScript>
 bounding box to the <object|object's> screen width.
 
 Introduced: 1.0

--- a/docs/glossary/x/XML-tree.lcdoc
+++ b/docs/glossary/x/XML-tree.lcdoc
@@ -7,11 +7,11 @@ Type: glossary
 Description:
 An <XML> document held in memory. An XML tree is a data structure
 containing all the content in an <XML document>, arranged to make it
-easy to traverse <owner|parent>, <sibling>, and <child> relationships
-between <node|nodes>.
+easy to traverse <owner|parent>, <sibling node|sibling>, 
+and <child node|child> relationships between <node|nodes>.
 
-References: node (glossary), owner (glossary), child (glossary),
-sibling (glossary), XML document (glossary), XML (glossary)
+References: node (glossary), owner (glossary), child node (glossary),
+sibling node (glossary), XML document (glossary), XML (glossary)
 
 Tags: text processing
 

--- a/docs/guides/LiveCode Builder Style Guide.md
+++ b/docs/guides/LiveCode Builder Style Guide.md
@@ -185,17 +185,17 @@ per tab.
 
 ### Wrapping
 
-Avoid lines longer than 80 characters.  Break long lines using a `\`
+Avoid lines longer than 80 characters.  Break long lines using a \\
 continuation character.  Indent continuation lines by two levels. For
 example:
 
-    constant kWordList is ["a", "very", "long", "list", "that", "is", "much",\
+    constant kWordList is ["a", "very", "long", "list", "that", "is", "much",\\
           "more", "readable", "when", "wrapped", "nicely"]
 
 When breaking a handler definition or handler type definition, break
 long lines at commas:
 
-    handler processStringAndArray(in pStringArg as String, \
+    handler processStringAndArray(in pStringArg as String, \\
           in pArrayArg as Array) returns Boolean
 
 ### Handler declarations, definitions and calls

--- a/docs/notes/bugfix-12504.md
+++ b/docs/notes/bugfix-12504.md
@@ -1,0 +1,1 @@
+# Added mutual referencing between the caseSensitive entry and related operator entries


### PR DESCRIPTION
Backslash in the "Wrapping" section is not escaped and currently appears as blank in Chrome. Have added the escape backslash to the existing backslash.