### PR TITLE
[bugfix-7948] Add docs note that revDeleteFolder can't delete defaultFolder

### DIFF
--- a/docs/dictionary/command/revDeleteFolder.lcdoc
+++ b/docs/dictionary/command/revDeleteFolder.lcdoc
@@ -53,6 +53,9 @@ all <file|files>, <subfolder|subfolders>, and their contents.
 > the <library> is available and the <revDeleteFolder> <command> 
 > can be used in any <handler>.
 
+>*Note: This <command> can not delete the defaultFolder and will
+> fail if the folderToDelete is or contains the defaultFolder.
+
 References: revCopyFolder (command), create folder (command),
 answer folder (command), delete file (command), revMoveFolder (command),
 function (control structure), folders (function), result (function),

--- a/docs/notes/bugfix-7948.md
+++ b/docs/notes/bugfix-7948.md
@@ -1,0 +1,1 @@
+# Added note that revDeleteFolder can not delete the defaultFolder


### PR DESCRIPTION
Added a note in the documentation for revDeleteFolder that choosing a folder that is or contains the defaultFolder will fail to delete it.