### PR TITLE
[[ Bug ]] Fix error when installing app to simulator

### DIFF
--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -39,8 +39,6 @@
 	</dict>
 	<key>UIRequiresPersistentWiFi</key>
 		${PERSISTENT_WIFI}
-	<key>UIApplicationExitsOnSuspend</key>
-		${APPLICATION_EXITS_ON_SUSPEND}
 	<key>UIInitialInterfaceOrientation</key>
 		${IPHONE_INITIAL_ORIENTATION}
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
The simulator plist template still contained the string `${APPLICATION_EXITS_ON_SUSPEND}`, which is no longer replaced by the S/B, resulting in a malformed plist and thus failure to install the app in the simulator.