### PR TITLE
[[ Bug 22668 ]] Fix bug preventing JS execution in Android browser

### DIFF
--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -1707,6 +1707,28 @@ static void MCAndroidEngineCallThreadCallback(void *p_context)
 			t_env -> DeleteLocalRef(t_java_string);
 		}
 		break;
+		case kMCJavaTypeUtf8CString:
+		{
+			jstring t_java_string;
+			if (context->is_static)
+				t_java_string = (jstring)t_env -> CallStaticObjectMethodA(t_class, t_method_id, t_params->params);
+			else
+				t_java_string = (jstring)t_env -> CallObjectMethodA(context->object, t_method_id, t_params->params);
+			if (t_cleanup_java_refs && t_env -> ExceptionCheck())
+			{
+				t_exception_thrown = true;
+				t_success = false;
+			}
+
+            char *t_utf8_string = nil;
+			if (t_success)
+                t_success = MCJavaStringToUTF8(t_env, t_java_string, t_utf8_string);
+            if (t_success)
+                *(char **)(context -> return_value) = t_utf8_string;
+
+			t_env -> DeleteLocalRef(t_java_string);
+		}
+		break;
 		case kMCJavaTypeMCString:
 			{
 				jstring t_java_string;

--- a/engine/src/mblandroidjava.cpp
+++ b/engine/src/mblandroidjava.cpp
@@ -605,6 +605,41 @@ bool MCJavaStringToNative(JNIEnv *env, jstring p_java_string, char *&r_native)
     return t_success;
 }
 
+bool MCJavaStringToUTF8(JNIEnv *env, jstring p_java_string, char *&r_utf_8)
+{
+    bool t_success = true;
+    
+    const jchar *t_unicode_string = nil;
+    int t_unicode_length = 0;
+    char *t_utf8 = nil;
+    int t_utf8_length;
+    
+    if (p_java_string != nil)
+        t_unicode_string = env -> GetStringChars(p_java_string, NULL);
+    
+    if (t_unicode_string != nil)
+    {
+        t_unicode_length = env -> GetStringLength(p_java_string);
+
+        t_utf8_length = UnicodeToUTF8(t_unicode_string, t_unicode_length * 2, nil, 0);
+
+        t_success = MCMemoryAllocate(t_utf8_length + 1, t_utf8);
+
+        if (t_success)
+        {
+            UnicodeToUTF8(t_unicode_string, t_unicode_length * 2, t_utf8, t_utf8_length);
+            t_utf8[t_utf8_length] = 0;
+        }
+
+        env -> ReleaseStringChars(p_java_string, t_unicode_string);
+    }
+    
+    if (t_success)
+        r_utf_8 = t_utf8;
+    
+    return t_success;
+}
+
 //////////
 
 bool MCJavaStringFromStringRef(JNIEnv *env, MCStringRef p_string, jstring &r_java_string)

--- a/engine/src/mblandroidjava.h
+++ b/engine/src/mblandroidjava.h
@@ -75,6 +75,7 @@ bool MCJavaStringFromNative(JNIEnv *env, const MCString *p_string, jstring &r_ja
 bool MCJavaStringFromUnicode(JNIEnv *env, const MCString *p_string, jstring &r_java_string);
 bool MCJavaStringToUnicode(JNIEnv *env, jstring p_java_string, unichar_t *&r_unicode, uint32_t &r_length);
 bool MCJavaStringToNative(JNIEnv *env, jstring p_java_string, char *&r_native);
+bool MCJavaStringToUTF8(JNIEnv *env, jstring p_java_string, char *&r_utf_8);
 bool MCJavaStringToStringRef(JNIEnv *env, jstring p_java_string, MCStringRef& r_stringref);
 bool MCJavaStringFromStringRef(JNIEnv *env, MCStringRef p_string, jstring &r_java_string);
 bool MCJavaByteArrayFromDataRef(JNIEnv *env, MCDataRef p_data, jbyteArray &r_byte_array);

--- a/extensions/widgets/browser/notes/22668.md
+++ b/extensions/widgets/browser/notes/22668.md
@@ -1,0 +1,1 @@
+# [22668] Fix bug preventing javascript being run from LiveCode script in the Android browser widget


### PR DESCRIPTION
This patch fixes a bug in the Android browser implementation - the signature
used to invoke the Java LibBrowserWebView.executeJavaScript used the char 't'
to signify a return type of java string converted to utf8-encoded c-string,
however as this conversion is unsupported the method call would fail.

The bug has been fixed by adding support for utf8 c-string return values from Java method calls.