### PR TITLE
[[ Bug 22487 ]] Audit engine for iOS dark mode issues

### DIFF
--- a/docs/notes/bugfix-22487.md
+++ b/docs/notes/bugfix-22487.md
@@ -1,0 +1,1 @@
+# mobilePick, mobilePickDate and ask dialog on iOS now use the correct colors in dark mode.

--- a/engine/src/mbliphonedialog.mm
+++ b/engine/src/mbliphonedialog.mm
@@ -268,8 +268,7 @@ int32_t MCScreenDC::popupanswerdialog(MCStringRef p_buttons[], uint32_t p_button
 		
 		t_textField.alpha = 0.75;
 		t_textField.borderStyle = UITextBorderStyleBezel;
-		t_textField.backgroundColor = [UIColor whiteColor];
-        
+
 		m_textResult = t_textField;
 		
 		// set up the input mode, either password or not
@@ -496,9 +495,7 @@ static void dopopupaskdialog_prewait(void *p_context)
         [t_alert_controller addTextFieldWithConfigurationHandler: ^(UITextField *p_text_field)
          {
              [p_text_field setAlpha: 0.75];
-             //[p_text_field setBorderStyle: UITextBorderStyleBezel];
-             [p_text_field setBackgroundColor: [UIColor whiteColor]];
-             
+			
              if (ctxt -> type == AT_PASSWORD)
                  [p_text_field setSecureTextEntry: YES];
              else

--- a/engine/src/mbliphonepick.mm
+++ b/engine/src/mbliphonepick.mm
@@ -570,7 +570,14 @@ return 1;
 
             [m_action_sheet_view addSubview: t_toolbar];
             [m_action_sheet_view addSubview: pickerView];
-            m_action_sheet_view.backgroundColor = [UIColor whiteColor];
+			if ([UIColor respondsToSelector:@selector(secondarySystemBackgroundColor)])
+			{
+				m_action_sheet_view.backgroundColor = [UIColor secondarySystemBackgroundColor];
+			}
+			else
+			{
+				m_action_sheet_view.backgroundColor = [UIColor whiteColor];
+			}
             [t_toolbar release];
 
             [MCIPhoneGetView() addSubview:m_action_sheet_view];

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -349,8 +349,15 @@ UIViewController *MCIPhoneGetViewController(void);
             
             [m_action_sheet_view addSubview: t_toolbar];
             [m_action_sheet_view addSubview: datePicker];
-            m_action_sheet_view.backgroundColor = [UIColor whiteColor];
-            [t_toolbar release];
+			if ([UIColor respondsToSelector:@selector(secondarySystemBackgroundColor)])
+			{
+				m_action_sheet_view.backgroundColor = [UIColor secondarySystemBackgroundColor];
+			}
+			else
+			{
+				m_action_sheet_view.backgroundColor = [UIColor whiteColor];
+			}
+			[t_toolbar release];
             
             [MCIPhoneGetView() addSubview:m_action_sheet_view];
             


### PR DESCRIPTION
This patch fixes a number of issues in iOS dark mode caused by using explicit
white backgrounds and default text color. The text appears un-rendered because
it is white on white in dark mode.