### PR TITLE
[[ Bug 22149 ]] Removed UIExitsOnSuspend key from plist

### DIFF
--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -66,8 +66,6 @@
 	</dict>
 	<key>UIRequiresPersistentWiFi</key>
 		${PERSISTENT_WIFI}
-	<key>UIApplicationExitsOnSuspend</key>
-		${APPLICATION_EXITS_ON_SUSPEND}
 	<key>UIInitialInterfaceOrientation</key>
 		${IPHONE_INITIAL_ORIENTATION}
 	<key>UISupportedInterfaceOrientations</key>

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1457,7 +1457,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    end if
    ----------
    
-   local tDisplayName, tMinimumOS, tDeviceFamily, tRequiredCapabilities, tPersistentWifi, tEnableBackgroundExecution
+   local tDisplayName, tMinimumOS, tDeviceFamily, tRequiredCapabilities, tPersistentWifi
    local tDisableATS
    local tFileSharing, tPrerenderedIcon
    put pSettings["ios,display name"] into tDisplayName
@@ -1465,37 +1465,21 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    put pSettings["ios,device family"] into tDeviceFamily
    put pSettings["ios,device capabilities"] into tRequiredCapabilities
    put pSettings["ios,persistent wifi"] into tPersistentWifi
-   -- MW-2011-03-10: Force this to true for now, until we can fix the engine
-   put pSettings["ios,enable background execution"] into tEnableBackgroundExecution
    
    -- AB-2017-05-31: Add more background modes
    local tBackgroundModes
    
-   if tEnableBackgroundExecution is empty then
-      put "false" into tEnableBackgroundExecution
-   end if
    
-   if tEnableBackgroundExecution then
-      put pSettings["ios,background audio"] into tBackgroundModes["${PLAY_AUDIO_WHEN_IN_BACKGROUND}"]
-      put pSettings["ios,background location update"] into tBackgroundModes["${BACKGROUND_LOCATION_UPDATE}"]
-      put pSettings["ios,background voip"] into tBackgroundModes["${BACKGROUND_VOIP}"]
-      put pSettings["ios,background newsstand downloads"] into tBackgroundModes["${BACKGROUND_NEWSSTAND_DOWNLOADS}"]
-      put pSettings["ios,external acc comn"] into tBackgroundModes["${EXTERNAL_ACC_COMM}"]
-      put pSettings["ios,use bt le"] into tBackgroundModes["${USE_BT_LE}"]
-      put pSettings["ios,acts as bt le"] into tBackgroundModes["${ACTS_AS_BT_LE}"]
-      put pSettings["ios,background fetch"] into tBackgroundModes["${BACKGROUND_FETCH}"]
-      put pSettings["ios,remote notifications"] into tBackgroundModes["${REMOTE_NOTIFICATIONS}"] 
-   else
-      put false into tBackgroundModes["${PLAY_AUDIO_WHEN_IN_BACKGROUND}"]
-      put false into tBackgroundModes["${BACKGROUND_LOCATION_UPDATE}"]
-      put false into tBackgroundModes["${BACKGROUND_VOIP}"]
-      put false into tBackgroundModes["${BACKGROUND_NEWSSTAND_DOWNLOADS}"]
-      put false into tBackgroundModes["${EXTERNAL_ACC_COMM}"]
-      put false into tBackgroundModes["${USE_BT_LE}"]
-      put false into tBackgroundModes["${ACTS_AS_BT_LE}"]
-      put false into tBackgroundModes["${BACKGROUND_FETCH}"]
-      put false into tBackgroundModes["${REMOTE_NOTIFICATIONS}"] 
-   end if
+   put pSettings["ios,background audio"] into tBackgroundModes["${PLAY_AUDIO_WHEN_IN_BACKGROUND}"]
+   put pSettings["ios,background location update"] into tBackgroundModes["${BACKGROUND_LOCATION_UPDATE}"]
+   put pSettings["ios,background voip"] into tBackgroundModes["${BACKGROUND_VOIP}"]
+   put pSettings["ios,background newsstand downloads"] into tBackgroundModes["${BACKGROUND_NEWSSTAND_DOWNLOADS}"]
+   put pSettings["ios,external acc comn"] into tBackgroundModes["${EXTERNAL_ACC_COMM}"]
+   put pSettings["ios,use bt le"] into tBackgroundModes["${USE_BT_LE}"]
+   put pSettings["ios,acts as bt le"] into tBackgroundModes["${ACTS_AS_BT_LE}"]
+   put pSettings["ios,background fetch"] into tBackgroundModes["${BACKGROUND_FETCH}"]
+   put pSettings["ios,remote notifications"] into tBackgroundModes["${REMOTE_NOTIFICATIONS}"] 
+   
    put pSettings["ios,file sharing"] into tFileSharing
    put pSettings["ios,prerendered icon"] into tPrerenderedIcon 
    
@@ -1701,7 +1685,6 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    replace "${DEVICE_CAPABILITY}" with it in pPlist
    
    replace "${PERSISTENT_WIFI}" with "<" & tPersistentWifi & "/>" in pPlist
-   replace "${APPLICATION_EXITS_ON_SUSPEND}" with "<" & not tEnableBackgroundExecution & "/>" in pPlist
    replace "${FILE_SHARING}" with "<" & tFileSharing & "/>" in pPlist
    replace "${PRE_RENDERED_ICON}" with "<" & tPrerenderedIcon & "/>" in pPlist
    


### PR DESCRIPTION
This patch removes the "UIExitsOnSuspend" key from the plist of iOS apps,
since the iOS AppStore no longer accepts apps that include this key
in their plist.

Requires https://github.com/livecode/livecode-ide/pull/2119

Closes https://quality.livecode.com/show_bug.cgi?id=22149