### PR TITLE
[[ Bug 22840 ]] Activate IME in redraw

### DIFF
--- a/docs/notes/bugfix-22840.md
+++ b/docs/notes/bugfix-22840.md
@@ -1,0 +1,4 @@
+# Improved IME activation
+
+The IME (soft keyboard on mobile) is now activated and deactivated if required
+only on redraw. The change allows `lock screen` to delay changes to the IME.

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -66,6 +66,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include "stackfileformat.h"
 
+#include "mode.h"
+
 MCRectangle MCCard::selrect;
 int2 MCCard::startx;
 int2 MCCard::starty;
@@ -804,7 +806,7 @@ Boolean MCCard::mdown(uint2 which)
 #ifdef _MOBILE
 				// Make sure the IME has gone away on mobile if due to an explicit card
 				// click.
-				MCscreen -> closeIME();
+				MCModeActivateIme(getstack(), false);
 #endif
 				message_with_valueref_args(MCM_mouse_down, MCSTR("1"));
 				if (!(MCbuttonstate & (0x1L << (which - 1))))

--- a/engine/src/desktop-dc.cpp
+++ b/engine/src/desktop-dc.cpp
@@ -926,20 +926,12 @@ void MCScreenDC::clearIME(Window w)
 	MCPlatformResetTextInputInWindow(MCactivefield -> getstack() -> getwindow());
 }
 
-void MCScreenDC::openIME()
-{
-}
-
 void MCScreenDC::activateIME(Boolean activate)
 {
 	if (!MCactivefield)
 		return;
 	
 	MCPlatformConfigureTextInputInWindow(MCactivefield -> getstack() -> getwindow(), activate);
-}
-
-void MCScreenDC::closeIME()
-{
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/desktop-dc.h
+++ b/engine/src/desktop-dc.h
@@ -109,9 +109,7 @@ public:
 	virtual void flushevents(uint2 e);
 	
 	virtual void clearIME(Window w);
-	virtual void openIME();
 	virtual void activateIME(Boolean activate);
-	virtual void closeIME();
 	
 	virtual void seticon(uint4 p_icon);
 	virtual void seticonmenu(MCStringRef p_menu);

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1294,7 +1294,7 @@ void MCInterfaceExecFocusOnNothing(MCExecContext &ctxt)
 		MCfocusedstackptr -> getcard() -> kunfocus();
 #ifdef _MOBILE
 	// Make sure the IME is forced closed if explicitly asked to be.
-	MCscreen -> closeIME();
+	MCModeActivateIme(ctxt.GetObject() -> getstack(), false);
 #endif
 }
 

--- a/engine/src/lnxdc.h
+++ b/engine/src/lnxdc.h
@@ -352,8 +352,7 @@ public:
     virtual void clearIME(Window w);
     virtual void configureIME(int32_t x, int32_t y);
 	virtual void activateIME(Boolean activate);
-	//virtual void closeIME();
-    
+	
     virtual bool loadfont(MCStringRef p_path, bool p_globally, void*& r_loaded_font_handle);
     virtual bool unloadfont(MCStringRef p_path, bool p_globally, void *r_loaded_font_handle);
 

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -639,10 +639,6 @@ void MCScreenDC::pingwait(void)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCScreenDC::openIME()
-{
-}
-
 extern int32_t MCInterfaceAndroidKeyboardEnumFromMCExecEnum(MCInterfaceKeyboardType p_type);
 extern int32_t MCInterfaceAndroidReturnKeyTypeEnumFromMCExecEnum(MCInterfaceReturnKeyType p_type);
 void MCScreenDC::activateIME(Boolean activate)
@@ -670,10 +666,6 @@ void MCScreenDC::activateIME(Boolean activate)
     }
     
     MCAndroidEngineRemoteCall("setTextInputVisible", "vbii", nil, activate, t_keyboard_type, t_return_key_type);
-}
-
-void MCScreenDC::closeIME()
-{
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mbldc.h
+++ b/engine/src/mbldc.h
@@ -169,10 +169,8 @@ public:
 //	char *charsettofontname(uint1 charset, const char *oldfontname);
 	
 	void clearIME(Window w);
-	void openIME();
 	void activateIME(Boolean activate);
-	void closeIME();
-
+	
 	void enactraisewindows(void);
 	
 	//

--- a/engine/src/mbliphonedc.mm
+++ b/engine/src/mbliphonedc.mm
@@ -784,10 +784,6 @@ void MCScreenDC::pingwait(void)
 	MCIPhoneBreakWait();
 }
 
-void MCScreenDC::openIME()
-{
-}
-
 void MCScreenDC::activateIME(Boolean activate)
 {
 	// MW-2012-08-06: [[ Fibers ]] Execute the system code on the main fiber.
@@ -796,14 +792,6 @@ void MCScreenDC::activateIME(Boolean activate)
 			MCIPhoneActivateKeyboard();
 	else
 			MCIPhoneDeactivateKeyboard();
-	});
-}
-
-void MCScreenDC::closeIME()
-{
-	// MW-2012-08-06: [[ Fibers ]] Execute the system code on the main fiber.
-	MCIPhoneRunBlockOnMainFiber(^(void) {
-		MCIPhoneDeactivateKeyboard();
 	});
 }
 

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -672,7 +672,7 @@ bool MCModeMakeLocalWindows(void)
 
 void MCModeActivateIme(MCStack *p_stack, bool p_activate)
 {
-	MCscreen -> activateIME(p_activate);
+	MCscreen -> pendingIME(p_activate);
 }
 
 void MCModeConfigureIme(MCStack *p_stack, bool p_enabled, int32_t x, int32_t y)

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1659,7 +1659,7 @@ bool MCModeMakeLocalWindows(void)
 
 void MCModeActivateIme(MCStack *p_stack, bool p_activate)
 {
-	MCscreen -> activateIME(p_activate);
+	MCscreen -> pendingIME(p_activate);
 }
 
 void MCModeConfigureIme(MCStack *p_stack, bool p_enabled, int32_t x, int32_t y)

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -1278,7 +1278,7 @@ bool MCModeMakeLocalWindows(void)
 
 void MCModeActivateIme(MCStack *p_stack, bool p_activate)
 {
-	MCscreen -> activateIME(p_activate);
+	MCscreen -> pendingIME(p_activate);
 }
 
 void MCModeConfigureIme(MCStack *p_stack, bool p_enabled, int32_t x, int32_t y)

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1441,6 +1441,8 @@ void MCRedrawDoUpdateScreen(void)
 {
 	if (MClockscreen != 0)
 		return;
+	
+	MCscreen->updateIME();
 
 	if (!s_screen_is_dirty)
 		return;

--- a/engine/src/uidc.cpp
+++ b/engine/src/uidc.cpp
@@ -335,6 +335,9 @@ MCUIDC::MCUIDC()
 	m_runloop_actions = nil;
     
     m_modal_loops = NULL;
+	
+	m_ime_activate = false;
+	m_pending_ime_activate = false;
 }
 
 MCUIDC::~MCUIDC()
@@ -1114,16 +1117,27 @@ uint1 MCUIDC::fontnametocharset(MCStringRef p_fontname)
 	return 0;
 }
 
-void MCUIDC::openIME()
-{}
 void MCUIDC::activateIME(Boolean activate)
 {}
 void MCUIDC::clearIME(Window w)
 {}
-void MCUIDC::closeIME()
-{}
 void MCUIDC::configureIME(int32_t x, int32_t y)
 {}
+
+void MCUIDC::updateIME()
+{
+	if (m_pending_ime_activate)
+	{
+		m_pending_ime_activate = false;
+		activateIME(m_ime_activate);
+	}
+}
+
+void MCUIDC::pendingIME(bool p_activate)
+{
+	m_pending_ime_activate = true;
+	m_ime_activate = p_activate;
+}
 
 void MCUIDC::updatemenubar(Boolean force)
 {

--- a/engine/src/uidc.h
+++ b/engine/src/uidc.h
@@ -372,6 +372,8 @@ protected:
 	// IM-2014-03-06: [[ revBrowserCEF ]] List of actions to run during the runloop
 	MCRunloopAction *m_runloop_actions;
 	
+	bool m_ime_activate;
+	bool m_pending_ime_activate;
 public:
 	MCColor white_pixel;
 	MCColor black_pixel;
@@ -594,9 +596,9 @@ public:
 	
 	virtual void clearIME(Window w);
     virtual void configureIME(int32_t x, int32_t y);
-	virtual void openIME();
 	virtual void activateIME(Boolean activate);
-	virtual void closeIME();
+	void pendingIME(bool activate);
+	void updateIME();
 
 	virtual void seticon(uint4 p_icon);
 	virtual void seticonmenu(MCStringRef p_menu);

--- a/engine/src/w32dc.h
+++ b/engine/src/w32dc.h
@@ -283,10 +283,8 @@ public:
 //	virtual char *charsettofontname(uint1 chharset, const char *oldfontname);
 	virtual uint1 fontnametocharset(MCStringRef p_fontname);
 	virtual void clearIME(Window w);
-	virtual void openIME();
 	virtual void activateIME(Boolean activate);
-	virtual void closeIME();
-
+	
 	virtual void enablebackdrop(bool p_hard);
 	virtual void disablebackdrop(bool p_hard);
 

--- a/engine/src/w32dce.cpp
+++ b/engine/src/w32dce.cpp
@@ -714,9 +714,6 @@ char *MCScreenDC::charsettofontname(uint1 charset, const char *oldfontname)
 }
 */
 
-void MCScreenDC::openIME()
-{}
-
 void MCScreenDC::activateIME(Boolean activate)
 {}
 
@@ -727,5 +724,3 @@ void MCScreenDC::clearIME(Window w)
 	ImmReleaseContext((HWND)w->handle.window,hIMC);
 }
 
-void MCScreenDC::closeIME()
-{}


### PR DESCRIPTION
This patch moves IME activation to screen redraw. This has the benefit of
limiting repeated IME activation/deactivation when setting field properties. It
additionally allows `lock screen` to be used to control IME activation.