### PR TITLE
[[ Bug 22671 ]] Fix mobile player controller visibility

### DIFF
--- a/docs/notes/bugfix-22671.md
+++ b/docs/notes/bugfix-22671.md
@@ -1,0 +1,1 @@
+# Ensure Android mobile player controller is not visible when the control is not visible

--- a/engine/src/java/com/runrev/android/nativecontrol/VideoControl.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/VideoControl.java
@@ -159,7 +159,10 @@ public class VideoControl extends NativeControl
     public void setShowController(boolean show)
     {
         if (show)
+		{
             m_video_view.setMediaController(m_video_controller);
+			m_video_view.setControllerVisible(getVisible());
+		}
         else
             m_video_view.setMediaController(null);
     }


### PR DESCRIPTION
This patch ensures that the mobile player controller is not visible when the
mobile player is invisible. This fixes an issue where setting the showController
property to true would show the controller regardless of the visibility of the
player.