### PR TITLE
[[ Bug 22605 ]] Fix iOS dark launch image clobbering light image

### DIFF
--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -958,7 +958,8 @@ private command revDecorateImageAssets pTarget, pSettings, pBaseFolder, pAppBund
          set the itemdelimiter to comma
          
          local tFileName
-         put format("livecode_launch_image@%s.%s", \
+         put format("livecode_launch_image%s@%s.%s", \
+               tAppearance, \
                tScale, \
                tExtension) into tFileName
          


### PR DESCRIPTION
This patch fixes an issue where if a user sets a dark launch image for the same
scale as a light image the file will clobber the light image when copied to
the image set.