### PR TITLE
[Bugfix-22433] Correct selectionChanged for missing text

### DIFF
--- a/docs/dictionary/message/selectionChanged.lcdoc
+++ b/docs/dictionary/message/selectionChanged.lcdoc
@@ -45,7 +45,7 @@ References: select (command), handler (glossary),
 insertion point (glossary), message (glossary), field (glossary),
 property (glossary), select (glossary), selection (keyword),
 field (keyword), player (keyword), currentTimeChanged (message),
-selectionChanged (message), selectedObjectChanged (message),
+selectedObjectChanged (message), textChanged (message), 
 arrowKey (message), player (object), selected (property),
 startTime (property), endTime (property)
 


### PR DESCRIPTION
Previous bugfix for 22433 had textChanged fail to display. Added to reference so that it will display.