### PR TITLE
[[ Bug 22688 ]] Fix bug preventing mobile browser control from loading after setting the "url" property to empty

### DIFF
--- a/extensions/widgets/browser/notes/22688.md
+++ b/extensions/widgets/browser/notes/22688.md
@@ -1,0 +1,1 @@
+# [22688] Fix bug preventing mobile browser control from loading after setting the "url" property to empty


### PR DESCRIPTION
This patch fixes bug 22688, where setting the url of a mobile browser control to empty would prevent subsequent url requests from loading.

Closes https://quality.livecode.com/show_bug.cgi?id=22688