### PR TITLE
[[ Bug 22508 ]] Don't clear the clipboard when setting dragdata on Windows

### DIFF
--- a/docs/notes/bugfix-22508.md
+++ b/docs/notes/bugfix-22508.md
@@ -1,0 +1,1 @@
+# Fix clipboard contents being cleared when setting dragdata on Windows

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -759,6 +759,21 @@ bool MCWin32RawClipboard::FlushData()
 	return OleFlushClipboard() == S_OK;
 }
 
+MCWin32RawClipboardItem* MCWin32RawClipboard::CreateNewItem()
+{
+	MCWin32RawClipboardItem *t_item;
+	t_item = MCWin32RawClipboardCommon::CreateNewItem();
+
+	if (t_item == NULL)
+		return NULL;
+
+	// fetch data object and push it to the clipboard
+	IDataObject * t_contents = t_item->GetDataObject();
+	OleSetClipboard(t_contents);
+
+	return t_item;
+}
+
 bool MCWin32RawClipboardNull::IsOwned() const
 {
 	// This clipboard is non-functional
@@ -801,9 +816,6 @@ MCWin32RawClipboardItem::MCWin32RawClipboardItem(MCWin32RawClipboardCommon* p_cl
 	m_object(nullptr),
 	m_reps()
 {
-	// create data object and push it to the clipboard
-	IDataObject * t_contents = GetDataObject();
-	OleSetClipboard(t_contents);
 }
 
 MCWin32RawClipboardItem::~MCWin32RawClipboardItem()

--- a/engine/src/w32-clipboard.h
+++ b/engine/src/w32-clipboard.h
@@ -177,6 +177,7 @@ public:
 	virtual bool PushUpdates();
 	virtual bool PullUpdates();
 	virtual bool FlushData();
+	virtual MCWin32RawClipboardItem* CreateNewItem();
 
 	MCWin32RawClipboard();
 };


### PR DESCRIPTION
This patch fixes issue 22508, where setting the dragdata on Windows would result in any data on the clipboard being cleared.