### PR TITLE
[22733] Remove redundant warning from the standalone builder

### DIFF
--- a/docs/notes/bugfix-22733.md
+++ b/docs/notes/bugfix-22733.md
@@ -1,0 +1,1 @@
+# Remove redundant warning from the standalone builder

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1620,17 +1620,6 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
       put "<key>UIUserInterfaceStyle</key><string>Light</string>" into tUIStyle
    end if
    
-   -- MM-2011-09-28: Make sure portrait and landscape iPad splashes are present if required.
-   --
-   if 2 is among the items of pSettings["ios,device family"] then
-      if tIPadOrientations contains "Portrait" and there is no file (pAppBundle & "/Default-Portrait.png") then
-         revStandaloneAddWarning "No iPad Portrait Splash Screen"
-      end if
-      if tIPadOrientations contains "Landscape" and there is no file (pAppBundle & "/Default-Landscape.png") then
-         revStandaloneAddWarning "No iPad Landscape Splash Screen"
-      end if
-   end if
-   
    if tStatusBarHidden is empty then
       put "false" into tStatusBarHidden
    end if


### PR DESCRIPTION
We no longer provide separate splash screens for iPad portrait and iPad landscape, since the storyboard mechanism takes care of this automatically.

Closes https://quality.livecode.com/show_bug.cgi?id=22733