### PR TITLE
[[ LifecycleListeners ]] Allow lcb widgets to register and listen for Android lifecycle events

### DIFF
--- a/extensions/modules/android-utils/android-utils.lcb
+++ b/extensions/modules/android-utils/android-utils.lcb
@@ -232,4 +232,109 @@ public handler AndroidHasPermission(in pPermission as String) returns Boolean
 	return tHasPermission
 end handler
 
+public handler type OnPauseHandler() returns nothing
+public handler type OnResumeHandler() returns nothing
+
+__safe foreign handler _JNI_Engine_LifecycleListener(in pListener as Array) returns JObject \
+    binds to "java:com.runrev.android.Engine$LifecycleListener>interface()"
+__safe foreign handler _JNI_Engine_RegisterLifecycleListener(in pSelf as JObject, in pListener as JObject) returns JBoolean \
+    binds to "java:com.runrev.android.Engine>registerLifecycleListener(Lcom/runrev/android/Engine$LifecycleListener;)Z"
+__safe foreign handler _JNI_Engine_UnregisterLifecycleListener(in pSelf as JObject, in pListener as JObject) returns JBoolean \
+    binds to "java:com.runrev.android.Engine>unregisterLifecycleListener(Lcom/runrev/android/Engine$LifecycleListener;)Z"
+
+/**
+Summary:
+Register handlers to be called when on application lifecycle events.
+
+Parameters:
+pPauseHandler: The handler to be called when the application is paused
+pResumeHandler: The handler to be called when the application is resumed
+
+Returns:
+A listener object that wraps the registered handlers.
+
+Example:
+private variable mLifecycleListener as optional JObject
+
+public handler OnOpen() returns nothing
+    put AndroidRegisterLifecycleListener(OnMyWidgetPaused, OnMyWidgetResumed) into mLifecycleListener
+end handler
+
+public handler OnClose() returns nothing
+    AndroidUnregisterLifecycleListener(mLifecycleListener)
+    put nothing into mLifecycleListener
+end handler
+
+private handler OnMyWidgetPaused() returns nothing
+    -- Perform pause actions
+end handler
+
+private handler OnMyWidgetResumed() returns nothing
+    -- Perform resume actions
+end handler
+
+Description:
+Use the <AndroidRegisterLifecycleListener> handler to register handlers to
+application lifecycle events. The handler <pPauseHandler> will be called when
+the application is paused and enters into the background. The handler
+<pResumeHandler> will be called when the application is resumed and returns from
+the background.
+
+A listener object will be returned that wraps the registered handlers and can be
+used with <AndroidUnregisterLifecycleListener> to cancel the registration.
+*/
+public handler AndroidRegisterLifecycleListener(in pPauseHandler as OnPauseHandler, in pResumeHandler as OnResumeHandler) returns JObject
+    variable tEngine as JObject
+    put _JNI_GetAndroidEngine() into tEngine
+
+    variable tLifecycleListenerHandler as Array
+    put { \
+        "OnPause": pPauseHandler, \
+        "OnResume": pResumeHandler \
+    } into tLifecycleListenerHandler
+
+    variable tLifecycleListener as JObject
+    put _JNI_Engine_LifecycleListener(tLifecycleListenerHandler) \
+        into tLifecycleListener
+
+    _JNI_Engine_RegisterLifecycleListener(tEngine, tLifecycleListener)
+    return tLifecycleListener
+end handler
+
+/**
+Summary:
+Unregister an object that is listening on application lifecycle events.
+
+Parameters:
+pListener: The listener object to be unregistered
+
+Returns:
+True if the listener object was previously registered and has been successfully
+unregistered.
+
+Example:
+private variable mLifecycleListener as optional JObject
+
+public handler OnOpen() returns nothing
+    put AndroidRegisterLifecycleListener(OnMyWidgetPaused, OnMyWidgetResumed) into mLifecycleListener
+end handler
+
+public handler OnClose() returns nothing
+    AndroidUnregisterLifecycleListener(mLifecycleListener)
+    put nothing into mLifecycleListener
+end handler
+
+Description:
+Use the <AndroidUnregisterLifecycleListener> handler to unregister an object
+created with <AndroidRegisterLifecycleListener> that is listening to application
+lifecycle events. This will have the effect that any handlers that the listener
+object is wrapping will no longer be called.
+*/
+public handler AndroidUnregisterLifecycleListener(in pListener as JObject) returns Boolean
+    variable tEngine as JObject
+    put _JNI_GetAndroidEngine() into tEngine
+
+    return _JNI_Engine_UnregisterLifecycleListener(tEngine, pListener)
+end handler
+
 end module

--- a/extensions/modules/android-utils/notes/feature-android_lifecycle_events.md
+++ b/extensions/modules/android-utils/notes/feature-android_lifecycle_events.md
@@ -1,0 +1,11 @@
+# Registering for lifecycle SensorEventListener
+
+A new handler `AndroidRegisterLifecycleListener` has been added that allows for
+widgets to track application lifecycle events, specifying handlers to be called
+when the application is paused or resumed. The first parameter is the handler to
+be called when the application is paused. The second parameter is the handler to
+be called when the application is resumed.
+
+The listener object returned by `AndroidRegisterLifecycleListener` can be
+unregistered by calling `AndroidUnregisterLifecycleListener`, meaning the pause
+and resume handlers will no longer be called.

--- a/ide-support/revdocsparser.livecodescript
+++ b/ide-support/revdocsparser.livecodescript
@@ -520,13 +520,20 @@ on revDocsExtractDocBlocks pText, pSource, @rAPIData, @rLibraryData
                break
             case "public"
                if word 2 of tLine is "handler" then
-                  put "handler" into tEntryData["type"]
-                  # eat the word 'public'
-                  put word 2 to -1 of tLine into tLine
-                  put token 2 of tLine into tEntryData["name"]
+                  if word 3 of tLine is "type" then
+                     put true into tEntryData["private"]
+                     put "type" into tEntryData["type"]
+                     put word 3 to -1 of tLine into tLine
+                     put true into tEntryEnded
+                  else
+                     put "handler" into tEntryData["type"]
+                     # eat the word 'public'
+                     put word 2 to -1 of tLine into tLine
+                     put token 2 of tLine into tEntryData["name"]
                   
-                  # If we have a widget, then public handlers are not in the message path and so don't need docs.
-                  put not tIsWidget into tEntryData["need_docs"]
+                     # If we have a widget, then public handlers are not in the message path and so don't need docs.
+                     put not tIsWidget into tEntryData["need_docs"]
+                  end if
                else 
                   put true into tEntryData["private"]
                   if word 2 of tLine is "foreign" then


### PR DESCRIPTION
This PR adds handlers to the android-utils module allowing lcb widgets to register for Android lifecycle events (at present these are pause and resume).

Note that we wrap the listener object in LiveCodeActivity.java, allowing for storage in a hash set. A possible alternative would be to use an index based container, with register returning the index of the listener in the container and unregister taking the index of the listener to unregister.