### PR TITLE
[[ Bug 21353 ]] Ensure long lines are shown in full in mobilePick on iOS

### DIFF
--- a/docs/notes/bugfix-21353.md
+++ b/docs/notes/bugfix-21353.md
@@ -1,0 +1,1 @@
+# Ensure the picker wheel of mobilePick does not truncate long lines on iOS

--- a/engine/src/mbliphonepick.mm
+++ b/engine/src/mbliphonepick.mm
@@ -120,6 +120,20 @@ UIViewController *MCIPhoneGetViewController(void);
 	m_use_checkmark = p_use;
 }
 
+- (UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row forComponent:(NSInteger)component reusingView:(UIView *)view
+{
+    UILabel* t_label = (UILabel*)view;
+    if (!t_label)
+    {
+        t_label = [[UILabel alloc] init];
+        t_label.adjustsFontSizeToFitWidth = YES;
+        t_label.textAlignment = NSTextAlignmentCenter;
+        [t_label setText:[[viewArray objectAtIndex:component] objectAtIndex:row]];
+    }
+    
+    return t_label;
+}
+
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
 	// HC-2011-10-03 [[ Picker Buttons ]] Showing the bar dynamicly, to indicate if any initial selections have been made.


### PR DESCRIPTION
Previously, if a line was too long, it was truncated at the end. Now, the text size of a long line will be reduced so as the line can fit the container of the picker wheel.