### PR TITLE
[22787] Prevent infinite loop between answer and resumeStack

### DIFF
--- a/docs/notes/bugfix-21566.md
+++ b/docs/notes/bugfix-21566.md
@@ -1,1 +1,0 @@
-# Fix crash when opening and closing modal windows under some circumstances

--- a/docs/notes/bugfix-22787.md
+++ b/docs/notes/bugfix-22787.md
@@ -1,0 +1,1 @@
+# Prevent infinite loop between answer dialog and resumeStack message

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -891,7 +891,7 @@ void MCMacPlatformEndModalSession(MCMacPlatformWindow *p_window)
 			return;
 		
 		[NSApp endModalSession: s_modal_sessions[t_final_index - 1] . session];
-		[s_modal_sessions[t_final_index - 1] . window -> GetHandle() performSelector:@selector(orderOut:) withObject:nil afterDelay:0];
+		[s_modal_sessions[t_final_index - 1] . window -> GetHandle() orderOut:nil];
 		s_modal_sessions[t_final_index - 1] . window -> Release();
 		s_modal_session_count -= 1;
 	}


### PR DESCRIPTION
This patch reverts the change of bugfix-21566 (https://github.com/livecode/livecode/pull/7232), since it has introduced a number of regressions, related to opening and closing modal dialogs under some circumstances.