### PR TITLE
[[ Bug 22379 ]] Ignore foreign handler calling convention on 64-bit Windows

### DIFF
--- a/docs/lcb/notes/22379.md
+++ b/docs/lcb/notes/22379.md
@@ -1,0 +1,1 @@
+# [22379] Fix error calling foreign handlers with non-default calling convention on 64-bit Windows

--- a/libscript/src/script-instance.cpp
+++ b/libscript/src/script-instance.cpp
@@ -1267,10 +1267,10 @@ bool MCScriptForeignHandlerInfoParse(MCStringRef p_binding, MCScriptForeignHandl
         {
             t_info->thread_affinity = t_thread_affinity;
         
-            /* The ABI for all platforms is always DEFAULT, except on Win32 where
-             * it is specified as part of the signature. */
+            /* The ABI for all platforms is always DEFAULT, except on 32-bit Win32
+             * where it is specified as part of the signature. */
             t_info->c.call_type = (int)FFI_DEFAULT_ABI;
-#ifdef _WIN32
+#if defined(_WIN32) && defined(__32_BIT__)
             t_info->c.call_type = t_cc == 0 ? (int)FFI_DEFAULT_ABI : t_cc;
 #endif
             t_info->c.function = t_function.Take();


### PR DESCRIPTION
This patch fixes bug 22379, where calling a foreign handler on 64-bit windows would fail if the handler was declared with a non-default calling convention.

Closes https://quality.livecode.com/show_bug.cgi?id=22379