### PR TITLE
[[ Bug 22663 ]] Support max width/height in Android mobilePickPhoto

### DIFF
--- a/docs/dictionary/command/mobilePickPhoto.lcdoc
+++ b/docs/dictionary/command/mobilePickPhoto.lcdoc
@@ -62,10 +62,9 @@ the command returns with result cancel. Otherwise a new image object is
 created on the current card of the default stack containing the chosen
 image. 
 
-The <maxwidth> and <maxheight> parameters are only available on iOS
-devices and constrain the maximum size of an image. The chosen image is
-scaled down proportionally to fit within the size specified. If either
-size specified is 0, then the parameter is ignored.
+The <maxwidth> and <maxheight> parameters constrain the maximum size of an
+image. The chosen image is scaled down proportionally to fit within the size
+specified. If either size specified is 0, then the parameter is ignored.
 
 >*Note:* The image object is cloned from the <templateImage>, so you can
 > use this to configure settings before calling the picker.

--- a/docs/notes/bugfix-22663.md
+++ b/docs/notes/bugfix-22663.md
@@ -1,0 +1,1 @@
+# Add support for max width and max height parameters to mobilePickPhoto on Android

--- a/engine/src/mblandroidcamera.cpp
+++ b/engine/src/mblandroidcamera.cpp
@@ -86,7 +86,7 @@ bool MCAndroidPickPhoto(const char *p_source, int32_t p_max_width, int32_t p_max
     if (!MCAndroidCheckRuntimePermission(MCSTR("android.permission.CAMERA")))
         return false;
     
-    MCAndroidEngineCall("showPhotoPicker", "vsii", nil, p_source, p_max_width, p_max_height);
+    MCAndroidEngineCall("showPhotoPicker", "vsiii", nil, p_source, p_max_width, p_max_height, MCjpegquality);
     // SN-2014-09-03: [[ Bug 13329 ]] MCAndroidPickPhoto's return value is ignored in 6.x,
     // but not in 7.0 - whence the failure in mobilePickPhoto
     return true;


### PR DESCRIPTION
This patch adds support for the max width and height parameters for
`mobilePickPhoto` on android. A previous patch added some support, however, the
behavior was quite different to iOS and the documentation was not updated.

Closes https://quality.livecode.com/show_bug.cgi?id=22663