### PR TITLE
[[ Bug 22593 ]] Add release note

### DIFF
--- a/docs/notes/bugfix-22593.md
+++ b/docs/notes/bugfix-22593.md
@@ -1,0 +1,1 @@
+# Fix support for font smoothing in macOS 10.14+


### PR DESCRIPTION
This patch adds a release note for bug 22593 which fixes support for font
smoothing in macOS 10.14+. The fix itself is against the thirdparty repo.

Requires https://github.com/livecode/livecode-thirdparty/pull/141