### PR TITLE
[[ Bug 22603 ]] Correctly translate popup location to global location

### DIFF
--- a/docs/lcb/notes/22603.md
+++ b/docs/lcb/notes/22603.md
@@ -1,0 +1,7 @@
+# LiveCode Builder Host Library
+
+## Widget library
+
+The `popup widget` command now correctly positions the widget.
+
+# [22603] The `popup widget` command incorrectly positions the popped up widget

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -432,7 +432,7 @@ extern "C" MC_DLLEXPORT_DEF MCValueRef MCWidgetExecPopupAtLocationWithProperties
     }
     
     MCPoint t_at;
-	t_at = t_host->getstack()->globaltostackloc(MCGPointToMCPoint(MCWidgetMapPointToGlobal(MCcurrentwidget, t_point)));
+	t_at = t_host->getstack()->stacktogloballoc(MCGPointToMCPoint(MCWidgetMapPointToGlobal(MCcurrentwidget, t_point)));
     
 	MCNewAutoNameRef t_kind;
 	/* UNCHECKED */ MCNameCreate(p_kind, &t_kind);


### PR DESCRIPTION
This patch fixes the translation of the location parameter of the popup widget
command into global coordinates. The unfortunately named `MCWidgetMapPointToGlobal`
function actually returns a point relative to the host stack. This then needs
translation from stack to global loc rather than the previous global to stack
loc.