### PR TITLE
[[ Bug 22801 ]] Fix crash in HTML5 standalones when getting / setting the effective rect of a stack

### DIFF
--- a/docs/notes/bugfix-22801.md
+++ b/docs/notes/bugfix-22801.md
@@ -1,0 +1,1 @@
+# Fix crash in HTML5 standalones when getting / setting the effective rect of a stack

--- a/engine/src/em-stack.cpp
+++ b/engine/src/em-stack.cpp
@@ -149,6 +149,13 @@ MCStack::view_platform_setgeom(const MCRectangle &p_rect)
 	return t_old;
 }
 
+MCRectangle MCStack::view_platform_getwindowrect() const
+{
+	uint32_t t_window = reinterpret_cast<uint32_t>(window);
+
+	return MCEmscriptenGetWindowRect(t_window);
+}
+
 /* ================================================================
  * Stub functions
  * ================================================================ */


### PR DESCRIPTION
This patch adds an emscripten engine implementation of the method MCStack::view_platform_getwindowrect, which fixes a crash when fetching the effective rect of a stack.

Closes https://quality.livecode.com/show_bug.cgi?id=22801