### PR TITLE
[22054] Ensure mobilePickPhoto() proceeds after taking a photo

### DIFF
--- a/docs/notes/bugfix-22054.md
+++ b/docs/notes/bugfix-22054.md
@@ -1,0 +1,1 @@
+# Ensure mobilePickPhoto() proceeds after taking a photo on Samsung phones

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2146,7 +2146,7 @@ public class Engine extends View implements EngineApi
 		String t_path = m_temp_image_file.getPath();
 
 		Uri t_uri;
-		t_uri = FileProvider.getProvider(getContext()).addPath(t_path, t_path, "image/jpeg", true, ParcelFileDescriptor.MODE_WRITE_ONLY);
+		t_uri = FileProvider.getProvider(getContext()).addPath(t_path, t_path, "image/jpeg", true, ParcelFileDescriptor.MODE_READ_WRITE);
 
 		Intent t_image_capture = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 		t_image_capture.putExtra(MediaStore.EXTRA_OUTPUT, t_uri);


### PR DESCRIPTION
On some Samsung devices,` mobilePickPhoto` did not proceed after taking a photo using the device camera. This happened because the temp file where the photo would be stored until the user accepts it could not be created due to insufficient permissions. This patch ensures the appropriate permissions are set so as `mobilePickPhoto` works as expected on all Android devices.

Tested in:
- Samsung M20 (previously affected by this bug - works fine with this patch)
- Samsung Galaxy S9 (not affected for me - but affected for other users - still works with this patch

Also tested in the following devices, where `mobilePickPhoto` did work fine, and continues to work fine with this patch:

- Google Pixel
- Google Pixel XL
- Google Pixel2 XL
- Samsung J5
- Samsung A3