### PR TITLE
[[ Bug 22645 ]] Add NSBluetoothAlwaysUsageDescription to iOS plist

### DIFF
--- a/docs/notes/bugfix-22645.md
+++ b/docs/notes/bugfix-22645.md
@@ -1,0 +1,1 @@
+# Add NSBluetoothAlwaysUsageDescription to iOS plist template

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -129,6 +129,8 @@
 	<string>This application requires access to Photo Library</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This application requires access to Bluetooth always</string>
 	${HEALTHKIT}
 	<key>LSApplicationQueriesSchemes</key>
 	<array>

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -94,6 +94,8 @@
 	<string>This application requires access to Photo Library</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This application requires access to Photo Library</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This application requires access to Bluetooth always</string>
 	${HEALTHKIT}
 </dict>
 </plist>

--- a/engine/rsrc/standalone-mobile-Info.plist
+++ b/engine/rsrc/standalone-mobile-Info.plist
@@ -72,5 +72,7 @@
 	<string>This application requires access to Location Services when in use</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>This application requires access to Location Services always</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This application requires access to Bluetooth always</string>
 </dict>
 </plist>


### PR DESCRIPTION
This patch adds the `NSBluetoothAlwaysUsageDescription` key and value to the
iOS template plist. If this key does not exist the application will crash
on iOS 13 when using bluetooth functions.