### PR TITLE
[[ Bug 22700 ]] Fix crash on enter in android native field widget

### DIFF
--- a/extensions/widgets/androidfield/androidfield.lcb
+++ b/extensions/widgets/androidfield/androidfield.lcb
@@ -851,7 +851,7 @@ __safe foreign handler _JNI_TextWatcher_TextChangedListener(in pCallbacks as Arr
 __safe foreign handler _JNI_TextView_addTextChangedListener(in pObj as JObject, in pParam_watcher as JObject) returns nothing \
 	binds to "java:android.widget.TextView>addTextChangedListener(Landroid/text/TextWatcher;)V?ui"
 
-handler type EditorActionCallback(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject) returns JObject
+handler type EditorActionCallback(in pView as JObject, in pActionId as JObject, in pKeyEvent as optional JObject) returns JObject
 __safe foreign handler _JNI_View_OnEditorActionListener(in pHandler as EditorActionCallback) returns JObject \
    binds to "java:android.widget.TextView$OnEditorActionListener>interface()"
 __safe foreign handler _JNI_TextView_setOnEditorActionListener(in pObj as JObject, in pParam_listener as JObject) returns nothing \
@@ -1074,7 +1074,7 @@ __safe foreign handler _JNI_Boolean_False() returns JObject \
    binds to "java:java.lang.Boolean>get.FALSE()Ljava/lang/Boolean;!static"
 __safe foreign handler _JNI_Boolean_True() returns JObject \
    binds to "java:java.lang.Boolean>get.TRUE()Ljava/lang/Boolean;!static"
-handler OnEditorAction(in pView as JObject, in pActionId as JObject, in pKeyEvent as JObject) returns JObject
+handler OnEditorAction(in pView as JObject, in pActionId as JObject, in pKeyEvent as optional JObject) returns JObject
    post "returnKey"
 
    // Return value determines whether the return key event is eaten

--- a/extensions/widgets/androidfield/notes/22700.md
+++ b/extensions/widgets/androidfield/notes/22700.md
@@ -1,0 +1,1 @@
+# [22700] Fix a crash when pressing "Next" on the virtual keyboard while editing android native field contents


### PR DESCRIPTION
This patch fixes a crash caused by an error calling an LCB handler from Java
where a Java Object parameter may be nil but the handler does not declare
the parameter as optional.

Closes https://quality.livecode.com/show_bug.cgi?id=22700