### PR TITLE
[Bugfix-22686] Correct parameter in playerPropertyAvailable example

### DIFF
--- a/docs/dictionary/message/playerPropertyAvailable.lcdoc
+++ b/docs/dictionary/message/playerPropertyAvailable.lcdoc
@@ -16,7 +16,7 @@ Platforms: mobile
 
 Example:
 on playerPropertyAvailable pPropertyName
-    if theProperty is "duration" then
+    if pPropertyName is "duration" then
         answer "You can now query the length of the movie"
     end if
 end playerPropertyAvailable

--- a/docs/notes/bugfix-22686.md
+++ b/docs/notes/bugfix-22686.md
@@ -1,0 +1,1 @@
+# Corrected example in playerPropertyAvailable


### PR DESCRIPTION
Changed a variable name used in the code example to match the parameter name it is supposed to be.