### PR TITLE
[[ Bug 22607 ]] Fix missing header

### DIFF
--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -55,6 +55,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "resolution.h"
 
+#include <objc/message.h>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 extern void X_main_loop(void);


### PR DESCRIPTION
This patch includes `objc/message.h` to resolve an undeclared identifier error
on `objc_msgSend`.