### PR TITLE
[[ Bug 21615 ]] Implement HiDPI scaling in emscripten engine

### DIFF
--- a/docs/notes/bugfix-21615.md
+++ b/docs/notes/bugfix-21615.md
@@ -1,0 +1,1 @@
+# Add HiDPI scaling support to HTML5 engine

--- a/engine/src/em-dc.cpp
+++ b/engine/src/em-dc.cpp
@@ -33,6 +33,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "globals.h"
 #include "graphics_util.h"
 
+#include <emscripten.h>
+
 /* ================================================================
  * Helper Functions
  * ================================================================ */
@@ -258,6 +260,7 @@ bool MCScreenDC::platform_getdisplays(bool p_effective, MCDisplay *&r_displays, 
 		return false;
 	
 	t_display->viewport = t_display->workarea = MCEmscriptenGetDisplayRect();
+	t_display->pixel_scale = emscripten_get_device_pixel_ratio();
 	
 	r_displays = t_display;
 	r_count = 1;

--- a/engine/src/em-event.js
+++ b/engine/src/em-event.js
@@ -130,6 +130,10 @@ mergeInto(LibraryManager.library, {
 				tInput.addEventListener(type, handler);
 			});
 
+			// Add listener for changes to device pixel ratio
+			var matchQuery = `(resolution: ${window.devicePixelRatio}dppx)`;
+			window.matchMedia(matchQuery).addListener(LiveCodeEvents._handleDevicePixelRatioChanged);
+
 			LiveCodeEvents._initialised = true;
 		},
 
@@ -892,6 +896,16 @@ mergeInto(LibraryManager.library, {
 		// UI events
 		// ----------------------------------------------------------------
 		
+		_handleDevicePixelRatioChanged: function() {
+			LiveCodeAsync.delay(function() {
+				Module.ccall('MCEmscriptenHandleDevicePixelRatioChanged',
+								'number', /* bool */
+								[],
+								[])
+			});
+			LiveCodeAsync.resume();
+		},
+
 		// prevent context menu popup on right-click
 		_handleContextMenu: function(e) {
 			e.preventDefault()

--- a/engine/src/em-resolution.cpp
+++ b/engine/src/em-resolution.cpp
@@ -29,17 +29,18 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
  * Resolution independence
  * ================================================================ */
 
-/* FIXME use emscripten_get_device_pixel_ratio() */
+static MCGFloat s_emscripten_device_scale = 1.0;
 
 void
 MCResPlatformInitPixelScaling()
 {
+	s_emscripten_device_scale = emscripten_get_device_pixel_ratio();
 }
 
 bool
 MCResPlatformSupportsPixelScaling()
 {
-	return false;
+	return true;
 }
 
 bool
@@ -57,15 +58,13 @@ MCResPlatformCanSetPixelScale()
 MCGFloat
 MCResPlatformGetDefaultPixelScale()
 {
-	MCEmscriptenNotImplemented();
-	return NAN;
+	return s_emscripten_device_scale;
 }
 
 MCGFloat
 MCResPlatformGetUIDeviceScale()
 {
-	MCEmscriptenNotImplemented();
-	return NAN;
+	return s_emscripten_device_scale;
 }
 
 void

--- a/engine/src/em-resolution.cpp
+++ b/engine/src/em-resolution.cpp
@@ -16,12 +16,22 @@ for more details.
 You should have received a copy of the GNU General Public License
 along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
+#include "globdefs.h"
+#include "filedefs.h"
+#include "osspec.h"
+#include "typedefs.h"
+#include "parsedef.h"
+#include "objdefs.h"
+
+#include "globals.h"
+
 #include "em-util.h"
 
 #include "sysdefs.h"
 
 #include "graphics.h"
 #include "resolution.h"
+#include "stacklst.h"
 
 #include <emscripten.h>
 
@@ -70,5 +80,19 @@ MCResPlatformGetUIDeviceScale()
 void
 MCResPlatformHandleScaleChange()
 {
-	MCEmscriptenNotImplemented();
+	// Global use-pixel-scaling value has been updated, so now we just need to reopen any open stack windows
+	MCstacks->reopenallstackwindows();
+}
+
+extern "C" MC_DLLEXPORT_DEF bool
+MCEmscriptenHandleDevicePixelRatioChanged()
+{
+	MCGFloat t_scale = emscripten_get_device_pixel_ratio();
+	if (t_scale != s_emscripten_device_scale)
+	{
+		s_emscripten_device_scale = t_scale;
+		MCResPlatformHandleScaleChange();
+	}
+
+	return true;
 }

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -1029,7 +1029,7 @@ public:
 		uint32_t p_minwidth, uint32_t p_minheight,
 		uint32_t p_maxwidth, uint32_t p_maxheight);
 	void view_device_updatewindow(MCRegionRef p_region);
-#elif defined(_MOBILE)
+#elif defined(_MOBILE) || defined(__EMSCRIPTEN__)
 
 	// IM-2014-01-30: [[ HiDPI ]] platform-specific view device methods
 	


### PR DESCRIPTION
This patch fixes bug 21615, by adding support for HiDPI scaling to the HTML5 (emscripten) engine

Closes https://quality.livecode.com/show_bug.cgi?id=21615