### PR TITLE
[22634] Fix scaling of mobilePick menus when device is on landscape

### DIFF
--- a/docs/notes/bugfix-22634.md
+++ b/docs/notes/bugfix-22634.md
@@ -1,0 +1,1 @@
+# Ensure mobilePick and mobilePickDate menus scale correctly on landscape orientation

--- a/engine/src/mbliphonepick.mm
+++ b/engine/src/mbliphonepick.mm
@@ -503,10 +503,14 @@ return 1;
 		// make a toolbar
         // MM-2012-10-15: [[ Bug 10463 ]] Make the picker scale to the width of the device rather than a hard coded value (fixes issue with landscape iPhone 5 being 568 not 480).
 		UIToolbar *t_toolbar;
-		t_toolbar = [[UIToolbar alloc] initWithFrame: (t_is_landscape ? CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . height, t_toolbar_landscape_height) : CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_portrait_height))];
+        
+        if (t_is_landscape)
+            t_toolbar = [[UIToolbar alloc] initWithFrame: CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_landscape_height)];
+        else
+            t_toolbar = [[UIToolbar alloc] initWithFrame: CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_portrait_height)];
+        
 		t_toolbar.barStyle = UIBarStyleBlack;
 		t_toolbar.translucent = YES;
-
 		[t_toolbar sizeToFit];
 
 		NSMutableArray *t_toolbar_items;
@@ -562,7 +566,7 @@ return 1;
             }
             else
             {
-                [pickerView setFrame:CGRectMake(0, t_toolbar_landscape_height, [[UIScreen mainScreen] bounds] . size . height, t_pick_wheel_height)];
+                [pickerView setFrame:CGRectMake(0, t_toolbar_landscape_height, [[UIScreen mainScreen] bounds] . size . width, t_pick_wheel_height)];
                 t_rect = CGRectMake(0, [[UIScreen mainScreen] bounds] . size . height - t_toolbar_landscape_height - t_pick_wheel_height, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_landscape_height + t_pick_wheel_height);
             }
             

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -283,7 +283,12 @@ UIViewController *MCIPhoneGetViewController(void);
 		// make a toolbar
         // MM-2012-10-15: [[ Bug 10463 ]] Make the picker scale to the width of the device rather than a hard coded value (fixes issue with landscape iPhone 5 being 568 not 480).
 		UIToolbar *t_toolbar;
-        t_toolbar = [[UIToolbar alloc] initWithFrame: (t_is_landscape ? CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . height, t_toolbar_landscape_height) : CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_portrait_height))];
+        
+        if (t_is_landscape)
+            t_toolbar = [[UIToolbar alloc] initWithFrame: (CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_landscape_height))];
+        else
+            t_toolbar = [[UIToolbar alloc] initWithFrame: (CGRectMake(0, 0, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_portrait_height))];
+        
 		t_toolbar.barStyle = UIBarStyleBlack;
 		t_toolbar.translucent = YES;
 		[t_toolbar sizeToFit];
@@ -341,7 +346,7 @@ UIViewController *MCIPhoneGetViewController(void);
             }
             else
             {
-                [datePicker setFrame:CGRectMake(0, t_toolbar_landscape_height, [[UIScreen mainScreen] bounds] . size . height, t_pick_wheel_height)];
+                [datePicker setFrame:CGRectMake(0, t_toolbar_landscape_height, [[UIScreen mainScreen] bounds] . size . width, t_pick_wheel_height)];
                 t_rect = CGRectMake(0, [[UIScreen mainScreen] bounds] . size . height - t_toolbar_landscape_height - t_pick_wheel_height, [[UIScreen mainScreen] bounds] . size . width, t_toolbar_landscape_height + t_pick_wheel_height);
             }
             


### PR DESCRIPTION
This patch ensures mobilePick and mobilePickDate menus use the full width of the screen when the device is on landscape orientation.

Closes https://quality.livecode.com/show_bug.cgi?id=22634

