### PR TITLE
 [Bugfix-22795] Correct documented opacity range in mobileBusyIndicatorStart

### DIFF
--- a/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
+++ b/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
@@ -36,7 +36,7 @@ Specifies the message that is to appear on the busy indicator dialog.
 
 opacity:
 Specifies the opacity of the busy indicator, which can lie in the range
-0 - 100. The default value is 42. This option is only available for iOS.
+1 - 100. The default value is 42. This option is only available for iOS.
 
 Description:
 Use the <mobileBusyIndicatorStart> command to show a native busy

--- a/docs/notes/bugfix-22795.md
+++ b/docs/notes/bugfix-22795.md
@@ -1,0 +1,1 @@
+# Corrected documented opacity range in mobileBusyIndicatorStart


### PR DESCRIPTION
Changed the minimum in the documented opacity range from 0 to 1 in mobileBusyIndicatorStart's docs.