### PR TITLE
[[ Bug 22614 ]] Resync mouse focus when control opacity changes

### DIFF
--- a/docs/notes/bugfix-22614.md
+++ b/docs/notes/bugfix-22614.md
@@ -1,0 +1,1 @@
+# Ensure focused control is correct when opacity of control under mouse pointer changes

--- a/engine/src/exec-interface-graphic.cpp
+++ b/engine/src/exec-interface-graphic.cpp
@@ -653,6 +653,7 @@ void MCGraphic::SetFilled(MCExecContext& ctxt, bool setting)
     }
 	if (changeflag(setting, F_OPAQUE))
 	{
+		sync_mfocus(false, false);
 		Redraw();
 	}
 }

--- a/engine/src/exec-interface-group.cpp
+++ b/engine/src/exec-interface-group.cpp
@@ -805,3 +805,13 @@ void MCGroup::SetVisible(MCExecContext &ctxt, uinteger_t part, bool setting)
 {
 	MCControl::SetVisible(ctxt, part, setting);
 }
+
+void MCGroup::SetOpaque(MCExecContext &ctxt, bool setting)
+{
+	if (changeflag(setting, F_OPAQUE))
+	{
+		sync_mfocus(false, false);
+		MCObject::Redraw();
+		m_layer_attr_changed = true;
+	}
+}

--- a/engine/src/exec-interface-object.cpp
+++ b/engine/src/exec-interface-object.cpp
@@ -3185,7 +3185,7 @@ void MCObject::SetVisible(MCExecContext& ctxt, uint32_t part, bool setting)
     
 	if (dirty)
         // AL-2015-06-30: [[ Bug 15556 ]] Use refactored function to sync mouse focus
-        sync_mfocus();
+        sync_mfocus(true, true);
 }
 
 void MCObject::GetVisible(MCExecContext& ctxt, uint32_t part, bool& r_setting)
@@ -3741,20 +3741,16 @@ void MCObject::SetRectProp(MCExecContext& ctxt, bool p_effective, MCRectangle p_
 
 	if (!MCU_equal_rect(t_rect, rect))
 	{
-		bool needmfocus;
-		needmfocus = false;
-
-		if (opened && getstack() == MCmousestackptr)
+		bool t_sync_mouse = false;
+		if (MCU_point_in_rect(rect, MCmousex, MCmousey))
 		{
-			MCControl *mfocused = MCmousestackptr->getcard()->getmfocused();
-			if (MCU_point_in_rect(rect, MCmousex, MCmousey))
-			{
-				if (!MCU_point_in_rect(t_rect, MCmousex, MCmousey) && isancestorof(mfocused))
-					needmfocus = true;
-			}
-			else
-				if (MCU_point_in_rect(t_rect, MCmousex, MCmousey) && isancestorof(mfocused))
-					needmfocus = true;
+			if (!MCU_point_in_rect(t_rect, MCmousex, MCmousey))
+				t_sync_mouse = true;
+		}
+		else
+		{
+			if (MCU_point_in_rect(t_rect, MCmousex, MCmousey))
+				t_sync_mouse = true;
 		}
 
 		if (gettype() >= CT_GROUP)
@@ -3767,8 +3763,8 @@ void MCObject::SetRectProp(MCExecContext& ctxt, bool p_effective, MCRectangle p_
 		else
 			setrect(t_rect);
 
-		if (needmfocus)
-			MCmousestackptr->getcard()->mfocus(MCmousex, MCmousey);
+		if (t_sync_mouse)
+			sync_mfocus(false, false);
 	}
 }
 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -3176,7 +3176,7 @@ void MCInterfaceExecCreateControl(MCExecContext& ctxt, MCStringRef p_new_name, i
 		t_object->setstringprop(ctxt, 0, P_NAME, False, p_new_name);
 
     // AL-2015-06-30: [[ Bug 15556 ]] Ensure mouse focus is synced after creating object
-    t_object -> sync_mfocus();
+    t_object -> sync_mfocus(false, true);
     
 	MCAutoValueRef t_id;
 	t_object->names(P_LONG_ID, &t_id);
@@ -3213,7 +3213,7 @@ void MCInterfaceExecCreateWidget(MCExecContext& ctxt, MCStringRef p_new_name, MC
         t_widget->setstringprop(ctxt, 0, P_NAME, False, p_new_name);
     
     // AL-2015-06-30: [[ Bug 15556 ]] Ensure mouse focus is synced after creating object
-    t_widget -> sync_mfocus();
+    t_widget -> sync_mfocus(false, true);
     
     MCAutoValueRef t_id;
     t_widget->names(P_LONG_ID, &t_id);

--- a/engine/src/group.h
+++ b/engine/src/group.h
@@ -319,8 +319,9 @@ public:
     void SetClipsToRect(MCExecContext& ctxt, bool p_clips_to_rect);
     void GetClipsToRect(MCExecContext& ctxt, bool &r_clips_to_rect);
 
-    void SetVisible(MCExecContext& ctxt, uinteger_t part, bool setting);
-    
+	virtual void SetVisible(MCExecContext& ctxt, uinteger_t part, bool setting);
+	virtual void SetOpaque(MCExecContext& ctxt, bool setting);
+	
 	virtual void SetEnabled(MCExecContext& ctxt, uint32_t part, bool setting);
 	virtual void SetDisabled(MCExecContext& ctxt, uint32_t part, bool setting);
     virtual void SetShowBorder(MCExecContext& ctxt, bool setting);

--- a/engine/src/object.cpp
+++ b/engine/src/object.cpp
@@ -5259,7 +5259,7 @@ uint32_t MCObject::getminimumstackfileversion(void)
 }
 
 // AL-2015-06-30: [[ Bug 15556 ]] Refactored function to sync mouse focus
-void MCObject::sync_mfocus(void)
+void MCObject::sync_mfocus(bool p_visiblility_changed, bool p_resize_parent)
 {
     bool needmfocus;
     needmfocus = false;
@@ -5278,17 +5278,21 @@ void MCObject::sync_mfocus(void)
         else if (MCU_point_in_rect(rect, MCmousex, MCmousey))
             needmfocus = true;
     }
-    
-    if (state & CS_KFOCUSED)
-        getcard(0)->kunfocus();
-    
-    // MW-2008-08-04: [[ Bug 7094 ]] If we change the visibility of the control
-    //   while its grabbed, we should ungrab it - otherwise it sticks to the
-    //   cursor.
-    if (gettype() >= CT_GROUP && getstate(CS_GRAB))
-        state &= ~CS_GRAB;
-    
-    resizeparent();
+	
+	if (p_visiblility_changed)
+	{
+		if (state & CS_KFOCUSED)
+			getcard(0)->kunfocus();
+		
+		// MW-2008-08-04: [[ Bug 7094 ]] If we change the visibility of the control
+		//   while its grabbed, we should ungrab it - otherwise it sticks to the
+		//   cursor.
+		if (gettype() >= CT_GROUP && getstate(CS_GRAB))
+			state &= ~CS_GRAB;
+	}
+	
+	if (p_resize_parent)
+		resizeparent();
     
     if (needmfocus)
         MCmousestackptr->getcard()->mfocus(MCmousex, MCmousey);

--- a/engine/src/object.h
+++ b/engine/src/object.h
@@ -1205,7 +1205,7 @@ public:
     bool is_rtl() const { return false; }
     
     // AL-2015-06-30: [[ Bug 15556 ]] Refactored function to sync mouse focus
-    void sync_mfocus(void);
+	void sync_mfocus(bool p_visiblility_changed, bool p_resize_parent);
     
     // This accessor is used by the widget event manager to trigger tooltip
     // display for widgets.


### PR DESCRIPTION
A change in a control's opacity can cause a change in the control
which should have the mouse focus - for example the currently
focused control may become transparent so that focus transfers to
any control underneath, or a control on a higher layer than the
focused control may become opaque and take the mouse focus.

This patch ensures that the mouse focus is resynced whenever any
control's opacity changes, so that a subsequent mouse event has
the correct target.

Closes https://quality.livecode.com/show_bug.cgi?id=22614