### PR TITLE
[[ Bug 22619 ]] Fix crash where listener param is null

### DIFF
--- a/docs/lcb/notes/22619.md
+++ b/docs/lcb/notes/22619.md
@@ -1,0 +1,4 @@
+# LiveCode Builder Language
+## Android Listener support
+
+# [19973] A `null` listener parameter no longer causes a crash. 

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -517,12 +517,20 @@ static bool __MCJavaProperListFromJObjectArray(jobjectArray p_obj_array, MCPrope
         MCJavaAutoLocalRef<jobject> t_object =
             s_env -> GetObjectArrayElement(p_obj_array, i);
         
-        MCAutoJavaObjectRef t_obj;
-        if (!MCJavaObjectCreate(t_object, &t_obj))
-            return false;
+        if (t_object != nullptr)
+        {
+            MCAutoJavaObjectRef t_obj;
+            if (!MCJavaObjectCreate(t_object, &t_obj))
+                return false;
 
-        if (!MCProperListPushElementOntoBack(*t_list, *t_obj))
-            return false;
+            if (!MCProperListPushElementOntoBack(*t_list, *t_obj))
+                return false;
+        }
+        else
+        {
+            if (!MCProperListPushElementOntoBack(*t_list, kMCNull))
+                return false;
+        }
     }
     
     return MCProperListCopy(*t_list, r_list);


### PR DESCRIPTION
This patch fixes an issue where if a listener method is called where one of
the parameters is `null` a crash would occur.

`__MCJavaProperListFromJObjectArray` is currently only called from
`MCJavaPrivateDoNativeListenerCallback` where the `JObjectArray` is the
function args.

Closes https://quality.livecode.com/show_bug.cgi?id=22619