### PR TITLE
[[ Bug 22718 ]] Don't fail opening socket if can't set SO_REUSEPORT option

### DIFF
--- a/docs/notes/bugfix-22718.md
+++ b/docs/notes/bugfix-22718.md
@@ -1,0 +1,1 @@
+# Fix error when accepting connections to a socket on some older Android devices


### PR DESCRIPTION
This patch fixes a bug where configuring a socket to allow reusing a
port would fail on platforms where this option is unsupported,
specifically Android devices running on Linux kernel version < 3.9.

The attempt to open the socket should continue, rather than fail if
this option can't be set.

Closes https://quality.livecode.com/show_bug.cgi?id=22718