### PR TITLE
[[ Bug 22763 ]] Ensure the captured image is not rotated when saved

### DIFF
--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -2234,10 +2234,12 @@ public class Engine extends View implements EngineApi
 					
 					/* In API Level >= 24, you have to use an input stream to make sure that access
 					 * to a photo in the library is granted. Before that you can just open the photo's
-					 * file direct. */
+					 * file directly. */
 					ExifInterface t_exif;
 					if (Build.VERSION.SDK_INT >= 24)
 					{
+						t_in.close();
+						t_in = ((LiveCodeActivity)getContext()).getContentResolver().openInputStream(t_photo_uri);
 						t_exif = new ExifInterface(t_in);
 					}
 					else


### PR DESCRIPTION
This patch ensures that the captured image returned by
mobilePickPhoto is not rotated. This is achieved by closing the
(now finished) original stream, and then creating a new one.