### PR TITLE
[[ Bug 22760 ]] Fix 'external' handler invocation

### DIFF
--- a/docs/lcb/notes/22760.md
+++ b/docs/lcb/notes/22760.md
@@ -1,0 +1,5 @@
+# LiveCode Builder Standard Library
+
+## Foreign function interface
+
+# [ 22760 ] Handlers invoked by foreign code on mobile now run on the correct thread.

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -221,6 +221,11 @@ bool MCIPhoneIsOnMainFiber(void)
     return MCFiberIsCurrentThread(s_main_fiber);
 }
 
+bool MCIPhoneIsOnScriptFiber(void)
+{
+    return MCFiberIsCurrentThread(s_script_fiber);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Boolean MCScreenDC::open(void)
@@ -1215,6 +1220,11 @@ void MCIPhoneCallSelectorOnMainFiberWithObject(id p_object, SEL p_selector, id p
 void MCIPhoneRunOnMainFiber(void (*p_callback)(void *), void *p_context)
 {
 	MCFiberCall(s_main_fiber, p_callback, p_context);
+}
+
+void MCIPhoneRunOnScriptFiber(void (*p_callback)(void *), void *p_context)
+{
+    MCFiberCall(s_script_fiber, p_callback, p_context);
 }
 
 static void invoke_block(void *p_context)

--- a/libfoundation/src/foundation-handler.cpp
+++ b/libfoundation/src/foundation-handler.cpp
@@ -87,18 +87,18 @@ bool MCHandlerExternalInvoke(MCHandlerRef self, MCValueRef *p_arguments, uindex_
     if (!MCAndroidIsOnEngineThread())
     {
         typedef void (*co_yield_callback_t)(void *);
-        extern void co_yield_to_android_and_call(co_yield_callback_t callback, void *context);
+        extern void co_yield_to_engine_and_call(co_yield_callback_t callback, void *context);
         MCHandlerInvokeTrampolineContext t_context = {self, p_arguments, p_argument_count, r_value, true};
-        co_yield_to_android_and_call(MCHandlerInvokeTrampoline, &t_context);
+        co_yield_to_engine_and_call(MCHandlerInvokeTrampoline, &t_context);
         return t_context.return_value;
     }
 #elif defined(TARGET_SUBPLATFORM_IPHONE) && !defined(CROSS_COMPILE_HOST)
-    extern bool MCIPhoneIsOnMainFiber(void);
-    if (!MCIPhoneIsOnMainFiber())
+    extern bool MCIPhoneIsOnScriptFiber(void);
+    if (!MCIPhoneIsOnScriptFiber())
     {
-        extern void MCIPhoneRunOnMainFiber(void (*)(void *), void *);
+        extern void MCIPhoneRunOnScriptFiber(void (*)(void *), void *);
         MCHandlerInvokeTrampolineContext t_context = {self, p_arguments, p_argument_count, r_value, true};
-        MCIPhoneRunOnMainFiber(MCHandlerInvokeTrampoline, &t_context);
+        MCIPhoneRunOnScriptFiber(MCHandlerInvokeTrampoline, &t_context);
         return t_context.return_value;
     }
 #endif

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -555,7 +555,9 @@ bool MCJavaObjectCreateNullable(jobject p_object, MCJavaObjectRef &r_object)
 
 static jstring MCJavaGetJObjectClassName(jobject p_obj)
 {
-    /* Make sure the fetched class local-refs are deleted on exit */
+	MCJavaDoAttachCurrentThread();
+	
+	/* Make sure the fetched class local-refs are deleted on exit */
     MCJavaAutoLocalRef<jclass> t_class =
         s_env->GetObjectClass(p_obj);
     MCJavaAutoLocalRef<jclass> javaClassClass =
@@ -1955,10 +1957,17 @@ jobject MCJavaPrivateDoNativeListenerCallback(jlong p_handler, jstring p_method_
     MCProperListRef t_mutable_list;
     if (!MCProperListMutableCopy(*t_list, t_mutable_list))
         return nullptr;
-    
-    MCErrorRef t_error =
+	
+	/* The handler is run on the script thread and could call code which executes
+	 * MCJavaDoAttachCurrentThread() so we must ensure s_env is reset correctly for the
+	 * current thread */
+	JNIEnv *t_old_env;
+	t_old_env = s_env;
+	MCErrorRef t_error =
         MCHandlerTryToExternalInvokeWithList(static_cast<MCHandlerRef>(t_handler),
                                              t_mutable_list, &t_result);
+	s_env = t_old_env;
+	
     jobject t_return = nullptr;
     if (*t_result != nil)
     {


### PR DESCRIPTION
This patch ensures that when a handler-ref is invoked from the main/ui thread
on mobile that a jump is made to the script/engine thread before being
executed.

After the handler is executed the JNI environment is reset for the calling
thread. This patch also fixes an issue where `MCJavaGetJObjectClassName` did
not call `MCJavaDoAttachCurrentThread` and therefore could access JNI
environment attached to a different thread.

(cherry picked from commit 15eff1554567cc63e5d6509b29201dc89d8ff20b)