### PR TITLE
Make sure you have permissions to clear extended attributes

### DIFF
--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -756,6 +756,13 @@ end performAdHocCodesign
 
 private command clearExtendedAttributes pAppBundle
    local tShell
+   -- make sure you have permission to clear extended attributes from bundle files
+   put "chmod -R u+w" && quote & pAppBundle & quote into tShell
+   get shell(tShell)
+   if the result is not zero then
+      throw "Setting permissions failed with error:" && it
+   end if
+   
    put "xattr -cr" && quote & pAppBundle & quote into tShell
    get shell(tShell)
    if the result is not zero then


### PR DESCRIPTION
When using the remote debugger to deploy a Mac app, the standalone app bundle is saved in a temp location, where you do not have permission to clear the extended attributes from the app bundle. This patch adds the necessary permissions.