### PR TITLE
[[ Bug 22802 ]] Fix crash in HTML5 standalones when fetching the system date or system time

### DIFF
--- a/docs/notes/bugfix-22802.md
+++ b/docs/notes/bugfix-22802.md
@@ -1,0 +1,1 @@
+# Fix crash in HTML5 standalones when fetching the system date or system time

--- a/engine/src/sysunxdate.cpp
+++ b/engine/src/sysunxdate.cpp
@@ -155,7 +155,7 @@ bool MCS_secondstodatetime(double p_seconds, MCDateTime& r_datetime)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if defined(_LINUX_DESKTOP) || defined(_LINUX_SERVER)
+#if defined(_LINUX_DESKTOP) || defined(_LINUX_SERVER) || defined(__EMSCRIPTEN__)
 
 #include <locale.h>
 #include <langinfo.h>


### PR DESCRIPTION
This patch fixes a crash fetching system date & time values by using the posix implementation of MCS_getdatetimelocale, which was previously missing from the emscripten engine.

Closes https://quality.livecode.com/show_bug.cgi?id=22802