### PR TITLE
[[ Foundation ]] Prevent emission of logging parameters in release mode

### DIFF
--- a/libfoundation/include/foundation.h
+++ b/libfoundation/include/foundation.h
@@ -1025,11 +1025,11 @@ extern void __MCUnreachable(void) ATTRIBUTE_NORETURN;
 
 #else
 
-#define MCAssert(expr) (void) (expr)
+#define MCAssert(expr)  (void)(0 ? (expr) : 0)
 
-#define MCLog(...) (void) (__VA_ARGS__)
+#define MCLog(...) (void)(0 ? (__VA_ARGS__) : 0)
 
-#define MCLogWithTrace(...) (void) (__VA_ARGS__)
+#define MCLogWithTrace(...) (void)(0 ? (__VA_ARGS__) : 0)
 
 #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >  4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 5)))
 


### PR DESCRIPTION
This patch ensures that `MCAssert`, `MCLog` and `MCLogWithTrace` only generate
executable code when building in debug mode.

Previously, the arguments to these macros would still be emitted as source
resulting in unwanted (and unused) expression evaluation at runtime. This
was done to eliminate unused variable errors for variables only used as
part of arguments to those macros.

Now, the arguments are still emitted as source in release mode but they are
contained within an if which will never be taken at runtime. This will mean
that the code should also be eliminated at compile-time as well.