### PR TITLE
[[ Bug 22577 ]] Ensure device token is returned in the correct form

### DIFF
--- a/docs/notes/bugfix-22577.md
+++ b/docs/notes/bugfix-22577.md
@@ -1,0 +1,1 @@
+# Ensure the device token in push notifications is returned correctly


### PR DESCRIPTION
For getting the device token, we were rendering an NSData into a formatted string,
which would use the debug representation. This worked fine until iOS 12.
On iOS 13, the debug representation of the NSData has changed, and does not
display the whole token. So we need to convert the NSData to a hex string
to get the correct representation.

See https://nshipster.com/apns-device-tokens/ for more details.

Tested this patch with both iOS 12.1 and iOS 13.2 SDKs