### PR TITLE
[[ Bug 22543 ]] Ensure multiple queued requests are handled correctly

### DIFF
--- a/extensions/widgets/browser/notes/22543.md
+++ b/extensions/widgets/browser/notes/22543.md
@@ -1,0 +1,1 @@
+# [22543] Fix display of "file://" urls for documents within an iOS app's private folder

--- a/libbrowser/src/libbrowser_wkwebview.h
+++ b/libbrowser/src/libbrowser_wkwebview.h
@@ -54,6 +54,10 @@ public:
 
 	void SyncJavaScriptHandlers();
 
+public:
+	// return the webview used by the browser class
+	bool GetWebView(WKWebView *&r_view);
+
 protected:
 	bool GetUrl(char *& r_url);
 	
@@ -99,7 +103,6 @@ protected:
 	bool SetMediaPlaybackRequiresUserAction(bool p_value);
 
 private:
-	bool GetWebView(WKWebView *&r_view);
 	bool GetContainerView(UIView *&r_view);
 	
 	bool Reconfigure(void);


### PR DESCRIPTION
This patch delays load requests sent to a WKWebView if there is on ongoing
request, waiting until that request has finished before making the new request.

This fixes an issue on iOS where the WebKit subprocess would be blocked from
reading HTML files within an app's sandboxed documents folder if multiple
requests are made without waiting for the previous request to begin.