### PR TITLE
[20120] Ensure location data is always returned on Android

### DIFF
--- a/docs/notes/bugfix-20120.md
+++ b/docs/notes/bugfix-20120.md
@@ -1,0 +1,1 @@
+Ensure location data is returned on Android, even if location tracking is done using only GPS.

--- a/engine/src/java/com/runrev/android/SensorModule.java
+++ b/engine/src/java/com/runrev/android/SensorModule.java
@@ -225,8 +225,7 @@ class SensorModule
         
         LocationManager m_location_manager;
         
-        LocationListener m_network_location_listener;
-        LocationListener m_gps_location_listener;
+        LocationListener m_location_listener;
         
         public LocationTracker()
         {
@@ -245,33 +244,13 @@ class SensorModule
             m_timestamp_offset = t_seconds_since_epoch - t_seconds_since_boot;
             
             m_location_manager = (LocationManager)m_engine.getContext().getSystemService(Context.LOCATION_SERVICE);
-            m_network_location_listener = new LocationListener()
+            m_location_listener = new LocationListener()
             {
                 // LocationListener methods
                 public void onLocationChanged(Location location)
                 {
                     if (m_gps_available)
                         return;
-                    LocationTracker.this.onLocationChanged(location);
-                }
-                
-                public void onProviderDisabled(String provider)
-                {
-                }
-                
-                public void onProviderEnabled(String provider)
-                {
-                }
-                
-                public void onStatusChanged(String provider, int status, Bundle extras)
-                {
-                }
-            };
-            
-            m_gps_location_listener = new LocationListener()
-            {
-                public void onLocationChanged(Location location)
-                {
                     LocationTracker.this.onLocationChanged(location);
                 }
                 
@@ -307,28 +286,22 @@ class SensorModule
                 return true;
             
             m_use_gps = !p_loosely;
+            
+            Criteria t_criteria = new Criteria();
+            if (m_use_gps)
+                t_criteria.setAccuracy(Criteria.ACCURACY_FINE);
+            else
+                t_criteria.setAccuracy(Criteria.ACCURACY_COARSE);
+            
             try
             {
-                m_location_manager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, m_network_location_listener);
+                m_location_manager.requestLocationUpdates(0, 0, t_criteria, m_location_listener, null);
                 m_registered = true;
             }
             catch (SecurityException e)
             {
             }
             
-            
-            if (m_use_gps)
-            {
-                try
-                {
-                    m_location_manager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, m_gps_location_listener);
-                    m_registered = true;
-                }
-                catch (SecurityException e)
-                {
-                }
-            }
-
             return m_registered;
         }
         
@@ -337,8 +310,7 @@ class SensorModule
             if (!m_registered)
                 return true;
             
-            m_location_manager.removeUpdates(m_network_location_listener);
-            m_location_manager.removeUpdates(m_gps_location_listener);
+            m_location_manager.removeUpdates(m_location_listener);
             // MM-2011-03-13: [[ Bug 10077 ]] Make sure we flag as unregistered or else we will never be able to register again.5
             m_registered = false;
             return true;


### PR DESCRIPTION
This patch ensures the best provider for location data will be chosen (GPS, Wifi, Cellular Network, Bluetooth). This ensures that in any case the location data is returned.