### PR TITLE
[[ Bug 18876 ]] Fix character duplication when deleting text on Android

### DIFF
--- a/docs/notes/bugfix-18876.md
+++ b/docs/notes/bugfix-18876.md
@@ -1,0 +1,1 @@
+# Fix text duplication when deleting text previously entered into a field on Android


### PR DESCRIPTION
This patch fixes an issue where using the backspace key to delete text
previously entered using a virtual keyboard on Android would result in extra
text being added to the field. This was due to both our own method overrides and
the underlying BaseInputConnection class sending synthesised KeyEvents to the
field. The implementation has been revised to prevent this.