### PR TITLE
[[ Bug 22623 ]] Add support for lcextd mobile external folder

### DIFF
--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -364,22 +364,27 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
          end if
          
          -- Only look for lcext files.
-         if the last item of tFile["name"] is not "lcext" then
-            next repeat
-         end if
+         switch the last item of tFile["name"]
+            case "lcext"
+               if there is no file tFile["resolved"] then
+                  throw "could not find referenced external -" && tFile["resolved"]
+               end if
+               if addExternalFromFile(tFile["resolved"], tClassesBuildFolder, tArchLibsBuildFolders) then
+                  -- Add the external to the list to load
+                  put char 1 to -7 of tFile["name"] & return after tExternals
+               end if
+               break
+            case "lcextd"
+               if there is no folder tFile["resolved"] then
+                  throw "could not find referenced external -" && tFile["resolved"]
+               end if
+               if addExternalFromFolder(tFile["resolved"], tClassesBuildFolder, tArchLibsBuildFolders) then
+                  -- Add the external to the list to load
+                  put char 1 to -8 of tFile["name"] & return after tExternals
+               end if
+               break
+         end switch 
          
-         -- Only process if the target exists
-         if there is no file tFile["resolved"] then
-            throw "could not find referenced external -" && tFile["resolved"]
-         end if
-         
-         -- MERG-2013-09-05: [[ Bug 11152 ]] Only list the external if it was successfully
-         --   extracted.
-         -- Now attempt to process the external
-         if addExternalFromFile(tFile["resolved"], tClassesBuildFolder, tArchLibsBuildFolders) then
-            -- Add the external to the list to load
-            put char 1 to -7 of tFile["name"] & return after tExternals
-         end if
       end repeat
       delete the last char of tExternals
       set the itemDelimiter to comma
@@ -1448,6 +1453,63 @@ private function addExternalFromFile pExternal, pClassesFolder, pArchLibsFolders
    
    return tLibFileA is an array
 end addExternalFromFile
+
+private function addExternalFromFolder pExternal, pClassesFolder, pArchLibsFolders
+   -- Get the name of the external.
+   local tExternalName
+   set the itemDelimiter to slash
+   get the last item of pExternal
+   set the itemDelimiter to "."
+   put the first item of it into tExternalName
+   set the itemDelimiter to slash
+   
+   -- Compute the class / lib names.
+   local tClassesFile, tLibFileA
+   put pClassesFolder & slash & "lib" & tExternalName & ".jar" into tClassesFile
+   
+   local tItems
+   put files(pExternal & "/Android") into tItems
+   
+   local tItemsFiltered
+   filter tItems with regex pattern ".*(\.jar|Classes)$" into tItemsFiltered
+   repeat for each line tItem in tItemsFiltered
+      if tItem ends with ".jar" then
+         revSBCopyFile pExternal & "/Android/" & tItem, \
+               pClassesFolder & slash & the last item of tItem 
+      else 
+         # will be Classes file
+         revSBCopyFile pExternal & "/Android/" & tItem, \
+               tClassesFile
+      end if
+   end repeat
+   
+   repeat for each key tArch in pArchLibsFolders
+      local tPattern
+      put "^(?:External-" & tArch & "|lib.+" & tArch & "\.so)$" into tPattern
+      filter tItems with regex pattern tPattern into tItemsFiltered
+      put pArchLibsFolders[tArch] & slash & "lib" & tExternalName & ".so" into tLibFileA[tArch]
+      repeat for each line tItem in tItemsFiltered
+         if tItem ends with ".so" then
+            revSBCopyFile pExternal & "/Android/" & tItem, \
+                  pClassesFolder & slash & the last item of tItem 
+         else 
+            # will be External-<Arch> file
+            revSBCopyFile pExternal & "/Android/" & tItem, \
+                  tLibFileA[tArch]
+         end if
+      end repeat
+   end repeat
+   
+   if there is a file tClassesFile then
+      repeat for each key tArch in pArchLibsFolders
+         if there is no file tLibFileA[tArch] then
+            throw "android external contains classes but no library for " & tArch
+         end if
+      end repeat
+   end if
+   
+   return tLibFileA is an array
+end addExternalFromFolder
 
 ################################################################################
 

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1139,7 +1139,7 @@ private command addToManifest pFile, pName, pAppBundle, @xManifest, @xRedirects
       exit addToManifest
    end if
    
-   if there is a file pFile then
+   if there is a file pFile or there is a folder pFile and pFile ends with ".lcextd" then
       put pAppBundle & slash & pName & tab & pFile & return after xManifest
       put pName & "//" & pFile & return after xRedirects
    else if there is a folder pFile then
@@ -1229,6 +1229,45 @@ private command revCopyMobileFiles pSettings, pBaseFolder, pAppBundle, pAppTarge
       -- If the file is an entitlement then handle appropriately
       if tSource ends with ".xcent" then
          put url ("binfile:" & tSource) after rCustomEntitlements
+         next repeat
+      end if
+      
+      if there is a folder tSource and tSource ends with ".lcextd" then
+         if tProcessedDylibs[tSource] then
+            next repeat
+         end if
+         
+         put true into tProcessedDylibs[tSource]
+         set the itemDel to slash
+         local tName
+         put char 1 to -8 of the last item of tSource into tName
+         
+         if pSDKs["sim"]["suffix"] is not empty then
+            put tSource & "/iOS/External-Simulator-" & pSDKs["sim"]["suffix"] into tTarget
+            if there is a file tTarget then
+               put tTarget into rExternals[tName]["sim"]
+               put "external" into rExternals[tName]["type"]
+               
+               -- Since simulator externals are not statically linked to the engine, we need to make sure the location
+               -- of the external is set correctlty relative to the app bundle, so the deploy command knows what to
+               -- dynamically link to.
+               --
+               put char (the number of chars in pAppBundle + 2) to -1 of tTarget into rExternals[tName]["location"]
+            end if
+         else
+            put "external" into rExternals[tName]["type"]        
+            repeat for each word tInstSet in "armv6 armv7 arm64 arm"
+               if pSDKs[tInstSet]["suffix"] is not empty then
+                  put tSource & "/iOS/External-Device-" & pSDKs[tInstSet]["suffix"] into tTarget
+                  if there is a file tTarget then
+                     put tTarget into rExternals[tName][tInstSet]
+                     put tName & ".lcext" into rExternals[tName]["location"]
+                  end if
+               end if             
+            end repeat
+         end if
+         set the itemDel to tab
+         
          next repeat
       end if
       

--- a/ide-support/revsblibrary.livecodescript
+++ b/ide-support/revsblibrary.livecodescript
@@ -1530,10 +1530,14 @@ function revSBLcextFileIsMobileExternal pFile, pPlatform
 end revSBLcextFileIsMobileExternal
 
 private function __FilterExternalsForMobile pList, pPlatform
-   filter pList with "*.lcext"
+   local tLcext
+   filter pList with "*.lcext" into tLcext
+   
+   local tLcextd
+   filter pList with "*.lcextd/" into tLcextd
    
    local tList, tError
-   repeat for each line tLine in pList
+   repeat for each line tLine in tLcext
       -- look inside the lcext zip to see if the platform is supported (in any architecture)
       if revSBLcextFileIsMobileExternal(tLine, pPlatform) then
          if tList is empty then
@@ -1543,6 +1547,18 @@ private function __FilterExternalsForMobile pList, pPlatform
          end if
       end if
    end repeat
+   
+   repeat for each line tLine in tLcextd
+      if there is a folder (tLine & pPlatform) then
+         delete the last char of tLine
+         if tList is empty then
+            put tLine into tList
+         else
+            put return & tLine after tList
+         end if
+      end if
+   end repeat
+   
    return tList
 end __FilterExternalsForMobile
 


### PR DESCRIPTION
This patch adds support for mobile externals to be included in the Ext folder
as a lcextd folder structure that mirrors the lcext archive structure. This
is to allow signing iOS object files for notarization.