### PR TITLE
[[ Bug 22693 ]] Fix url callbacks sent when setting html in CEF browser

### DIFF
--- a/extensions/widgets/browser/notes/22693.md
+++ b/extensions/widgets/browser/notes/22693.md
@@ -1,0 +1,3 @@
+# [22693] Fix bug that caused url progress messages to be sent when setting the htmltext of the browser on Windows & Linux
+
+This bug under certain conditions could result in the url property being set to an incorrect value when saving the stack as a standalone.


### PR DESCRIPTION
This patch fixes bug 22693, where url progress messages were being sent while setting the html text of a browser widget. This could sometimes result in an incorrect url property value being assigned while saving as a standalone.

Closes https://quality.livecode.com/show_bug.cgi?id=22693