### PR TITLE
[Bugfix-22596] Include Android in playLoudness docs

### DIFF
--- a/docs/dictionary/property/playLoudness.lcdoc
+++ b/docs/dictionary/property/playLoudness.lcdoc
@@ -9,7 +9,7 @@ Specifies the volume of sounds played by the play command.
 
 Introduced: 1.0
 
-OS: mac, windows, linux, ios
+OS: mac, windows, linux, ios, android
 
 Platforms: desktop, server, mobile
 

--- a/docs/notes/bugfix-22596.md
+++ b/docs/notes/bugfix-22596.md
@@ -1,0 +1,1 @@
+# Included Android as supported in the playLoudness dictionary entry


### PR DESCRIPTION
Included Android as a supported platform in the playLoudness dictionary entry