### PR TITLE
[[ Bug 22612]] Allow detection of "Apple Distribution" certificates

### DIFF
--- a/docs/notes/bugfix-22612.md
+++ b/docs/notes/bugfix-22612.md
@@ -1,0 +1,1 @@
+# Allow detection of "Apple Distribution" certificates

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1916,7 +1916,10 @@ private function revGetMobileProfileInfo pProfileId
    
    repeat for each element tCert in tCerts
       put the base64Decode of tCert into tCert
-      if tCert contains "Distribution" then
+      if tCert contains "Apple Distribution:" then
+         put true into tIsDist
+         get offset("Apple Distribution:", tCert)
+      else if tCert contains "iPhone Distribution:" then
          put true into tIsDist
          get offset("iPhone Distribution:", tCert)
       else if tCert Contains "iOS Development:" then


### PR DESCRIPTION
Apple now allows devs to create an `Apple Distribution` certificate - which is valid for all i-platforms.

The S/B was only searching for `iPhone Distribution` certificates. This patch includes `Apple Distribution` to the types of certificates that are valid.

Closes https://quality.livecode.com/show_bug.cgi?id=22612