### PR TITLE
[Bugfix-22723] Change pasteKey example syntax

### DIFF
--- a/docs/dictionary/message/pasteKey.lcdoc
+++ b/docs/dictionary/message/pasteKey.lcdoc
@@ -18,9 +18,10 @@ Platforms: desktop, server
 
 Example:
 on pasteKey -- replace returns with spaces before pasting
-  if the clipboardData["text"] is not empty then set \
-     the clipboardData["text"] to \
+  if the clipboardData["text"] is not empty then 
+     set the clipboardData["text"] to \
      replaceText(the clipboardData["text"],return,space)
+  end if
   paste
 end pasteKey
 

--- a/docs/dictionary/message/pasteKey.lcdoc
+++ b/docs/dictionary/message/pasteKey.lcdoc
@@ -18,11 +18,11 @@ Platforms: desktop, server
 
 Example:
 on pasteKey -- replace returns with spaces before pasting
-  if the clipboardData["text"] is not empty then 
-     set the clipboardData["text"] to \
-     replaceText(the clipboardData["text"],return,space)
-  end if
-  paste
+   if the clipboardData["text"] is not empty then 
+      set the clipboardData["text"] to \
+            replaceText(the clipboardData["text"],return,space)
+   end if
+   paste
 end pasteKey
 
 Description:

--- a/docs/notes/bugfix-22723.md
+++ b/docs/notes/bugfix-22723.md
@@ -1,0 +1,1 @@
+# Changed syntax of pasteKey example


### PR DESCRIPTION
Changed the single line if statement to multiple lines so as to reduce confusion.