### PR TITLE
[[ mergExt ]] Update pointer

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2020-1-13"
+constant kMergExtVersion = "2020-4-2"
 constant kTSNetVersion = "1.4.1"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer to include builds against iOS SDK 13.4