### PR TITLE
[[ Bug 21001 ]] Fix forwarding of key events in HTML5 engine

### DIFF
--- a/docs/notes/bugfix-21001.md
+++ b/docs/notes/bugfix-21001.md
@@ -1,0 +1,1 @@
+# Fix bug preventing detection of backspace keypresses in HTML5 engine

--- a/engine/src/em-event.js
+++ b/engine/src/em-event.js
@@ -504,8 +504,9 @@ mergeInto(LibraryManager.library, {
 						 ['number',  // MCStack *stack
 						  'number',  // uint32_t modifiers
 						  'number',  // uint32_t char_code
-						  'number'], // uint32_t key_code
-						 [stack, modifiers, char_code, key_code]);
+						  'number', // uint32_t key_code
+						  'number'], // MCEventKeyState key_state
+						 [stack, modifiers, char_code, key_code, 2]);
 		},
 
 		_handleKeyboardEvent: function(e) {

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -157,6 +157,7 @@ struct MCEvent
 					uint32_t modifiers;
 					uint32_t key_code;
 					uint32_t char_code;
+					MCEventKeyState state;
 				} press;
 			};
 		} key;
@@ -490,32 +491,37 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
 	case kMCEventTypeKeyPress:
 		{
 			MCStackHandle t_stack = t_event->key.stack;
-            
-            MCObject *t_target = t_menu != nil ? t_menu : t_stack;
+
+			MCObject *t_target = t_menu != nil ? t_menu : t_stack;
 
 			MCmodifierstate = t_event -> key . press . modifiers;
 
-			// If 'char_code' is 0, then this key press has not generated a
-			// character.
+			MCAutoStringRef t_char;
+
 			if (t_event -> key . press . char_code == 0)
 			{
-				t_target -> kdown(kMCEmptyString, t_event -> key . press . key_code);
-				t_target -> kup(kMCEmptyString, t_event -> key . press . key_code);
-				break;
+				// If 'char_code' is 0, then this key press has not generated a
+				// character.
+				t_char = kMCEmptyString;
+			}
+			else
+			{
+				// Otherwise 'char_code' is the unicode codepoint, so first map to
+				// UTF-16 codeunits
+				unichar_t t_unichars[2];
+				uindex_t t_length = 1;
+				if (MCUnicodeCodepointToSurrogates(t_event->key.press.char_code, t_unichars[0], t_unichars[1]))
+					t_length = 2;
+
+				// Now the string is created with the appropriate unicode-capable function
+				MCStringCreateWithChars(t_unichars, t_length, &t_char);
 			}
 
-			// Otherwise 'char_code' is the unicode codepoint, so first map to
-			// UTF-16 codeunits
-			unichar_t t_unichars[2];
-            uindex_t t_length = 1;
-            if (MCUnicodeCodepointToSurrogates(t_event->key.press.char_code, t_unichars[0], t_unichars[1]))
-                t_length = 2;
+			if (t_event->key.press.state == kMCEventKeyStateDown || t_event->key.press.state == kMCEventKeyStatePressed)
+				t_target -> kdown(*t_char, t_event -> key . press . key_code);
 
-			// Now the string is created with the appropriate unicode-capable function
-			MCAutoStringRef t_buffer;
-            MCStringCreateWithChars(t_unichars, t_length, &t_buffer);
-			t_target -> kdown(*t_buffer, t_event -> key . press . key_code);
-			t_target -> kup(*t_buffer, t_event -> key . press . key_code);
+			if (t_event->key.press.state == kMCEventKeyStateUp || t_event->key.press.state == kMCEventKeyStatePressed)
+				t_target -> kup(*t_char, t_event -> key . press . key_code);
 		}
 		break;
 
@@ -1087,7 +1093,7 @@ bool MCEventQueuePostKeyFocus(MCStack *p_stack, bool p_owner)
 }
 
 MC_DLLEXPORT_DEF
-bool MCEventQueuePostKeyPress(MCStack *p_stack, uint32_t p_modifiers, uint32_t p_char_code, uint32_t p_key_code)
+bool MCEventQueuePostKeyPress(MCStack *p_stack, uint32_t p_modifiers, uint32_t p_char_code, uint32_t p_key_code, MCEventKeyState p_key_state)
 {
 	MCEvent *t_event;
 	if (!MCEventQueuePost(kMCEventTypeKeyPress, t_event))
@@ -1097,6 +1103,7 @@ bool MCEventQueuePostKeyPress(MCStack *p_stack, uint32_t p_modifiers, uint32_t p
 	t_event -> key . press . modifiers = p_modifiers;
 	t_event -> key . press . char_code = p_char_code;
 	t_event -> key . press . key_code = p_key_code;
+	t_event -> key . press . state = p_key_state;
 
 	return true;
 }

--- a/engine/src/eventqueue.h
+++ b/engine/src/eventqueue.h
@@ -48,8 +48,16 @@ MC_DLLEXPORT bool MCEventQueuePostMousePress(MCStack *stack, uint32_t time, uint
 bool MCEventQueuePostMouseWheel(MCStack *stack, uint32_t time, uint32_t modifiers, int32_t dh, int32_t dv);
 MC_DLLEXPORT bool MCEventQueuePostMousePosition(MCStack *stack, uint32_t time, uint32_t modifiers, int32_t x, int32_t y);
 
+enum MCEventKeyState
+{
+	kMCEventKeyStateDown,
+	kMCEventKeyStateUp,
+	// Synthetic down+up key state
+	kMCEventKeyStatePressed,
+};
+
 MC_DLLEXPORT bool MCEventQueuePostKeyFocus(MCStack *stack, bool owner);
-MC_DLLEXPORT bool MCEventQueuePostKeyPress(MCStack *stack, uint32_t modifiers, uint32_t char_code, uint32_t key_code);
+MC_DLLEXPORT bool MCEventQueuePostKeyPress(MCStack *stack, uint32_t modifiers, uint32_t char_code, uint32_t key_code, MCEventKeyState key_state);
 
 MC_DLLEXPORT bool MCEventQueuePostImeCompose(MCStack *stack, bool enabled, uint32_t offset, const uint16_t *chars, uint32_t char_count);
 

--- a/engine/src/mbldc.cpp
+++ b/engine/src/mbldc.cpp
@@ -214,7 +214,7 @@ void MCScreenDC::handle_key_press(uint32_t p_modifiers, uint32_t p_char_code, ui
 	if (p_char_code >= 32 && p_char_code < 128)
 		p_key_code = p_char_code;
 	
-	MCEventQueuePostKeyPress(t_stack, p_modifiers, p_char_code, p_key_code);
+	MCEventQueuePostKeyPress(t_stack, p_modifiers, p_char_code, p_key_code, kMCEventKeyStatePressed);
 }
 
 void MCScreenDC::handle_key_focus(bool p_gain_focus)


### PR DESCRIPTION
This patch fixes bug 21001, where backspace key presses were not correctly forwarded to HTML5 standalones.

Closes https://quality.livecode.com/show_bug.cgi?id=21001