### PR TITLE
[21857] Make autoupdater faster when downloading a new LC version

### DIFF
--- a/builder/installer/installeruiupdatedownloadcardbehavior.livecodescript
+++ b/builder/installer/installeruiupdatedownloadcardbehavior.livecodescript
@@ -57,7 +57,7 @@ private command downloadNewVersion pUrl, pCheckSum, pDestination
       put urlEncode(the last item of pURL) into the last item of pURL
       set the itemDel to comma
       libURLSetStatusCallback "downloadLatestRevisionUpdates", the long id of me
-      load URL pURL with message "downloadLatestRevisionComplete"
+      libURLDownloadToFile pUrl, sFileName, "downloadLatestRevisionComplete"
    else
       
       -- The file already exists execute it
@@ -77,7 +77,6 @@ end downloadNewVersion
 --
 on downloadLatestRevisionComplete pURL, pStatus
    if pStatus is among the words "downloaded cached" then
-      put URL the uRemoteURL of me into URL ("binfile:" & sFileName)
       launchDownloadedInstaller
       if the result is not empty then
          set the uError of card "Finish" to the result

--- a/docs/notes/bugfix-21857.md
+++ b/docs/notes/bugfix-21857.md
@@ -1,0 +1,1 @@
+# Make autoupdater faster when downloading a new LiveCode version


### PR DESCRIPTION
This patch ensures the autoupdater uses `libUrlDownloadToFile` when downloading a new LC version. Previously, `load url` was used, which is OK for small files of few MB, but painfully slow for large files.