### PR TITLE
[[ Build ]] Make use of thirdparty prebuilts optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -152,6 +152,7 @@ def process_env_options(opts):
         'AR', 'CC', 'CXX', 'LINK', 'OBJCOPY', 'OBJDUMP',
         'STRIP', 'JAVA_SDK', 'NODE_JS', 'BUILD_EDITION', 'CC_PREFIX', 'CROSS',
         'SYSROOT', 'AUX_SYSROOT', 'TRIPLE', 'MS_SPEECH_SDK5', 'QUICKTIME_SDK',
+        'BUILD_THIRDPARTY',
         )
     for v in vars:
         opts[v] = os.getenv(v)
@@ -719,6 +720,9 @@ def core_gyp_args(opts):
     args.append('-Dbuild_edition=' + opts['BUILD_EDITION'])
 
     args.append('-Duniform_arch=' + opts['UNIFORM_ARCH'])
+
+    if opts['BUILD_THIRDPARTY'] is not None:
+        args.append('-Duse_prebuilt_thirdparty=0')
 
     return args
 

--- a/config/thirdparty.gypi
+++ b/config/thirdparty.gypi
@@ -21,5 +21,7 @@
 		'use_system_libxslt%':		0,
 		'use_system_libz%':		0,
 		'use_system_libzip%':		0,
+
+		'use_prebuilt_thirdparty%': 1,
 	},
 }

--- a/engine/kernel-development.gyp
+++ b/engine/kernel-development.gyp
@@ -50,7 +50,7 @@
 				'kernel.gyp:kernel',
 
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'sources':

--- a/engine/kernel-installer.gyp
+++ b/engine/kernel-installer.gyp
@@ -37,7 +37,7 @@
 			'dependencies':
 			[
 				'kernel.gyp:kernel',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'includes':

--- a/engine/kernel-server.gyp
+++ b/engine/kernel-server.gyp
@@ -57,12 +57,12 @@
 				'../prebuilt/libcurl.gyp:libcurl',
 				'../prebuilt/libopenssl.gyp:libopenssl',
 
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pcre',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
+				'../thirdparty/libpcre/libpcre.gyp:libpcre',
+				'../thirdparty/libjpeg/libjpeg.gyp:libjpeg',
+				'../thirdparty/libgif/libgif.gyp:libgif',
+				'../thirdparty/libpng/libpng.gyp:libpng',
 		
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libz/libz.gyp:libz',
 		
 				'engine-common.gyp:quicktime_stubs',
 				
@@ -94,7 +94,7 @@
 					{
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_cairo',
+							'../thirdparty/libcairo/libcairo.gyp:libcairo',
 						],
 
 						'defines':

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -24,12 +24,12 @@
 				
 				'../prebuilt/libopenssl.gyp:libopenssl_headers',
 
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pcre',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
+				'../thirdparty/libpcre/libpcre.gyp:libpcre',
+				'../thirdparty/libjpeg/libjpeg.gyp:libjpeg',
+				'../thirdparty/libgif/libgif.gyp:libgif',
+				'../thirdparty/libpng/libpng.gyp:libpng',
 
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libz/libz.gyp:libz',
 
 				'engine-common.gyp:encode_version',
 				'engine-common.gyp:quicktime_stubs',
@@ -79,9 +79,9 @@
 										
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_freetype',
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_harfbuzz',
+							'../thirdparty/libskia/libskia.gyp:libskia',
+							'../thirdparty/libfreetype/libfreetype.gyp:libfreetype',
+							'../thirdparty/libharfbuzz/libharfbuzz.gyp:libharfbuzz',
 						],
 
 						'link_settings':
@@ -109,7 +109,7 @@
 
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
+							'../thirdparty/libskia/libskia.gyp:libskia',
 						],
 					},
 				],

--- a/libfoundation/libfoundation.gyp
+++ b/libfoundation/libfoundation.gyp
@@ -47,7 +47,7 @@
 			[
 				'../prebuilt/libicu.gyp:libicu',
 				'../prebuilt/libicu.gyp:encode_minimal_icu_data',
-                '../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+                '../thirdparty/libz/libz.gyp:libz',
 				'../thirdparty/libffi/libffi.gyp:libffi',
 			],
 			

--- a/libgraphics/libgraphics.gyp
+++ b/libgraphics/libgraphics.gyp
@@ -14,10 +14,10 @@
 			
 			'dependencies':
 			[
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_gif',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_png',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_jpeg',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_skia',
+				'../thirdparty/libgif/libgif.gyp:libgif',
+				'../thirdparty/libpng/libpng.gyp:libpng',
+				'../thirdparty/libjpeg/libjpeg.gyp:libjpeg',
+				'../thirdparty/libskia/libskia.gyp:libskia',
 				'../libfoundation/libfoundation.gyp:libFoundation',
 			],
 
@@ -28,8 +28,8 @@
 					{
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_freetype',
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_harfbuzz',
+							'../thirdparty/libfreetype/libfreetype.gyp:libfreetype',
+							'../thirdparty/libharfbuzz/libharfbuzz.gyp:libharfbuzz',
 							'../prebuilt/libicu.gyp:libicu',
 						],
 					},

--- a/libscript/libscript.gyp
+++ b/libscript/libscript.gyp
@@ -48,7 +48,7 @@
 			'dependencies':
 			[
 				'../libfoundation/libfoundation.gyp:libFoundation',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../thirdparty/libffi/libffi.gyp:libffi',
 			],
 			
 			'include_dirs':

--- a/prebuilt/scripts/build-thirdparty.bat
+++ b/prebuilt/scripts/build-thirdparty.bat
@@ -45,6 +45,9 @@ IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 ECHO Configuring Thirdparty for %BUILDTRIPLE%
 ECHO ========== CONFIGURING ==========  >%THIRDPARTY_BUILD_LOG%
 
+REM Configure project files to build thirdparty libraries
+SET BUILD_THIRDPARTY=1
+
 REM Generate project files
 cd %_TOOLS_DIR%..
 python config.py --platform %BUILD_PLATFORM% >>%THIRDPARTY_BUILD_LOG% 2>>&1

--- a/prebuilt/scripts/build-thirdparty.sh
+++ b/prebuilt/scripts/build-thirdparty.sh
@@ -57,6 +57,9 @@ elif [ "$PLATFORM" == "win32" ]; then
 	LIBPATH=""
 fi
 
+# Configure project files to build thirdparty libraries
+export BUILD_THIRDPARTY=1
+
 make -C .. config-$MAKE_TARGET
 
 if [ "$PLATFORM" == "mac" ] || [ "$PLATFORM" == "ios" ] ; then

--- a/revdb/revdb.gyp
+++ b/revdb/revdb.gyp
@@ -98,7 +98,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_mysql',
+				'../thirdparty/libmysql/libmysql.gyp:libmysql',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
@@ -156,7 +156,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_mysql',
+				'../thirdparty/libmysql/libmysql.gyp:libmysql',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
@@ -223,7 +223,7 @@
 					{
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_iodbc',
+							'../thirdparty/libiodbc/libiodbc.gyp:libiodbc',
 						],
 					},
 					{
@@ -287,7 +287,7 @@
 					{
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_iodbc',
+							'../thirdparty/libiodbc/libiodbc.gyp:libiodbc',
 						],
 					},
 					{
@@ -360,7 +360,7 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pq',
+				'../thirdparty/libpq/libpq.gyp:libpq',
 			],
 			
 			'include_dirs':
@@ -405,7 +405,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_pq',
+				'../thirdparty/libpq/libpq.gyp:libpq',
 				'../thirdparty/libopenssl/libopenssl.gyp:libopenssl_stubs',
 			],
 			
@@ -467,7 +467,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_sqlite',
+				'../thirdparty/libsqlite/libsqlite.gyp:libsqlite',
 			],
 			
 			'include_dirs':
@@ -574,7 +574,7 @@
 			'dependencies':
 			[
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_sqlite',
+				'../thirdparty/libsqlite/libsqlite.gyp:libsqlite',
 			],
 			
 			'include_dirs':

--- a/revpdfprinter/revpdfprinter.gyp
+++ b/revpdfprinter/revpdfprinter.gyp
@@ -17,7 +17,7 @@
 			[
 				'../libcore/libcore.gyp:libCore',
 				'../libexternal/libexternal.gyp:libExternal',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_cairo',
+				'../thirdparty/libcairo/libcairo.gyp:libcairo',
 			],
 			
 			'include_dirs':
@@ -76,7 +76,7 @@
 
 						'dependencies':
 						[
-							'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_freetype',
+							'../thirdparty/libfreetype/libfreetype.gyp:libfreetype',
 						],
 					},
 				],

--- a/revxml/revxml.gyp
+++ b/revxml/revxml.gyp
@@ -30,9 +30,9 @@
             [
                 '../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xml',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xslt',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libxml/libxml.gyp:libxml',
+				'../thirdparty/libxslt/libxslt.gyp:libxslt',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'include_dirs':
@@ -80,9 +80,9 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xml',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_xslt',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libxml/libxml.gyp:libxml',
+				'../thirdparty/libxslt/libxslt.gyp:libxslt',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'include_dirs':

--- a/revzip/revzip.gyp
+++ b/revzip/revzip.gyp
@@ -25,8 +25,8 @@
 			[
 				'../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_zip',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libzip/libzip.gyp:libzip',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'sources':
@@ -77,8 +77,8 @@
 			[
                 '../libexternal/libexternal.gyp:libExternal',
                 '../libexternal/libexternal.gyp:libExternal-symbol-exports',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_zip',
-				'../prebuilt/thirdparty.gyp:thirdparty_prebuilt_z',
+				'../thirdparty/libzip/libzip.gyp:libzip',
+				'../thirdparty/libz/libz.gyp:libz',
 			],
 			
 			'sources':

--- a/toolchain/lc-compile-ffi-java/lc-compile-ffi-java.gyp
+++ b/toolchain/lc-compile-ffi-java/lc-compile-ffi-java.gyp
@@ -15,7 +15,7 @@
 			
 			'dependencies':
 			[
-				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../../thirdparty/libffi/libffi.gyp:libffi',
 			],
 
 			'conditions':

--- a/toolchain/lc-compile/lc-compile.gyp
+++ b/toolchain/lc-compile/lc-compile.gyp
@@ -15,7 +15,7 @@
 
 			'dependencies':
 			[
-				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../../thirdparty/libffi/libffi.gyp:libffi',
 			],
 			
 			'conditions':

--- a/toolchain/lc-compile/lc-run.gyp
+++ b/toolchain/lc-compile/lc-run.gyp
@@ -19,7 +19,7 @@
 				'../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../libscript/libscript.gyp:libScript',
 				'../../libscript/libscript.gyp:stdscript',
-				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../../thirdparty/libffi/libffi.gyp:libffi',
 			],
 			
 			'sources':

--- a/toolchain/lc-compile/src/lc-compile-lib.gyp
+++ b/toolchain/lc-compile/src/lc-compile-lib.gyp
@@ -20,7 +20,7 @@
 				'../../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../../libscript/libscript.gyp:libScript',
 				'../../libcompile/libcompile.gyp:libcompile',
-				'../../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../../../thirdparty/libffi/libffi.gyp:libffi',
 			],
 
 			'sources':

--- a/toolchain/libcompile/libcompile.gyp
+++ b/toolchain/libcompile/libcompile.gyp
@@ -18,7 +18,7 @@
 			[
 				'../../libfoundation/libfoundation.gyp:libFoundation',
 				'../../libscript/libscript.gyp:libScript',
-				'../../prebuilt/thirdparty.gyp:thirdparty_prebuilt_ffi',
+				'../../thirdparty/libffi/libffi.gyp:libffi',
 			],
 
 			'sources':


### PR DESCRIPTION
This PR allows the use of prebuilt thirdparty libraries to be determined by the 'BUILD_THIRDPARTY' environment variable. If this variable is set when configuring the build project files (i.e. with `make config-<platform>`) then rather than use the prebuilt thirdparty libraries these libraries will be compiled from source.

*Note* - depends on https://github.com/livecode/livecode-thirdparty/pull/142