### PR TITLE
[[ Bug 21387 ]] Provide means to create function ptr with abi

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -110,6 +110,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 // __HAS_CORE_FOUNDATION__ will be defined if the platform has the CF libraries.
 #undef __HAS_CORE_FOUNDATION__
 
+// __HAS_MULTIPLE_ABIS__ will be defined if the platform has more than one
+// function ABI
+#undef __HAS_MULTIPLE_ABIS__
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 //  CONFIGURE DEFINITIONS FOR WINDOWS
@@ -130,6 +134,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define __i386__ 1
 #define __LP32__ 1
 #define __SMALL__ 1
+#define __HAS_MULTIPLE_ABIS__ 1
 #elif defined(_M_X64)
 #define __64_BIT__ 1
 #define __LITTLE_ENDIAN__ 1
@@ -3133,8 +3138,26 @@ MC_DLLEXPORT bool MCHandlerExternalInvoke(MCHandlerRef handler, MCValueRef *argu
  *       ExternalInvoke if the current thread is unknown. */
 MC_DLLEXPORT /*copy*/ MCErrorRef MCHandlerTryToInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
 MC_DLLEXPORT /*copy*/ MCErrorRef MCHandlerTryToExternalInvokeWithList(MCHandlerRef handler, MCProperListRef& x_arguments, MCValueRef& r_value);
-    
+   
+/* Create a C function ptr which calls the given handler ref. The function ptr is
+ * stored in the handler ref and is freed when it is. On 32-bit Win32, the calling
+ * convention used is __cdecl. */
 MC_DLLEXPORT bool MCHandlerGetFunctionPtr(MCHandlerRef handler, void*& r_func_ptr);
+
+/* Create a C function ptr with a specific ABI. The function ptr is stored in the
+ * handler ref and is freed when it is. The ABI argument only has an effect on 32-bit
+ * Win32, on all other platforms it is ignored. */
+enum MCHandlerAbiKind
+{
+	kMCHandlerAbiDefault,
+	kMCHandlerAbiStdCall,
+	kMCHandlerAbiThisCall,
+	kMCHandlerAbiFastCall,
+	kMCHandlerAbiCDecl,
+	kMCHandlerAbiPascal,
+	kMCHandlerAbiRegister
+};
+MC_DLLEXPORT bool MCHandlerGetFunctionPtrWithAbi(MCHandlerRef handler, MCHandlerAbiKind p_convention, void*& r_func_ptr);
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/libfoundation/src/foundation-private.h
+++ b/libfoundation/src/foundation-private.h
@@ -460,12 +460,27 @@ struct __MCForeignValue: public __MCValue
 
 ////////
 
+#ifdef __HAS_MULTIPLE_ABIS__
+struct __MCHandlerClosureWithAbi
+{
+	__MCHandlerClosureWithAbi *next;
+	int abi;
+	void *closure;
+	void *function_ptr;
+};
+#endif
+
 struct __MCHandler: public __MCValue
 {
     MCTypeInfoRef typeinfo;
     const MCHandlerCallbacks *callbacks;
+	/* We store the closure with default ABI in the value. */
     void *closure;
     void *function_ptr;
+#ifdef __HAS_MULTIPLE_ABIS__
+	/* All closures with non-default ABIs are stored in a linked list. */
+	__MCHandlerClosureWithAbi *other_closures;
+#endif
     char context[1];
 };
 


### PR DESCRIPTION
This patch adds a new low-level method `MCHandlerGetFunctionPtrWithAbi` which
generates a function ptr for a given handler ref with a specific callling
convention. This method is intended to be used by LCB modules which need to
create callbacks to pass to foreign handlers on 32-bit Win32 and thus might
require the non-default (cdecl) calling convention. On platforms other than
32-bit Win32, then method does the same as `MCHandlerGetFunctionPtr`.

A new global (libfoundation) define has been added `__HAS_MULTIPLE_ABIS__`
which is defined only for 32-bit Win32. This define is used to control the
addition of an `other_closures` member to the internal `__MCHandler` value
struct. This member is used to store a linked-list of closures (and function
pointers) made for a given `MCHandlerRef` instance.

The closure (and function pointer) for the default ABI, regardless of platform,
is still stored within the `__MCHandler` value struct so only those for non-
default ABIs are stored in the linked list.

Bug report: https://quality.livecode.com/show_bug.cgi?id=21387

Requires: https://github.com/livecode/livecode-thirdparty/pull/145