### PR TITLE
[[ Bug 22839 ]] Clear focused control ref from card when relayering

### DIFF
--- a/docs/notes/bugfix-22839.md
+++ b/docs/notes/bugfix-22839.md
@@ -1,0 +1,1 @@
+# Fix crash when relayering focused control into group

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1646,6 +1646,9 @@ void MCCard::relayercontrol_remove(MCControl *p_control)
 	
 	// Remove the control from the card's objptr list.
 	t_control_ptr -> remove(objptrs);
+	// make sure this card no longer points to the removed control
+	clearfocus(t_control_ptr, nullptr);
+	
 	delete t_control_ptr;
 
 	// Remove the control from the stack's list.


### PR DESCRIPTION
This patch ensures there are no lingering keyboard or mouse focus control
references after relayering a control from card to group owner.