### PR TITLE
[Bug 22557] OAuth2 - Prevent double URL encoding of authentication code

### DIFF
--- a/extensions/script-libraries/oauth2/notes/22557.md
+++ b/extensions/script-libraries/oauth2/notes/22557.md
@@ -1,0 +1,1 @@
+# [22557] Prevent double URL encoding of authentication code

--- a/extensions/script-libraries/oauth2/oauth2.livecodescript
+++ b/extensions/script-libraries/oauth2/oauth2.livecodescript
@@ -238,13 +238,14 @@ command OAuth2 pAuthURL, pTokenURL, pClientID, pClientSecret, pScopes, pPort, pP
    
    local tResult
    put the dialogData into tResult
+   -- all keys/values in tResult are already URL encoded
    
    if tResult["code"] is not empty then
       local tParams
       put "grant_type=authorization_code" into tParams
       put "&client_id=" & urlEncode(pClientID) after tParams
       put "&client_secret=" & urlEncode(pClientSecret) after tParams
-      put "&code=" & urlEncode(tResult["code"]) after tParams
+      put "&code=" & tResult["code"] after tParams
       put "&redirect_uri=" & urlEncode(kRedirectURL & ":" & pPort & "/") after tParams
       
       local tResponse


### PR DESCRIPTION
The data returned after authentication is URL encoded.  The existing behavior would URL encode the authentication code.  In several cases, the code returned by Google included characters that were already encoded which invalidated the code when encoded a second time.