### PR TITLE
[[ Bug 22705 ]] Resolve crash focusing on unopen stack

### DIFF
--- a/docs/notes/bugfix-22705.md
+++ b/docs/notes/bugfix-22705.md
@@ -1,0 +1,1 @@
+# Fix crash focusing on an unopen stack

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -1114,7 +1114,11 @@ MCImageBitmap *MCScreenDC::snapshot(MCRectangle &p_rect, uint4 p_window, MCStrin
 
 void MCScreenDC::controlgainedfocus(MCStack *p_stack, uint32_t p_id)
 {
-	MCPlatformSwitchFocusToView(p_stack -> getwindow(), p_id);
+	MCPlatformWindowRef t_window = p_stack -> getwindow();
+	if (t_window != nullptr)
+	{
+		MCPlatformSwitchFocusToView(p_stack -> getwindow(), p_id);
+	}
 }
 
 void MCScreenDC::controllostfocus(MCStack *p_stack, uint32_t p_id)


### PR DESCRIPTION
This patch resolves a crash where `controlgainedfocus` is called with a stack
parameter which is unopened and therefore `p_stack -> getwindow()` returns
`nullptr`.