### PR TITLE
[[ Bug 22756 ]] Update mergExt for iOS 13.5

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2020-4-2"
+constant kMergExtVersion = "2020-6-18"
 constant kTSNetVersion = "1.4.2"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer for iOS 13.5