### PR TITLE
[[ Bug 22787 ]] Fix event handling during modal sessions

### DIFF
--- a/docs/notes/bugfix-22787.md
+++ b/docs/notes/bugfix-22787.md
@@ -1,0 +1,2 @@
+# Fix event handling when modal dialogs are displayed
+


### PR DESCRIPTION
This patch fixes event handling when modal sessions are active by ensuring
all events get processed by the modal session. This is essentially reversion
of the fix to Bug 13555 (from 2014) and Bug 21566 (included in 9.6).

If there is an active modal session, all event handling is controlled by
a single run of the modal session; rather than attempting to bypass it by
peeking the event queue.

This change appears to fix several modal dialog related issues which have
been reported since 2014, as well as several regressions from the attempted
fix of Bug 21566.

Closes https://quality.livecode.com/show_bug.cgi?id=22787