### PR TITLE
[22780] Ensure the compositorType property can be set to "none"

### DIFF
--- a/docs/notes/bugfix-22780.md
+++ b/docs/notes/bugfix-22780.md
@@ -1,0 +1,1 @@
+# Ensure no error is thrown when setting the compositorType property to "none"

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -93,7 +93,7 @@ static MCExecEnumTypeInfo _kMCInterfaceCharsetTypeInfo =
 static MCExecEnumTypeElementInfo _kMCInterfaceCompositorTypeElementInfo[] =
 {
     { "", kMCTileCacheCompositorNone, false },
-	{ "none", kMCTileCacheCompositorNone, true },
+	{ "none", kMCTileCacheCompositorNone, false },
 	{ "Software", kMCTileCacheCompositorSoftware, false },
 	{ "CoreGraphics", kMCTileCacheCompositorCoreGraphics, false },
 	{ "opengl", kMCTileCacheCompositorOpenGL, false },


### PR DESCRIPTION
This patch ensures the compositorType property can be set to "none".
Previously this enumeration value was set to read-only, thus an error
was thrown when attempting to set the compositorType to "none"

Closes https://quality.livecode.com/show_bug.cgi?id=22780