### PR TITLE
[[ Bug 22673 ]] Show first frame in Android player

### DIFF
--- a/docs/notes/bugfix-22673.md
+++ b/docs/notes/bugfix-22673.md
@@ -1,0 +1,1 @@
+# Show first frame in Android mobile player after loading file

--- a/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
@@ -395,9 +395,7 @@ public class ExtVideoView extends SurfaceView implements MediaPlayerControl {
             mVideoHeight = mp.getVideoHeight();
 
             int seekToPosition = mSeekWhenPrepared;  // mSeekWhenPrepared may be changed after seekTo() call
-            if (seekToPosition != 0) {
-                seekTo(seekToPosition);
-            }
+            seekTo(seekToPosition);
             // IM-2014-02-25: [[ Bug 11753 ]] don't set looping here as this seems to put
             // the player into an error state
             /* CODE REMOVED */


### PR DESCRIPTION
This patch ensures that a seek to position 0 is done after loading a file
in the Android mobile player. This resolves an issue where the first frame
is not being rendered after loading a file.