### PR TITLE
[[ Bug 22615 ]] Fix build error when barcode scanner is included

### DIFF
--- a/docs/notes/bugfix-22615.md
+++ b/docs/notes/bugfix-22615.md
@@ -1,0 +1,1 @@
+# Fix error when building an Android standalone if the Barcode Scanner widget is included

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1837,7 +1837,11 @@ command MergeManifestArray @xManifestArrayA, pAdditionalsA
                   into tExistingA
             put tData["@attributes"] into tNewA
             repeat for each line tKey in the keys of tNewA
-               put tNewA[tKey] after tExistingA[tKey]
+               // do not merge the "theme", "name" and "exported" attributes
+               if tKey is "android:theme" or tKey is "android:name" or tKey is "android:exported" then
+                  next repeat
+               end if
+               put tNewA[tKey] into tExistingA[tKey]
             end repeat
             put tExistingA into xManifestArrayA[tActivityIndex]["@attributes"]
             break


### PR DESCRIPTION
When a barcode scanner is included, the manifest merging functionality of the S/B is used. This patch ensures that the attributes `android:theme`,  `android:name` and `android:exported` of the _original_ manifest will not be overwritten by the ones of the additional manifest of the components needed for the barcode scanner support.

Closes https://quality.livecode.com/show_bug.cgi?id=22615