### PR TITLE
[[ Bug 22777 ]] Implement hitTest in iOS native container view

### DIFF
--- a/docs/notes/bugfix-22777.md
+++ b/docs/notes/bugfix-22777.md
@@ -1,0 +1,1 @@
+# Fix native container layers on iOS blocking events to underlying native layers

--- a/engine/src/native-layer-ios.mm
+++ b/engine/src/native-layer-ios.mm
@@ -201,6 +201,7 @@ MCNativeLayer *MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_nati
 @interface com_runrev_livecode_MCContainerView: UIView
 
 - (void)setFrame:(CGRect)frame;
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event;
 
 @end
 
@@ -212,6 +213,20 @@ MCNativeLayer *MCNativeLayer::CreateNativeLayer(MCObject *p_object, void *p_nati
 {
 	[super setFrame:frame];
 	[self setBounds:frame];
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+	UIView *t_hit_view = [super hitTest:point withEvent:event];
+	
+	/* The container view should not trap any events so if the hitTest returns self we
+	 * return nil so the heirarchy continues to be navigated to find a view */
+	if (t_hit_view == self)
+	{
+		return nil;
+	}
+	
+	return t_hit_view;
 }
 
 @end


### PR DESCRIPTION
This patch implements a hit test in the iOS native container view so it does not
block events from underlying views. By returning `nil` if the event does not
hit a child view the remaining view hierarchy will be traversed to find the
correct target view.