### PR TITLE
[22737] Ensure the externals lcextd folder is not copied into the apk

### DIFF
--- a/docs/notes/bugfix-22737.md
+++ b/docs/notes/bugfix-22737.md
@@ -1,0 +1,1 @@
+# Make sure the externals lcextd folder is not copied into the apk

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1297,7 +1297,9 @@ private command addAssetsToArchive pFileData, pBaseFolder, pArchive
             revZipAddUncompressedItemWithFile pArchive, "assets/" & tFile["name"], tFile["resolved"]
          end if
       else if there is a folder tFile["resolved"] then
-         addAssetsFromFolderToArchive tFile["resolved"], "assets" & slash & tFile["name"], pArchive, tFonts
+         if not (tFile["resolved"] ends with ".lcextd") then
+            addAssetsFromFolderToArchive tFile["resolved"], "assets" & slash & tFile["name"], pArchive, tFonts
+         end if
       else
          throw "could not find referenced asset to include -" && tFile["resolved"]
       end if


### PR DESCRIPTION
Closes https://quality.livecode.com/show_bug.cgi?id=22737