### PR TITLE
[[ Bugfix 21305 ]] Improve performance of stackfile saving on Windows

### DIFF
--- a/docs/notes/bugfix-21305.md
+++ b/docs/notes/bugfix-21305.md
@@ -1,0 +1,2 @@
+# Improve performance of stackfile saving on Windows
+

--- a/engine/src/w32dc.cpp
+++ b/engine/src/w32dc.cpp
@@ -84,6 +84,11 @@ MCScreenDC::MCScreenDC()
 	m_printer_dc = NULL;
 	m_printer_dc_locked = false;
 	m_printer_dc_changed = false;
+
+	/* Initialize metrics with sensible defaults. */
+	m_metrics_x_dpi = 96;
+	m_metrics_y_dpi = 96;
+	memset(&m_metrics_non_client, 0, sizeof(m_metrics_non_client));
 }
 
 MCScreenDC::~MCScreenDC()
@@ -289,28 +294,38 @@ MCStack *MCScreenDC::platform_getstackatpoint(int32_t x, int32_t y)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void *MCScreenDC::GetNativeWindowHandle(Window p_win)
+void MCScreenDC::updatemetrics(void)
 {
-	return p_win != nil ? p_win->handle.window : nil;
+	/* Get the DC representing the whole 'screen' so we can get default dpi
+	 * metrics from it. */
+	HDC t_dc;
+	t_dc = GetDC(NULL);
+	if (t_dc != NULL)
+	{
+		m_metrics_x_dpi = GetDeviceCaps(t_dc, LOGPIXELSX);
+		m_metrics_y_dpi = GetDeviceCaps(t_dc, LOGPIXELSY);
+		ReleaseDC(NULL, t_dc);
+	}
+	else
+	{
+		m_metrics_x_dpi = 96;
+		m_metrics_y_dpi = 96;
+	}
+
+	/* Fetch the 'non-client-metrics' which contains the names of fonts to use
+	 * which match the current system settings. */
+	m_metrics_non_client.cbSize = sizeof(m_metrics_non_client);
+	if (!SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(m_metrics_non_client), &m_metrics_non_client, 0))
+	{
+		memset(&m_metrics_non_client, 0, sizeof(m_metrics_non_client));
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-// IM-2014-01-28: [[ HiDPI ]] Return the x & y dpi of the main screen
-bool MCWin32GetScreenDPI(uint32_t &r_xdpi, uint32_t &r_ydpi)
+void *MCScreenDC::GetNativeWindowHandle(Window p_win)
 {
-	HDC t_dc;
-	t_dc = GetDC(NULL);
-
-	if (t_dc == NULL)
-		return false;
-
-	r_xdpi = GetDeviceCaps(t_dc, LOGPIXELSX);
-	r_ydpi = GetDeviceCaps(t_dc, LOGPIXELSY);
-
-	ReleaseDC(NULL, t_dc);
-
-	return true;
+	return p_win != nil ? p_win->handle.window : nil;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -329,7 +344,8 @@ MCGFloat MCWin32GetLogicalToScreenScale(void)
 		return 1.0;
 
 	uint32_t t_x, t_y;
-	/* UNCHECKED */ MCWin32GetScreenDPI(t_x, t_y);
+	t_x = ((MCScreenDC *)MCscreen)->getscreenxdpi();
+	t_y = ((MCScreenDC *)MCscreen)->getscreenydpi();
 
 	return (MCGFloat) MCMax(t_x, t_y) / NORMAL_DENSITY;
 }
@@ -348,12 +364,8 @@ bool MCWin32GetMonitorPixelScale(HMONITOR p_monitor, MCGFloat &r_pixel_scale)
 	if (!MCWin32GetDpiForMonitor(t_result, p_monitor, kMCWin32MDTDefault, &t_xdpi, &t_ydpi) ||
 		t_result != S_OK)
 	{
-		// fallback to the global system DPI setting
-		uint32_t t_screen_xdpi, t_screen_ydpi;
-		if (!MCWin32GetScreenDPI(t_screen_xdpi, t_screen_ydpi))
-			return false;
-		t_xdpi = t_screen_xdpi;
-		t_ydpi = t_screen_ydpi;
+		t_xdpi = ((MCScreenDC *)MCscreen)->getscreenxdpi();
+		t_ydpi = ((MCScreenDC *)MCscreen)->getscreenydpi();
 	}
 
 	r_pixel_scale = (MCGFloat)MCMax(t_xdpi, t_ydpi) / NORMAL_DENSITY;

--- a/engine/src/w32dc.h
+++ b/engine/src/w32dc.h
@@ -166,6 +166,10 @@ class MCScreenDC : public MCUIDC
     int m_main_window_depth = 0;
     HWND m_main_window_current = nullptr;
 
+	uint32_t m_metrics_x_dpi;
+	uint32_t m_metrics_y_dpi;
+	NONCLIENTMETRICSW m_metrics_non_client;
+
 protected:
 	static uint4 pen_inks[];
 	static uint4 image_inks[];
@@ -355,6 +359,10 @@ public:
 	void processdesktopchanged(bool p_notify = true, bool p_update_fonts = true);
 	void processtaskbarnotify(HWND hwnd, WPARAM wparam, LPARAM lparam);
 
+	uint32_t getscreenxdpi(void) const { return m_metrics_x_dpi; }
+	uint32_t getscreenydpi(void) const { return m_metrics_y_dpi; }
+	const NONCLIENTMETRICSW& getnonclientmetrics(void) const { return m_metrics_non_client; }
+
 	// These rountines convert a UTF-8 string into with a 'WIDE' or 'ANSI'
 	// string suitable for passing to a windows API W or A function. The
 	// caller is reponsible for freeing the returned string.
@@ -362,6 +370,10 @@ public:
 	static LPCSTR convertutf8toansi(const char *p_utf8_string);
 
 private:
+	/* Refetch any system metric information that may be changed by either a
+	 * WM_SETTINGCHANGE or WM_DISPALYCHANGE message. */
+	void updatemetrics(void);
+
 	bool initialisebackdrop(void);
 	void finalisebackdrop(void);
 };

--- a/engine/src/w32dcs.cpp
+++ b/engine/src/w32dcs.cpp
@@ -248,6 +248,10 @@ Boolean MCScreenDC::open()
 	MCdoubletime = GetDoubleClickTime();
 	opened++;
 
+	/* Fetch any system metrics we need which are updated on WM_SETTINGCHANGE or 
+	 * WM_DISPLAYCHANGE. */
+	updatemetrics();
+
 	MCDisplay const *t_displays;
 	getdisplays(t_displays, false);
 	MCwbr = t_displays[0] . workarea;
@@ -1127,6 +1131,9 @@ void MCScreenDC::processdesktopchanged(bool p_notify, bool p_update_fonts)
 	// IM-2014-01-28: [[ HiDPI ]] Use updatedisplayinfo() method to update & compare display details
 	bool t_changed;
 	t_changed = false;
+
+	/* Update any system metrics which are used often and are cached. */
+	updatemetrics();
 
 	updatedisplayinfo(t_changed);
 


### PR DESCRIPTION
This patch adds a cache of some critical system metrics which are used when writing field object content to a stackfile. Previously these metrics would be queried directly every time an `MCBlock` was serialized, they are now queried on startup and when a broadcast notification is received which indicates they may have changed. This makes a substantial difference to saving stackfiles which contain lots of text stored in fields.

Partially closes https://quality.livecode.com/show_bug.cgi?id=21305