### PR TITLE
[Bugfix-22796] Add info about activity/busy indicators' input blocking

### DIFF
--- a/docs/dictionary/command/iphoneActivityIndicatorStart.lcdoc
+++ b/docs/dictionary/command/iphoneActivityIndicatorStart.lcdoc
@@ -52,5 +52,10 @@ location on the screen. If a location is not specified, then the
 animation is positioned in the middle of the screen. You can turn the
 activity indicator off by calling <iphoneActivityIndicatorStop>.
 
-References: iphoneActivityIndicatorStop (command)
+While this busy indicator is displayed, user input continues to be
+accepted. This is different to the behavior from the indicator 
+displayed by <mobileBusyIndicatorStart>.
+
+References: iphoneActivityIndicatorStop (command),
+mobileBusyIndicatorStart (command)
 

--- a/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
+++ b/docs/dictionary/command/mobileBusyIndicatorStart.lcdoc
@@ -48,5 +48,10 @@ indicator on the top of the LiveCode stack that is running.
 You can turn the busy indicator off by calling
 <mobileBusyIndicatorStop>. 
 
-References: mobileBusyIndicatorStop (command)
+While this busy indicator is displayed, user input is blocked. This is
+different to the behavior from the indicator displayed 
+by <iphoneActivityIndicatorStart>.
 
+
+References: mobileBusyIndicatorStop (command), 
+iphoneActivityIndicatorStart (command)

--- a/docs/notes/bugfix-22796.md
+++ b/docs/notes/bugfix-22796.md
@@ -1,0 +1,1 @@
+# Documented iphoneActivityIndicatorStart and mobileBusyIndicatorStart's input blocking behaviours.


### PR DESCRIPTION
Explained in their dictionary entries that iphoneActivityIndicatorStart will not block user input whereas mobileActivityIndicatorStart will.