### PR TITLE
[[ Documentation ]] Add references between scriptOnly property and script only stack glossary

### DIFF
--- a/docs/dictionary/property/scriptOnly.lcdoc
+++ b/docs/dictionary/property/scriptOnly.lcdoc
@@ -70,7 +70,7 @@ examining the file itself.
     set the scriptOnly of stack "Secrets" to false
     set the password of stack "Secrets" to field "Password"
 
-References:create stack (command), stack (object), behavior (property)
+References:create stack (command), stack (object), behavior (property), script only stack (glossary)
 
 Tags: objects
 

--- a/docs/dictionary/property/scriptOnly.lcdoc
+++ b/docs/dictionary/property/scriptOnly.lcdoc
@@ -48,6 +48,7 @@ Stack:
 The name or ID of the stack.
 
 Description:
+A <script only stack> is a stack whose <scriptOnly> property is true.
 A <scriptOnly> stack will save just the script with a single header line
 declaring the stack name. If the stack has a <stack> <behavior>, the 
 name of the behavior stack is also saved to the header line. Any other 

--- a/docs/glossary/s/script-only-stack.lcdoc
+++ b/docs/glossary/s/script-only-stack.lcdoc
@@ -15,7 +15,7 @@ and, optionally with a <behavior> <stack> reference:
 Anything else in the file is the <script> of the <script only stack>.
 
 References: text file (glossary), stack (glossary), script (property), 
-behavior (property)
+behavior (property), scriptOnly (property)
 
 Tags: objects
 

--- a/docs/glossary/s/script-only-stack.lcdoc
+++ b/docs/glossary/s/script-only-stack.lcdoc
@@ -13,6 +13,9 @@ and, optionally with a <behavior> <stack> reference:
 	script "StackName" with behavior "BehaviorName"
 
 Anything else in the file is the <script> of the <script only stack>.
+If a stack is script only, its <scriptOnly> property will return true:
+
+    if the scriptOnly of stack "StackName" is true then...
 
 References: text file (glossary), stack (glossary), script (property), 
 behavior (property), scriptOnly (property)


### PR DESCRIPTION
Reference "script only stack" from the "scriptOnly" dictionary entry and vice versa. The "script only stack" glossary entry is the only place where the behavior syntax is explicitly explained. This patch allows the "scriptOnly" entry to access that entry as well.