### PR TITLE
[[ Bug 22616 ]] Fix incorrect placement of native layers within moved group

### DIFF
--- a/docs/notes/bugfix-22616.md
+++ b/docs/notes/bugfix-22616.md
@@ -1,0 +1,1 @@
+# Fixed browser widget within a group on Android appearing in an incorrect position after moving the group

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -991,6 +991,12 @@ void MCGroup::applyrect(const MCRectangle &nrect)
 			vscroll(-scrolly, False);
 			int2 dx = rect.x - nrect.x;
 			int2 dy = rect.y - nrect.y;
+			
+			/* Make sure we update the group rect before the child controls. This
+			 * is to ensure any native layers can fetch the correct rect to compute
+			 * their relative location. */
+			rect = nrect;
+			
 			MCControl *cptr = controls;
 			do
 			{
@@ -1005,7 +1011,6 @@ void MCGroup::applyrect(const MCRectangle &nrect)
 			while (cptr != controls);
 			minrect.x -= dx;
 			minrect.y -= dy;
-			rect = nrect;
 			setsbrects();
 			hscroll(oldx, False);
 			vscroll(oldy, False);


### PR DESCRIPTION
This patch fixes bug 22616, where the native layer of a widget within a group
would be offset incorrectly from the parent layer when the group was moved.

This is due to position calculations being based on the rect of the parent
group, which was not updated until after the native layer of the widget was
repositioned, so the new position of the layer was based on the old position
of its container rather than the updated position.

Closes https://quality.livecode.com/show_bug.cgi?id=22616