### PR TITLE
[[ Bug 22698 ]] Fix crash when relayering field with key focus

### DIFF
--- a/docs/notes/bugfix-22698.md
+++ b/docs/notes/bugfix-22698.md
@@ -1,0 +1,1 @@
+# Fix crash when relayering the currently focused field

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -322,6 +322,8 @@ void MCCard::kfocus()
         // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
         //   (otherwise the engine state can change due to script).
         MCscreen -> controlgainedfocus(getstack(), kfocused -> getid());
+		// Mark card as focused
+		setstate(true, CS_KFOCUSED);
 		kfocused->getref()->kfocus();
 	}
 	if (kfocused == NULL)
@@ -361,6 +363,8 @@ Boolean MCCard::kfocusnext(Boolean top)
                     // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
                     //   (otherwise the engine state can change due to script).
 					MCscreen -> controllostfocus(getstack(), oldkfocused -> getid());
+					// Mark card as unfocused
+					setstate(false, CS_KFOCUSED);
 					oldkfocused->getref()->kunfocus();
 					if (oldkfocused == NULL)
 						return False;
@@ -371,6 +375,8 @@ Boolean MCCard::kfocusnext(Boolean top)
             // MW-2014-07-29: [[ Bug 13001 ]] Sync the view focus before the engine state
             //   (otherwise the engine state can change due to script).
 			MCscreen -> controlgainedfocus(getstack(), kfocused -> getid());
+			// Mark card as focused
+			setstate(true, CS_KFOCUSED);
 			kfocused->getref()->kfocus();
 			done = True;
 			break;
@@ -420,6 +426,8 @@ Boolean MCCard::kfocusprev(Boolean bottom)
                     // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
                     //   (otherwise the engine state can change due to script).
 					MCscreen -> controllostfocus(getstack(), oldkfocused -> getid());
+					// Mark card as unfocused
+					setstate(false, CS_KFOCUSED);
 					oldkfocused->getref()->kunfocus();
 					if (oldkfocused == NULL)
 						return False;
@@ -430,6 +438,8 @@ Boolean MCCard::kfocusprev(Boolean bottom)
             // MW-2014-07-29: [[ Bug 13001 ]] Sync the view focus before the engine state
             //   (otherwise the engine state can change due to script).
 			MCscreen -> controlgainedfocus(getstack(), kfocused -> getid());
+			// Mark card as focused
+			setstate(true, CS_KFOCUSED);
 			kfocused->getref()->kfocus();
 			done = True;
 			break;
@@ -453,6 +463,8 @@ void MCCard::kunfocus()
         // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
         //   (otherwise the engine state can change due to script).
         MCscreen -> controllostfocus(getstack(), oldkfocused -> getid());
+		// Mark card as unfocused
+		setstate(false, CS_KFOCUSED);
 		oldkfocused->getref()->kunfocus();
 	}
 	else
@@ -1382,6 +1394,8 @@ void MCCard::kfocusset(MCControl *target)
             // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
             //   (otherwise the engine state can change due to script).
             MCscreen -> controllostfocus(getstack(), tkfocused -> getid());
+			// Mark card as unfocused
+			setstate(false, CS_KFOCUSED);
 			tkfocused->getref()->kunfocus();
 		}
 		if (kfocused != NULL)
@@ -1395,6 +1409,8 @@ void MCCard::kfocusset(MCControl *target)
                 // MW-2014-08-12: [[ Bug 13167 ]] Sync the view focus before the engine state
                 //   (otherwise the engine state can change due to script).
                 MCscreen -> controlgainedfocus(getstack(), kfocused -> getid());
+				// Mark card as focused
+				setstate(true, CS_KFOCUSED);
 				kfocused->getref()->kfocus();
 
 				// OK-2009-04-29: [[Bug 8013]] - Its possible that kfocus() can set kfocused to NULL if the 

--- a/engine/src/exec-interface2.cpp
+++ b/engine/src/exec-interface2.cpp
@@ -3492,13 +3492,20 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
 		t_new_target_handle = t_new_target != nil ? t_new_target : nil;
 
 		// Make sure we remove focus from the control.
+		MCObjectHandle t_kfocused_handle = nil;
 		bool t_was_mfocused, t_was_kfocused;
 		t_was_mfocused = t_card -> getstate(CS_MFOCUSED) == True;
 		t_was_kfocused = t_card -> getstate(CS_KFOCUSED) == True;
 		if (t_was_mfocused)
 			t_card -> munfocus();
 		if (t_was_kfocused)
+		{
+			// keep note of which object had key focus before the relayering
+			MCControl *t_kfocused = t_card->getkfocused();
+			if (t_kfocused != nil)
+				t_kfocused_handle = t_kfocused->GetHandle();
 			t_card -> kunfocus();
+		}
         
 		// Check the source and new owner objects exist, and if we have a target object
 		// that that exists and is still a child of new owner.
@@ -3521,8 +3528,8 @@ void MCInterfaceDoRelayer(MCExecContext& ctxt, int p_relation, MCObjectPtr p_sou
 			t_success = false;
 		}
         
-		if (t_was_kfocused)
-			t_card -> kfocus();
+		if (t_was_kfocused && t_kfocused_handle.IsValid())
+			t_card->kfocusset(static_cast<MCControl*>(t_kfocused_handle.Get()));
 		if (t_was_mfocused)
 			t_card -> mfocus(MCmousex, MCmousey);
 	}

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3074,6 +3074,10 @@ void MCGroup::relayercontrol(MCControl *p_source, MCControl *p_target)
 void MCGroup::relayercontrol_remove(MCControl *p_control)
 {
 	p_control -> remove(controls);
+
+	// make sure this group no longer points to the removed control
+	clearfocus(p_control);
+
 	if (!computeminrect(False))
 		layer_redrawrect(p_control -> geteffectiverect());
 		


### PR DESCRIPTION
This patch fixes bug 22698, where relayering a field which has the key focus can cause an engine crash.

Closes https://quality.livecode.com/show_bug.cgi?id=22698