### PR TITLE
[[ Bug 22684 ]] Fix mobileSensorReading("location",false) returning empty list

### DIFF
--- a/docs/notes/bugfix-22684.md
+++ b/docs/notes/bugfix-22684.md
@@ -1,0 +1,1 @@
+# Ensure mobileSensorReading("location",false) returns a non-empty list

--- a/engine/src/exec-sensor.cpp
+++ b/engine/src/exec-sensor.cpp
@@ -205,24 +205,22 @@ void MCSensorGetLocationOfDevice(MCExecContext& ctxt, MCStringRef &r_location)
         t_success = t_location.MakeMutable();
         if (t_success)
         {
-            if (!isfinite(t_reading.latitude))
+            if (isfinite(t_reading.latitude))
                 t_success = MCStringAppendFormat(*t_location, "%lf,", t_reading.latitude);
             else
                 t_success = MCStringAppendChar(*t_location, ',');
         }
         if (t_success)
         {
-            if (!isfinite(t_reading.longitude))
+            if (isfinite(t_reading.longitude))
                 t_success = MCStringAppendFormat(*t_location, "%lf,", t_reading.longitude);
             else
                 t_success = MCStringAppendChar(*t_location, ',');
         }
         if (t_success)
         {
-            if (!isfinite(t_reading.altitude))
-                t_success = MCStringAppendFormat(*t_location, "%lf,", t_reading.altitude);
-            else
-                t_success = MCStringAppendChar(*t_location, ',');
+            if (isfinite(t_reading.altitude))
+                t_success = MCStringAppendFormat(*t_location, "%lf", t_reading.altitude);
         }
         
         if (t_success)


### PR DESCRIPTION
This patch fixes a logical error that resulted in the `mobileSensorReading("location",false)` command to return an empty list.

Closes https://quality.livecode.com/show_bug.cgi?id=22684