### PR TITLE
[[ emscripten ]] Keep hidden input field in fixed position in browser window

### DIFF
--- a/engine/src/em-event.js
+++ b/engine/src/em-event.js
@@ -114,9 +114,14 @@ mergeInto(LibraryManager.library, {
 			// Create the hidden input element
 			var tInput = document.createElement('input');
 			tInput.type = 'text';
-			tInput.style.position = 'absolute';
+			tInput.style.position = 'fixed';
+			tInput.style.display = 'block';
 			tInput.style.zIndex = 0;
 			tInput.style.opacity = 0;
+			tInput.style.setProperty('left', '0px', 'important');
+			tInput.style.setProperty('top', '0px', 'important');
+			tInput.style.setProperty('width', '1px', 'important');
+			tInput.style.setProperty('height', '1px', 'important');
 
 			LiveCodeEvents._inputelement = tInput;
 			document.body.appendChild(tInput);


### PR DESCRIPTION
This patch changes the CSS style of the hidden input field used to detect input events to ensure it is kept within the visible area of the page within the browser. This change prevents the browser window from scrolling when focus is passed to the hidden field, even in browsers that don't support the 'preventScroll' passed to the Element.focus method.