### PR TITLE
[[ Bug 22763 ]] Fix resizing mobilePickPhoto for API Level < 24

### DIFF
--- a/docs/notes/bugfix-22763.md
+++ b/docs/notes/bugfix-22763.md
@@ -1,0 +1,1 @@
+# Ensure mobilePickPhoto with width and height params works on older Android versions

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2232,9 +2232,18 @@ public class Engine extends View implements EngineApi
 					float t_width = t_bitmap.getWidth();
 					float t_height = t_bitmap.getHeight();
 					
-					InputStream t_exif_in = ((LiveCodeActivity)getContext()).getContentResolver().openInputStream(t_photo_uri);
-					
-					ExifInterface t_exif = new ExifInterface(t_exif_in);
+					/* In API Level >= 24, you have to use an input stream to make sure that access
+					 * to a photo in the library is granted. Before that you can just open the photo's
+					 * file direct. */
+					ExifInterface t_exif;
+					if (Build.VERSION.SDK_INT >= 24)
+					{
+						t_exif = new ExifInterface(t_in);
+					}
+					else
+					{
+						t_exif = new ExifInterface(t_photo_uri.getPath());
+					}
 					
 					int t_orientation = t_exif.getAttributeInt(ExifInterface.TAG_ORIENTATION,
 															   ExifInterface.ORIENTATION_NORMAL);


### PR DESCRIPTION
This patch ensures that calling `mobilePickPhoto` with width and height params works in older Android versions too. Previously, a constructor for `ExifInterface` was used, that was available in API 24+ (Android 7+).

This patch uses another constructor, that is available in older APIs as well.

Closes https://quality.livecode.com/show_bug.cgi?id=22763