### PR TITLE
[[ Bug 22556 ]] Fix unpaired unlock of dragboard

### DIFF
--- a/docs/notes/bugfix-22556.md
+++ b/docs/notes/bugfix-22556.md
@@ -1,0 +1,1 @@
+# Drag and drop on macOS from LiveCode to another application no longer fails after three drags

--- a/engine/src/clipboard.cpp
+++ b/engine/src/clipboard.cpp
@@ -76,6 +76,7 @@ bool MCClipboard::Lock(bool p_skip_pull) const
 
 bool MCClipboard::Unlock() const
 {
+    MCAssert(m_lock_count > 0);
     // Decrement the lock count. If it moves from one to zero, push any changes
     // out to the underlying OS clipboard.
     //

--- a/engine/src/dispatch.cpp
+++ b/engine/src/dispatch.cpp
@@ -1710,7 +1710,7 @@ void MCDispatch::wmdragleave(Window w)
 	}
     
     // We are no longer the drop target and no longer care about the drag data.
-    MCdragboard->Unlock();
+    MCdragboard->PushUpdates();
     MCdragboard->ReleaseData();
 	m_drag_target = false;
 }


### PR DESCRIPTION
This patch fixes an issue where `MCdragboard->Unlock()` was called when the
drag leaves the window when `MCdragboard->Lock()` had not been called. The
call to `Unlock()` has been changed to `PushUpdates()` so that the system
dragboard is updated with the current data so that it can be dropped onto
other applications etc. This change resolves an issue where after a number of
drags from LiveCode to another application drag and drop no longer appears to
function.