### PR TITLE
[[ 22635 ]] Remove unsupported Android minimum deployment versions

### DIFF
--- a/docs/notes/bugfix-22635.md
+++ b/docs/notes/bugfix-22635.md
@@ -1,0 +1,1 @@
+# Removed unsupported minimum deployment versions from the Android standalone settings

--- a/ide-support/revdeploylibraryandroid.livecodescript
+++ b/ide-support/revdeploylibraryandroid.livecodescript
@@ -283,10 +283,6 @@ end deployGetJDK
 
 function deployGetVersionsMap
    local tMap
-   put "4.1 - Jelly Bean" into tMap[16]
-   put "4.2" into tMap[17]
-   put "4.3" into tMap[18]
-   put "4.4 - KitKat" into tMap[19]
    put "5.0 - Lollipop" into tMap[21]
    put "5.1" into tMap[22]
    put "6.0 - Marshmallow" into tMap[23]

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -89,7 +89,7 @@ private function updateMinimumAPI pVersionSet, pLimit
    
    answer "The minimum Android API is currently set to" && \
          pVersionSet && \
-         "but the" & tLimitType & " Android API available from LiveCode" && the version && \
+         "but the" && tLimitType & " Android API available from LiveCode" && the version && \
          "is" && pLimit & "." & LF & \
          "Do you want to update the minimum Android API to" && pLimit & "?" \
          with "No" or "Yes" \
@@ -588,9 +588,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       //  Otherwise the app restarts on orientation change.
       local tConfigChangesProp
       put "keyboardHidden|orientation" into tConfigChangesProp
-      if pSettings["android,minimum version"] > 12 then
-         put "|screenSize" after tConfigChangesProp
-      end if
+      put "|screenSize" after tConfigChangesProp
       replace "${CONFIG_CHANGES}" with tConfigChangesProp in tManifest
       
       // SN-2015-09-30: [[ Bug 10267 ]] Hardware Acceleration option added
@@ -893,7 +891,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       -- Stackfile to use
       put the effective filename of stack pStack into tDeploy["stackfile"]
       
-       -- Splash to use (if non-commercial)
+      -- Splash to use (if non-commercial)
       if line 3 of the revLicenseInfo is among the words of "Educational Personal" then
          -- MW-2011-03-17: Make sure absolute paths work correctly
          if pSettings["android,splash"] is not empty and pathIsRelative(pSettings["android,splash"]) then


### PR DESCRIPTION
Closes https://quality.livecode.com/show_bug.cgi?id=22635

The android engines are compiled with `--api 21` thus the minimum supported Android version is now API 21 (Android 5.0).

Note that if an existing stack has the minimum Android version set to something that was removed by this patch, this is not a problem.

The S/B will present an dialog informing the user about the new minimum Android version supported, and ask them if they want to update their existing minimum Android version (see `updateMinimumAPI`)