### PR TITLE
WIP: [[ Bugfix 21305 ]] Improve performance of stackfile saving on Windows

### DIFF
--- a/docs/notes/bugfix-21305.md
+++ b/docs/notes/bugfix-21305.md
@@ -1,0 +1,2 @@
+# Improve performance of stackfile saving on Windows
+

--- a/engine/src/dsklnx.cpp
+++ b/engine/src/dsklnx.cpp
@@ -1179,7 +1179,7 @@ public:
         const char *t_mode;
         if (p_mode == kMCOpenFileModeRead)
             t_mode = IO_READ_MODE;
-        else if (p_mode == kMCOpenFileModeWrite)
+        else if (p_mode == kMCOpenFileModeWrite || p_mode == kMCOpenFileModeBufferedWrite)
             t_mode = IO_WRITE_MODE;
         else if (p_mode == kMCOpenFileModeUpdate)
             t_mode = IO_UPDATE_MODE;
@@ -1212,6 +1212,7 @@ public:
             t_fptr = fdopen(p_fd, IO_READ_MODE);
             break;
         case kMCOpenFileModeWrite:
+		case kMCOpenFileModeBufferedWrite:
             t_fptr = fdopen(p_fd, IO_WRITE_MODE);
             break;
         case kMCOpenFileModeUpdate:
@@ -1244,7 +1245,7 @@ public:
 
         if (p_mode == kMCOpenFileModeRead)
             t_fptr = fopen(*t_path_sys, IO_READ_MODE);
-        else if (p_mode == kMCOpenFileModeWrite)
+        else if (p_mode == kMCOpenFileModeWrite || p_mode == kMCOpenFileModeBufferedWrite)
             t_fptr = fopen(*t_path_sys, IO_WRITE_MODE);
         else if (p_mode == kMCOpenFileModeUpdate)
             t_fptr = fopen(*t_path_sys, IO_UPDATE_MODE);

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -3960,6 +3960,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
                     fptr = fopen(*t_path_utf, IO_APPEND_MODE);
                     break;
                 case kMCOpenFileModeWrite:
+				case kMCOpenFileModeBufferedWrite:
                     fptr = fopen(*t_path_utf, IO_WRITE_MODE);
                     break;
                 default:
@@ -3996,6 +3997,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
                 t_stream = fdopen(p_fd, IO_UPDATE_MODE);
                 break;
             case kMCOpenFileModeWrite:
+			case kMCOpenFileModeBufferedWrite:
                 t_stream = fdopen(p_fd, IO_WRITE_MODE);
                 break;
             default:
@@ -4006,7 +4008,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 			return NULL;
 		
 		// MH-2007-05-17: [[Bug 3196]] Opening the write pipe to a process should not be buffered.
-        if (p_mode == kMCOpenFileModeWrite)
+        if (p_mode == kMCOpenFileModeWrite || p_mode == kMCOpenFileModeBufferedWrite)
 			setvbuf(t_stream, NULL, _IONBF, 0);
 		
 		IO_handle t_handle;
@@ -4041,6 +4043,7 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
                 fptr = fopen(*t_path_utf, IO_UPDATE_MODE);
                 break;
             case kMCOpenFileModeWrite:
+			case kMCOpenFileModeBufferedWrite:
                 fptr = fopen(*t_path_utf, IO_WRITE_MODE);
                 break;
             default:

--- a/engine/src/em-system.cpp
+++ b/engine/src/em-system.cpp
@@ -759,6 +759,7 @@ MCEmscriptenSystem::OpenFile(MCStringRef p_path,
 		t_open_flags = O_RDONLY;
 		break;
 	case kMCOpenFileModeWrite:
+	case kMCOpenFileModeBufferedWrite:
 		t_open_flags = O_WRONLY | O_TRUNC | O_CREAT;
 		break;
 	case kMCOpenFileModeUpdate:

--- a/engine/src/mblandroidio.cpp
+++ b/engine/src/mblandroidio.cpp
@@ -258,6 +258,7 @@ IO_handle MCAndroidSystem::OpenFile(MCStringRef p_path, intenum_t p_mode, Boolea
         t_mode = 0;
         break;
     case kMCOpenFileModeWrite:
+	case kMCOpenFileModeBufferedWrite:
         t_mode = 1;
         break;
     case kMCOpenFileModeUpdate:

--- a/engine/src/mbliphone.mm
+++ b/engine/src/mbliphone.mm
@@ -600,6 +600,7 @@ IO_handle MCIPhoneSystem::OpenFile(MCStringRef p_path, intenum_t p_mode, Boolean
         t_mode = 0;
         break;
     case kMCOpenFileModeWrite:
+	case kMCOpenFileModeBufferedWrite:
         t_mode = 1;
         break;
     case kMCOpenFileModeUpdate:

--- a/engine/src/mcio.h
+++ b/engine/src/mcio.h
@@ -51,6 +51,7 @@ enum MCOpenFileMode
 {
     kMCOpenFileModeRead,
     kMCOpenFileModeWrite,
+	kMCOpenFileModeBufferedWrite,
     kMCOpenFileModeUpdate,
     kMCOpenFileModeAppend,
     kMCOpenFileModeCreate,


### PR DESCRIPTION
The patch adds a simple write buffer to the Win32 `MCStdioFileHandle` implementation. As serializing stacks usually involves a very large number of 1, 2 and 4 byte writes, the buffer vastly reduces the number of `WriteFile` Win32 API calls which are made.

In order to ensure there aren't any problems with saving stackfiles if the write buffer does not flush on close, a call to `MCS_flush` has been added to the stackfile serialization code after the last terminating byte is written. This ensures that the original stackfile will not be removed until it is certain that the new stackfile is fully written.

Note: The lack of a flush in the above case is actually a long standing 'hole' in stackfile saving. Whilst Windows did not have a engine-side write buffer, the `CloseHandle` API call could still fail, and the other platforms all used stdio FILE handles underneath which could also fail on `fclose`.