### PR TITLE
[[ Bug 22606 ]] Support opting out of iOS dark mode

### DIFF
--- a/docs/notes/bugfix-22606.md
+++ b/docs/notes/bugfix-22606.md
@@ -1,0 +1,1 @@
+# Add support for opting out of iOS dark mode

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -134,5 +134,6 @@
 	<array>
 		${APP_URL_WHITELIST}
 	</array>
+	${UI_STYLE}
 </dict>
 </plist>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -95,5 +95,6 @@
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
 	${HEALTHKIT}
+	${UI_STYLE}
 </dict>
 </plist>

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1550,7 +1550,12 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
          revStandaloneAddWarning "No iPad supported intial orientation.  Assuming Portrait."
          put "Portrait" into tIPadOrientations
       end if
-   end if 
+   end if
+
+   local tUIStyle
+   if not pSettings["ios,supports dark mode"] then
+      put "<key>UIUserInterfaceStyle</key><string>Light</string>" into tUIStyle
+   end if
    
    -- MM-2011-09-28: Make sure portrait and landscape iPad splashes are present if required.
    --
@@ -1620,6 +1625,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    replace "${CUSTOM_FONTS}" with tCustomFonts in pPlist
    replace "${DISABLE_ATS}" with tDisableATS in pPlist
    replace "${HEALTHKIT}" with tHealthKit in pPlist
+   replace "${UI_STYLE}" with tUIStyle in pPlist
    
    -- PM-2018-01-15: [[Bug 20852]] Get info about Xcode/SDK versions
    if pTarget is "Device" then


### PR DESCRIPTION
This patch adds support for using the `UIUserInterfaceStyle` plist entry
to opt out of dark mode support. This is required for apps compiled against
iOS 13.0 and up if they do not support dark mode as the system automatically
opts in.

IDE PR for checkbox on standalone settings forthcoming