### PR TITLE
[Bugfix-22796] Add info about activity/busy indicators' input blocking

### DIFF
--- a/docs/dictionary/command/iphoneActivityIndicatorStart.lcdoc
+++ b/docs/dictionary/command/iphoneActivityIndicatorStart.lcdoc
@@ -52,5 +52,9 @@ location on the screen. If a location is not specified, then the
 animation is positioned in the middle of the screen. You can turn the
 activity indicator off by calling <iphoneActivityIndicatorStop>.
 
+While this busy indicator is displayed, user input continues to be
+accepted. This is different to the behavior from the indicator 
+displayed by <mobileBusyIndicatorStart>.
+
 References: iphoneActivityIndicatorStop (command)
 

--- a/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
+++ b/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
@@ -36,7 +36,7 @@ Specifies the message that is to appear on the busy indicator dialog.
 
 opacity:
 Specifies the opacity of the busy indicator, which can lie in the range
-0 - 100. The default value is 42. This option is only available for iOS.
+1 - 100. The default value is 42. This option is only available for iOS.
 
 Description:
 Use the <mobileBusyIndicatorStart> command to show a native busy
@@ -48,5 +48,11 @@ indicator on the top of the LiveCode stack that is running.
 You can turn the busy indicator off by calling
 <mobileBusyIndicatorStop>. 
 
-References: mobileBusyIndicatorStop (command)
+While this busy indicator is displayed, user input is blocked. This is
+different to the behavior from the indicator displayed 
+by <iphoneActivityIndicatorStart>.
+
+
+References: mobileBusyIndicatorStop (command), 
+iphoneActivityIndicatorStart (command)
 

--- a/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
+++ b/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
@@ -36,7 +36,7 @@ Specifies the message that is to appear on the busy indicator dialog.
 
 opacity:
 Specifies the opacity of the busy indicator, which can lie in the range
-1 - 100. The default value is 42. This option is only available for iOS.
+0 - 100. The default value is 42. This option is only available for iOS.
 
 Description:
 Use the <mobileBusyIndicatorStart> command to show a native busy

--- a/docs/notes/bugfix-22796.md
+++ b/docs/notes/bugfix-22796.md
@@ -1,0 +1,1 @@
+# Added information to iphoneActivityIndicatorStart and mobileBusyIndicatorStart about blocked input.


### PR DESCRIPTION
Added information to iphoneActivityIndicatorStart and mobileActivityIndicatorStart regarding how each handle input once they have been called.

(This also fixes bug 22795 by changing the stated opacity range for mobileBusyIndicatorStart to 1 - 100)