### PR TITLE
[[ Build ]] Rename assert type enum entries

### DIFF
--- a/engine/src/cmds.cpp
+++ b/engine/src/cmds.cpp
@@ -1580,23 +1580,23 @@ Parse_stat MCAssertCmd::parse(MCScriptPoint& sp)
 	// See if there is a type token
 	MCScriptPoint temp_sp(sp);
 	if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_TRUE) == PS_NORMAL)
-		m_type = TYPE_TRUE;
+		m_type = ASSERT_TYPE_TRUE;
 	else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_FALSE) == PS_NORMAL)
-		m_type = TYPE_FALSE;
+		m_type = ASSERT_TYPE_FALSE;
 	else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_SUCCESS) == PS_NORMAL)
-		m_type = TYPE_SUCCESS;
+		m_type = ASSERT_TYPE_SUCCESS;
 	else if (sp . skip_token(SP_SUGAR, TT_UNDEFINED, SG_FAILURE) == PS_NORMAL)
-		m_type = TYPE_FAILURE;
+		m_type = ASSERT_TYPE_FAILURE;
 	else
-		m_type = TYPE_NONE;
+		m_type = ASSERT_TYPE_NONE;
 	
 	// Now try to parse an expression
 	if (sp.parseexp(False, True, &m_expr) == PS_NORMAL)
 		return PS_NORMAL;
 
 	// Now if we are not of NONE type, then backup and try for just an
-	// expression (TYPE_NONE).
-	if (m_type != TYPE_NONE)
+	// expression (ASSERT_TYPE_NONE).
+	if (m_type != ASSERT_TYPE_NONE)
 	{
 		MCperror -> clear();
 		sp = temp_sp;
@@ -1604,7 +1604,7 @@ Parse_stat MCAssertCmd::parse(MCScriptPoint& sp)
 	
 	// Parse the expression again (if not NONE, otherwise we already have
 	// a badexpr error to report).
-	if (m_type == TYPE_NONE ||
+	if (m_type == ASSERT_TYPE_NONE ||
 		sp.parseexp(False, True, &m_expr) != PS_NORMAL)
 	{
 		MCperror -> add(PE_ASSERT_BADEXPR, sp);
@@ -1612,7 +1612,7 @@ Parse_stat MCAssertCmd::parse(MCScriptPoint& sp)
 	}
 	
 	// We must be of type none.
-	m_type = TYPE_NONE;
+	m_type = ASSERT_TYPE_NONE;
 	
 	return PS_NORMAL;
 }

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -37,7 +37,7 @@ class MCAssertCmd: public MCStatement
 public:
 	MCAssertCmd(void)
 	{
-		m_type = TYPE_NONE;
+		m_type = ASSERT_TYPE_NONE;
 		m_expr = nil;
 	}
 	

--- a/engine/src/exec-debugging.cpp
+++ b/engine/src/exec-debugging.cpp
@@ -392,8 +392,8 @@ void MCDebuggingExecAssert(MCExecContext& ctxt, int type, bool p_eval_success, b
 {
     switch(type)
 	{
-		case TYPE_NONE:
-		case TYPE_TRUE:
+		case ASSERT_TYPE_NONE:
+		case ASSERT_TYPE_TRUE:
 			// If the expression threw an error, then just throw.
 			if (!p_eval_success)
             {
@@ -406,7 +406,7 @@ void MCDebuggingExecAssert(MCExecContext& ctxt, int type, bool p_eval_success, b
 				return;
             break;
             
-		case TYPE_FALSE:
+		case ASSERT_TYPE_FALSE:
 			// If the expression threw an error, then just throw.
 			if (!p_eval_success)
             {
@@ -419,12 +419,12 @@ void MCDebuggingExecAssert(MCExecContext& ctxt, int type, bool p_eval_success, b
 				return;
             break;
             
-		case TYPE_SUCCESS:
+		case ASSERT_TYPE_SUCCESS:
 			if (p_eval_success)
 				return;
 			break;
             
-		case TYPE_FAILURE:
+		case ASSERT_TYPE_FAILURE:
 			if (!p_eval_success)
 				return;
 			break;

--- a/engine/src/parsedef.h
+++ b/engine/src/parsedef.h
@@ -79,11 +79,11 @@ enum Ask_type {
 };
 
 enum Assert_type {
-    TYPE_NONE,
-    TYPE_TRUE,
-    TYPE_FALSE,
-    TYPE_SUCCESS,
-    TYPE_FAILURE,
+    ASSERT_TYPE_NONE,
+    ASSERT_TYPE_TRUE,
+    ASSERT_TYPE_FALSE,
+    ASSERT_TYPE_SUCCESS,
+    ASSERT_TYPE_FAILURE,
 };
 
 inline Chunk_term ct_class(Chunk_term src)


### PR DESCRIPTION
This patch renames the entries of the Assert_type enumeration, adding the
'ASSERT_' prefix to give a more meaningful name and to avoid conflicts with
values from other enumerations

*Note* Fixes a compiler error when building with Xcode 11.3.1:
'Declaration shadows a variable in the global namespace'