### PR TITLE
[[ Bug 22843 ]] Implement modal/sheet without waiting

### DIFF
--- a/docs/dictionary/command/go.lcdoc
+++ b/docs/dictionary/command/go.lcdoc
@@ -4,7 +4,7 @@ Synonyms: open
 
 Type: command
 
-Syntax: go [{visible | invisible}] [to] <card> [of <stack>] [{as <mode> |in [a] new window|in <window>}]
+Syntax: go [{visible | invisible}] [to] <card> [of <stack>] [{as <mode> [without waiting]|in [a] new window|in <window>}]
 
 Syntax: go [{visible | invisible}] [to] {first | prev[ious]| next | last | any} [marked] [<card>]
 
@@ -48,6 +48,9 @@ set the defaultFolder to tStackFolder
 go stack "somethingElse.livecode"
 -- "somethingElse" being the name of a stack file in the same folder
 
+Example:
+go stack "EditRecord" as modal without waiting
+
 Parameters:
 card:
 Any card reference. Cards can be described by their name, number, or ID
@@ -60,13 +63,13 @@ command opens the main stack of the specified stack file.
 
 mode (enum):
 
--   editable window
--   palette
--   modal dialog box
--   modeless dialog box 
--   sheet dialog box - appears in <defaultStack(property)>
--   drawer - appears in <defaultStack(property)>, centered at left 
-    side if there's room 
+- toplevel: editable window
+- palette
+- modal: dialog box
+- modeless: dialog box 
+- sheet: dialog box - appears in <defaultStack(property)>
+- drawer: appears in <defaultStack(property)>, centered at left 
+  side if there's room 
 
 
 window:

--- a/docs/dictionary/command/modal.lcdoc
+++ b/docs/dictionary/command/modal.lcdoc
@@ -2,7 +2,7 @@ Name: modal
 
 Type: command
 
-Syntax: modal <stack>
+Syntax: modal <stack> [without waiting]
 
 Summary:
 Opens a <stack> as a <modal dialog box>.
@@ -18,6 +18,9 @@ modal stack "Custom Answer Dialog"
 
 Example:
 modal stack x of stacksToPresent
+
+Example:
+modal stack "NewRecord" without waiting
 
 Parameters:
 stack:
@@ -56,13 +59,13 @@ are sent regardless of the setting of the <lockMessages> <property>.
 If the stack is already displayed as a modal dialog box, the <modal>
 <command> does not close and reopen it.
 
-The <modal> <command> pauses the running <handler> until the 
-<modal dialog box> is dismissed (usually by clicking a button in the 
-<modal dialog box>). To <return> information to the <handler> about 
-which <button(keyword)> was clicked, in the <button(object)|button's>
-<script>, set a <global|global variable> or <custom property>. After the
-<dialog box> is dismissed, the <handler> can query this <variable> or
-<property> and act accordingly.
+Unless the without waiting clause is used the <modal> <command> pauses
+the running <handler> until the  <modal dialog box> is dismissed (usually
+by clicking a button in the  <modal dialog box>). To <return> information
+to the <handler> about  which <button(keyword)> was clicked, in the
+<button(object)|button's> <script>, set a <global|global variable> or
+<custom property>. After the <dialog box> is dismissed, the <handler> can
+query this <variable> or <property> and act accordingly.
 
 Modal dialog boxes cannot be resized or edited. To edit a modal dialog
 box, use the topLevel <command> to display it in an <editable window>.

--- a/docs/dictionary/command/sheet.lcdoc
+++ b/docs/dictionary/command/sheet.lcdoc
@@ -2,7 +2,7 @@ Name: sheet
 
 Type: command
 
-Syntax: sheet <stack> [in <parentStack>]
+Syntax: sheet <stack> [in <parentStack>] [without waiting]
 
 Summary:
 Displays a <stack> as a <sheet|sheet dialog box>.
@@ -18,6 +18,9 @@ sheet stack "myFilePickerStack"
 
 Example:
 sheet me in stack "project1"
+
+Example:
+sheet stack "ColorPicker" without waiting
 
 Parameters:
 stack:
@@ -51,13 +54,13 @@ want to prevent the close <message|messages> from being sent; the open
 <message|messages> are sent regardless of the setting of the
 <lockMessages> <property>.
 
-The <sheet> <command> pauses the running <handler> until the
-<sheet(command)> is dismissed (usually by clicking a button in the
-<sheet(command)>). To <return> information to the <handler> about which
-<button(keyword)> was clicked, in the <button(object)|button's>
-<script>, set a <global|global variable> or <custom property>. After the
-<dialog box> is dismissed, the <handler> can query this <variable> or
-<property> and act accordingly.
+Unless the without waiting clause is used the <sheet> <command> pauses
+the running <handler> until the <sheet(command)> is dismissed (usually
+by clicking a button in the <sheet(command)>). To <return> information
+to the <handler> about which <button(keyword)> was clicked, in the
+<button(object)|button's> <script>, set a <global|global variable> or
+<custom property>. After the <dialog box> is dismissed, the <handler> can
+query this <variable> or <property> and act accordingly.
 
 Attempting to open a sheet from within another sheet displays the second
 <stack> as a <modal dialog box> instead.

--- a/docs/notes/bugfix-22843.md
+++ b/docs/notes/bugfix-22843.md
@@ -1,0 +1,4 @@
+# New `without waiting` clause added to modal, sheet and go commands
+
+The new clause allows for the opening of modal and sheet dialogs without the
+handler waiting for the stack to be closed before continuing.

--- a/engine/src/button.cpp
+++ b/engine/src/button.cpp
@@ -2804,7 +2804,7 @@ void MCButton::openmenu(Boolean grab)
 			menu->menuset(menuhistory, rect.height >> 1);
 		}
 
-		menu->openrect(rel, (Window_mode)menumode, NULL, WP_DEFAULT, OP_NONE);
+		menu->openrect(rel, (Window_mode)menumode, NULL, WP_DEFAULT, OP_NONE, false);
 		menu->mode_openasmenu(t_did_grab ? sptr : NULL);
 		
 		// MW-2014-03-11: [[ Bug 11893 ]] Make sure we don't do anything to a stack panel.

--- a/engine/src/cardlst.cpp
+++ b/engine/src/cardlst.cpp
@@ -219,7 +219,7 @@ void MCCardlist::gorel(int2 offset)
 	if (sptr != MCdefaultstackptr && MCdefaultstackptr->hcstack())
 		MCdefaultstackptr->close();
 	sptr->setcard(cards->card, False, False);
-	sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE);
+	sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE, false);
 	MCdefaultstackptr = sptr;
 }
 
@@ -249,7 +249,7 @@ void MCCardlist::godirect(Boolean start)
 	if (sptr != MCdefaultstackptr && MCdefaultstackptr->hcstack())
 		MCdefaultstackptr->close();
 	sptr->setcard(cards->card, False, False);
-	sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE);
+	sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE, false);
 	MCdefaultstackptr = sptr;
 }
 

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1898,6 +1898,7 @@ class MCSubwindow : public MCStatement
 	MCExpression *properties;
 protected:
 	Window_mode mode;
+	bool m_wait_while_open;
 public:
 	MCSubwindow()
 	{
@@ -1921,6 +1922,7 @@ public:
 	MCTopLevel()
 	{
 		mode = WM_TOP_LEVEL;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1930,6 +1932,7 @@ public:
 	MCModal()
 	{
 		mode = WM_MODAL;
+		m_wait_while_open = true;
 	}
 };
 
@@ -1939,6 +1942,7 @@ public:
 	MCModeless()
 	{
 		mode = WM_MODELESS;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1948,6 +1952,7 @@ public:
 	MCOption()
 	{
 		mode = WM_OPTION;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1957,6 +1962,7 @@ public:
 	MCPalette()
 	{
 		mode = WM_PALETTE;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1966,6 +1972,7 @@ public:
 	MCPopup()
 	{
 		mode = WM_POPUP;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1975,6 +1982,7 @@ public:
 	MCPulldown()
 	{
 		mode = WM_PULLDOWN;
+		m_wait_while_open = false;
 	}
 };
 
@@ -1984,6 +1992,7 @@ public:
 	MCSheet()
 	{
 		mode = WM_SHEET;
+		m_wait_while_open = true;
 	}
 };
 
@@ -1994,6 +2003,7 @@ public:
 	MCDrawer()
 	{
 		mode = WM_DRAWER;
+		m_wait_while_open = false;
 	}
 };
 

--- a/engine/src/cmds.h
+++ b/engine/src/cmds.h
@@ -1769,6 +1769,7 @@ class MCGo : public MCStatement
 	
 	MCChunk *widget;
 	Chunk_term direction;
+	bool m_wait_while_open;
 public:
     MCGo() :
         background(nil),
@@ -1780,7 +1781,8 @@ public:
         visibility_type(kMCInterfaceExecGoVisibilityImplicit),
         thisstack(False),
 		widget(nil),
-        direction(CT_BACKWARD)
+        direction(CT_BACKWARD),
+		m_wait_while_open(false)
     {
         ;
     };

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -1490,6 +1490,13 @@ Parse_stat MCSubwindow::parse(MCScriptPoint &sp)
 			return PS_ERROR;
 		}
 	}
+	else if ((mode == WM_MODAL || mode == WM_SHEET) &&
+		(sp.skip_token(SP_SUGAR, TT_PREP, PT_WITHOUT) == PS_NORMAL) &&
+		(sp.skip_token(SP_MOVE, TT_UNDEFINED, MM_WAITING) == PS_NORMAL))
+	{
+		m_wait_while_open = false;
+	}
+			 
 	return PS_NORMAL;
 }
 
@@ -1558,9 +1565,9 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 		case WM_PALETTE:
 		case WM_MODAL:
 			if (*optr_name != nil)
-				MCInterfaceExecOpenStackByName(ctxt, *optr_name, mode);
+				MCInterfaceExecOpenStackByName(ctxt, *optr_name, mode, m_wait_while_open);
 			else
-				MCInterfaceExecOpenStack(ctxt, (MCStack *)optr, mode);
+				MCInterfaceExecOpenStack(ctxt, (MCStack *)optr, mode, m_wait_while_open);
 		break;
 		case WM_SHEET:
 		case WM_DRAWER:
@@ -1572,9 +1579,9 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 				if (mode == WM_SHEET)
 				{
 					if (*optr_name != nil)
-						MCInterfaceExecSheetStackByName(ctxt, *optr_name, *t_parent_name, thisstack == True);
+						MCInterfaceExecSheetStackByName(ctxt, *optr_name, *t_parent_name, thisstack == True, m_wait_while_open);
 					else
-						MCInterfaceExecSheetStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True);
+						MCInterfaceExecSheetStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True, m_wait_while_open);
 				}
 				else
 				{
@@ -1630,9 +1637,9 @@ void MCSubwindow::exec_ctxt(MCExecContext &ctxt)
 						}
 					}
 					if (optr == nil)
-						MCInterfaceExecDrawerStackByName(ctxt, *optr_name, *t_parent_name, thisstack == True, t_pos, t_align);
+						MCInterfaceExecDrawerStackByName(ctxt, *optr_name, *t_parent_name, thisstack == True, t_pos, t_align, m_wait_while_open);
 					else
-						MCInterfaceExecDrawerStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True, t_pos, t_align);
+						MCInterfaceExecDrawerStack(ctxt, (MCStack *)optr, *t_parent_name, thisstack == True, t_pos, t_align, m_wait_while_open);
 				}
 				break;
 			}

--- a/engine/src/cmdss.cpp
+++ b/engine/src/cmdss.cpp
@@ -204,6 +204,19 @@ Parse_stat MCGo::parse(MCScriptPoint &sp)
 						(PE_GO_NOMODE, sp);
 						return PS_ERROR;
 					}
+					
+					if (mode == WM_MODAL || mode == WM_SHEET)
+					{
+						if ((sp.skip_token(SP_SUGAR, TT_PREP, PT_WITHOUT) == PS_NORMAL) &&
+							(sp.skip_token(SP_MOVE, TT_UNDEFINED, MM_WAITING) == PS_NORMAL))
+						{
+							m_wait_while_open = false;
+						}
+						else
+						{
+							m_wait_while_open = true;
+						}
+					}
 				}
 				else
 				{
@@ -748,7 +761,7 @@ void MCGo::exec_ctxt(MCExecContext &ctxt)
 	else if (window != nil)
 		MCInterfaceExecGoCardInWindow(ctxt, cptr, *t_window, visibility_type, thisstack == True);
 	else
-        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visibility_type, thisstack == True);
+        MCInterfaceExecGoCardAsMode(ctxt, cptr, mode, visibility_type, thisstack == True, m_wait_while_open);
 }
 
 MCHide::~MCHide()

--- a/engine/src/exec-dialog.cpp
+++ b/engine/src/exec-dialog.cpp
@@ -448,7 +448,7 @@ void MCDialogExecCustomAnswerDialog(MCExecContext &ctxt, MCNameRef p_stack, MCNa
             added = True;
         }
         
-		t_success = ES_NORMAL == t_stack->openrect(t_parent_stack->getrect(), p_sheet ? WM_SHEET : WM_MODAL, p_sheet ? t_parent_stack : nil, WP_DEFAULT, OP_NONE);
+		t_success = ES_NORMAL == t_stack->openrect(t_parent_stack->getrect(), p_sheet ? WM_SHEET : WM_MODAL, p_sheet ? t_parent_stack : nil, WP_DEFAULT, OP_NONE, true);
         
         if (added)
             MCnexecutioncontexts--;
@@ -746,7 +746,7 @@ void MCDialogExecCustomAskDialog(MCExecContext& ctxt, MCNameRef p_stack, MCNameR
             added = True;
         }
         
-		t_success = ES_NORMAL == t_stack->openrect(t_parent_stack->getrect(), p_as_sheet ? WM_SHEET : WM_MODAL, p_as_sheet ? t_parent_stack : nil, WP_DEFAULT, OP_NONE);
+		t_success = ES_NORMAL == t_stack->openrect(t_parent_stack->getrect(), p_as_sheet ? WM_SHEET : WM_MODAL, p_as_sheet ? t_parent_stack : nil, WP_DEFAULT, OP_NONE, true);
         
         if (added)
             MCnexecutioncontexts--;

--- a/engine/src/exec-ide.cpp
+++ b/engine/src/exec-ide.cpp
@@ -57,7 +57,7 @@ void MCIdeExecShowMessageBox(MCExecContext& ctxt)
 
 	// MW-2007-08-14: [[ Bug 3310 ]] - "show message box" toplevels rather than palettes
 	if (mb != NULL)
-		mb->openrect(ctxt . GetObject()->getstack()->getrect(), WM_PALETTE, NULL, WP_DEFAULT, OP_NONE);
+		mb->openrect(ctxt . GetObject()->getstack()->getrect(), WM_PALETTE, NULL, WP_DEFAULT, OP_NONE, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -4335,7 +4335,7 @@ void MCInterfaceExecChooseTool(MCExecContext& ctxt, MCStringRef p_input, int p_t
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, MCInterfaceExecGoVisibility p_visibility_type)
+void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, int p_mode, bool p_this_stack, MCInterfaceExecGoVisibility p_visibility_type, bool p_wait_while_open)
 {
 	
 	if (p_card == nil)
@@ -4549,14 +4549,14 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 		ctxt . Throw();
 }
 
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack)
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack, bool p_wait_while_open)
 {
-	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visibility_type);
+	MCInterfaceExecGo(ctxt, p_card, nil, p_mode, p_this_stack, p_visibility_type, p_wait_while_open);
 }
 
 void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack)
 {
-	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visibility_type);
+	MCInterfaceExecGo(ctxt, p_card, p_window, WM_MODELESS, p_this_stack, p_visibility_type, false);
 }
 
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt)
@@ -4582,7 +4582,7 @@ void MCInterfaceExecGoHome(MCExecContext& ctxt, MCCard *p_card)
 		MCdefaultstackptr->close();
 		MCdefaultstackptr->checkdestroy();
 	}
-	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, kMCInterfaceExecGoVisibilityImplicit);
+	MCInterfaceExecGo(ctxt, p_card, nil, 0, false, kMCInterfaceExecGoVisibilityImplicit, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -2794,7 +2794,7 @@ void MCInterfaceExecPopupButton(MCExecContext& ctxt, MCButton *p_target, MCPoint
 	}
 }
 
-void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p_parent, MCRectangle p_rect, int p_at, int p_aligned, int p_mode)
+void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p_parent, MCRectangle p_rect, int p_at, int p_aligned, int p_mode, bool p_wait_while_open)
 {
 	if (p_mode != WM_PULLDOWN && p_mode != WM_POPUP && p_mode != WM_OPTION)
     	MCU_watchcursor(ctxt . GetObject()->getstack(), False);
@@ -2836,7 +2836,7 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
 		MCdefaultstackptr = t_old_defaultstack;
 }
 
-void MCInterfaceExecDrawerOrSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, int p_mode)
+void MCInterfaceExecDrawerOrSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, int p_mode, bool p_wait_while_open)
 {
 	MCStack *parentptr;
     parentptr = nil;
@@ -2864,15 +2864,15 @@ void MCInterfaceExecDrawerOrSheetStack(MCExecContext& ctxt, MCStack *p_target, M
 		}
 		else
             // AL-2014-11-24: [[ Bug 14076 ]] Don't override window mode with WM_DRAWER
-			MCInterfaceExecSubwindow(ctxt, p_target, parentptr, parentptr->getrect(), p_at, p_aligned, p_mode);
+			MCInterfaceExecSubwindow(ctxt, p_target, parentptr, parentptr->getrect(), p_at, p_aligned, p_mode, p_wait_while_open);
 	}
 	else if (MCdefaultstackptr->getopened() || !MCtopstackptr)
-		MCInterfaceExecSubwindow(ctxt, p_target, MCdefaultstackptr, MCdefaultstackptr->getrect(), p_at, p_aligned, p_mode);
+		MCInterfaceExecSubwindow(ctxt, p_target, MCdefaultstackptr, MCdefaultstackptr->getrect(), p_at, p_aligned, p_mode, p_wait_while_open);
 	else
-		MCInterfaceExecSubwindow(ctxt, p_target, MCtopstackptr, MCtopstackptr->getrect(), p_at, p_aligned, p_mode);
+		MCInterfaceExecSubwindow(ctxt, p_target, MCtopstackptr, MCtopstackptr->getrect(), p_at, p_aligned, p_mode, p_wait_while_open);
 }
 
-void MCInterfaceExecDrawerOrSheetStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, int p_mode)
+void MCInterfaceExecDrawerOrSheetStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, int p_mode, bool p_wait_while_open)
 {
 	MCStack *sptr;
 	sptr = ctxt . GetObject()->getstack()->findstackname(p_name);
@@ -2884,37 +2884,27 @@ void MCInterfaceExecDrawerOrSheetStackByName(MCExecContext& ctxt, MCNameRef p_na
 		return;
 	}
 	
-	MCInterfaceExecDrawerOrSheetStack(ctxt, sptr, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, p_mode);
+	MCInterfaceExecDrawerOrSheetStack(ctxt, sptr, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, p_mode, p_wait_while_open);
 }
 
-void MCInterfaceExecDrawerStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned)
+void MCInterfaceExecDrawerStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, bool p_wait_while_open)
 {	
-	MCInterfaceExecDrawerOrSheetStack(ctxt, p_target, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, WM_DRAWER);
+	MCInterfaceExecDrawerOrSheetStack(ctxt, p_target, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, WM_DRAWER, p_wait_while_open);
 }
 
-void MCInterfaceExecDrawerStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned)
+void MCInterfaceExecDrawerStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack, int p_at, int p_aligned, bool p_wait_while_open)
 {	
-	MCInterfaceExecDrawerOrSheetStackByName(ctxt, p_name, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, WM_DRAWER);
+	MCInterfaceExecDrawerOrSheetStackByName(ctxt, p_name, p_parent_name, p_parent_is_thisstack, p_at, p_aligned, WM_DRAWER, p_wait_while_open);
 }
 
-void MCInterfaceExecDrawerStackLegacy(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack, intenum_t p_at, intenum_t p_aligned)
+void MCInterfaceExecSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack, bool p_wait_while_open)
 {
-	MCInterfaceExecDrawerStack(ctxt, p_target, parent, p_parent_is_thisstack, (int)p_at, (int)p_aligned);
+	MCInterfaceExecDrawerOrSheetStack(ctxt, p_target, p_parent_name, p_parent_is_thisstack, WP_DEFAULT, OP_CENTER, WM_SHEET, p_wait_while_open);
 }
 
-void MCInterfaceExecDrawerStackByNameLegacy(MCExecContext& ctxt, MCNameRef p_name, MCNameRef parent, bool p_parent_is_thisstack, intenum_t p_at, intenum_t p_aligned)
+void MCInterfaceExecSheetStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack, bool p_wait_while_open)
 {
-	MCInterfaceExecDrawerStackByName(ctxt, p_name, parent, p_parent_is_thisstack, (int)p_at, (int)p_aligned);
-}
-
-void MCInterfaceExecSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef p_parent_name, bool p_parent_is_thisstack)
-{
-	MCInterfaceExecDrawerOrSheetStack(ctxt, p_target, p_parent_name, p_parent_is_thisstack, WP_DEFAULT, OP_CENTER, WM_SHEET);
-}
-
-void MCInterfaceExecSheetStackByName(MCExecContext& ctxt, MCNameRef p_name, MCNameRef p_parent_name, bool p_parent_is_thisstack)
-{
-	MCInterfaceExecDrawerOrSheetStackByName(ctxt, p_name, p_parent_name, p_parent_is_thisstack, WP_DEFAULT, OP_CENTER, WM_SHEET);
+	MCInterfaceExecDrawerOrSheetStackByName(ctxt, p_name, p_parent_name, p_parent_is_thisstack, WP_DEFAULT, OP_CENTER, WM_SHEET, p_wait_while_open);
 }
 
 static MCStack* open_stack_relative_to(MCStack *p_target)
@@ -2927,13 +2917,13 @@ static MCStack* open_stack_relative_to(MCStack *p_target)
         return p_target;
 }
 
-void MCInterfaceExecOpenStack(MCExecContext& ctxt, MCStack *p_target, int p_mode)
+void MCInterfaceExecOpenStack(MCExecContext& ctxt, MCStack *p_target, int p_mode, bool p_wait_while_open)
 {
     MCStack* t_stack = open_stack_relative_to(p_target);
-    MCInterfaceExecSubwindow(ctxt, p_target, nil, t_stack->getrect(), WP_DEFAULT, OP_NONE, p_mode);
+    MCInterfaceExecSubwindow(ctxt, p_target, nil, t_stack->getrect(), WP_DEFAULT, OP_NONE, p_mode, p_wait_while_open);
 }
 
-void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_name, int p_mode)
+void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_name, int p_mode, bool p_wait_while_open)
 {
 	MCStack *sptr;
 	sptr = ctxt . GetObject()->getstack()->findstackname(p_name);
@@ -2945,7 +2935,7 @@ void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_name, int p
 		return;
 	}
 	
-	MCInterfaceExecOpenStack(ctxt, sptr, p_mode);
+	MCInterfaceExecOpenStack(ctxt, sptr, p_mode, p_wait_while_open);
 }
 
 void MCInterfaceExecPopupStack(MCExecContext& ctxt, MCStack *p_target, MCPoint *p_at, int p_mode)
@@ -2972,7 +2962,7 @@ void MCInterfaceExecPopupStack(MCExecContext& ctxt, MCStack *p_target, MCPoint *
 		}
 		MCRectangle t_rect;
 		t_rect = MCU_recttoroot(MCtargetptr -> getstack(), MCtargetptr -> getrect());
-		MCInterfaceExecSubwindow(ctxt, p_target, nil, t_rect, WP_DEFAULT, OP_NONE, p_mode);
+		MCInterfaceExecSubwindow(ctxt, p_target, nil, t_rect, WP_DEFAULT, OP_NONE, p_mode, false);
 		if (!MCabortscript)
 			return;
 

--- a/engine/src/exec-interface.cpp
+++ b/engine/src/exec-interface.cpp
@@ -1611,7 +1611,7 @@ void MCInterfaceExecPopToLast(MCExecContext& ctxt)
 	Boolean oldtrace = MCtrace;
 	MCtrace = False;
 	if (sptr->setcard(cptr, True, False) == ES_NORMAL
-		        && sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE) == ES_NORMAL)
+		        && sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE, false) == ES_NORMAL)
 	{
 		MCtrace = oldtrace;
 		return;
@@ -1824,7 +1824,7 @@ static void MCInterfaceRevertStack(MCExecContext& ctxt, MCStack *p_stack)
         p_stack -> scheduledelete();
         p_stack = MCdispatcher->findstackname(*t_name);
         if (p_stack != NULL)
-            p_stack->openrect(oldrect, oldmode, NULL, WP_DEFAULT, OP_NONE);
+            p_stack->openrect(oldrect, oldmode, NULL, WP_DEFAULT, OP_NONE, oldmode == WM_MODAL || oldmode == WM_SHEET);
     }
     else
         ctxt . Throw();
@@ -2814,7 +2814,7 @@ void MCInterfaceExecSubwindow(MCExecContext& ctxt, MCStack *p_target, MCStack *p
 		added = True;
 	}
     
-	if (p_target->openrect(p_rect, (Window_mode)p_mode, p_parent, (Window_position)p_at, (Object_pos)p_aligned) != ES_NORMAL)
+	if (p_target->openrect(p_rect, (Window_mode)p_mode, p_parent, (Window_position)p_at, (Object_pos)p_aligned, p_wait_while_open) != ES_NORMAL)
     {
         ctxt.Throw();
     }
@@ -4493,7 +4493,7 @@ void MCInterfaceExecGo(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window
 #endif	
 	
 	if (t_stack->setcard(p_card, True, True) == ES_ERROR
-	        || t_stack->openrect(rel, wm, parentptr, WP_DEFAULT, OP_NONE) == ES_ERROR)
+	        || t_stack->openrect(rel, wm, parentptr, WP_DEFAULT, OP_NONE,p_wait_while_open) == ES_ERROR)
 	{
 		MCtrace = oldtrace;
 		stat = ES_ERROR;

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2383,14 +2383,12 @@ void MCInterfaceExecShowTaskBar(MCExecContext& ctxt);
 
 void MCInterfaceExecPopupWidget(MCExecContext &ctxt, MCNameRef p_kind, MCPoint *p_at, MCArrayRef p_properties);
 void MCInterfaceExecPopupButton(MCExecContext& ctxt, MCButton *p_target, MCPoint *p_at);
-void MCInterfaceExecDrawerStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack, int p_at, int p_aligned);
-void MCInterfaceExecDrawerStackByName(MCExecContext& ctxt, MCNameRef p_target, MCNameRef parent, bool p_parent_is_thisstack, int p_at, int p_aligned);
-void MCInterfaceExecDrawerStackLegacy(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack, intenum_t p_at, intenum_t p_aligned);
-void MCInterfaceExecDrawerStackByNameLegacy(MCExecContext& ctxt, MCNameRef p_target, MCNameRef parent, bool p_parent_is_thisstack, intenum_t p_at, intenum_t p_aligned);
-void MCInterfaceExecSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack);
-void MCInterfaceExecSheetStackByName(MCExecContext& ctxt, MCNameRef p_target, MCNameRef parent, bool p_parent_is_thisstack);
-void MCInterfaceExecOpenStack(MCExecContext& ctxt, MCStack *p_target, int p_mode);
-void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_target, int p_mode);
+void MCInterfaceExecDrawerStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack, int p_at, int p_aligned, bool p_wait_while_open);
+void MCInterfaceExecDrawerStackByName(MCExecContext& ctxt, MCNameRef p_target, MCNameRef parent, bool p_parent_is_thisstack, int p_at, int p_aligned, bool p_wait_while_open);
+void MCInterfaceExecSheetStack(MCExecContext& ctxt, MCStack *p_target, MCNameRef parent, bool p_parent_is_thisstack, bool p_wait_while_open);
+void MCInterfaceExecSheetStackByName(MCExecContext& ctxt, MCNameRef p_target, MCNameRef parent, bool p_parent_is_thisstack, bool p_wait_while_open);
+void MCInterfaceExecOpenStack(MCExecContext& ctxt, MCStack *p_target, int p_mode, bool p_wait_while_open);
+void MCInterfaceExecOpenStackByName(MCExecContext& ctxt, MCNameRef p_target, int p_mode, bool p_wait_while_open);
 void MCInterfaceExecPopupStack(MCExecContext& ctxt, MCStack *p_target, MCPoint *p_at, int p_mode);
 void MCInterfaceExecPopupStackByName(MCExecContext& ctxt, MCNameRef p_target, MCPoint *p_at, int p_mode);
 

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -2453,7 +2453,7 @@ enum MCInterfaceExecGoVisibility
 	kMCInterfaceExecGoVisibilityExplicitVisible,
 	kMCInterfaceExecGoVisibilityExplicitInvisible
 };
-void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack);
+void MCInterfaceExecGoCardAsMode(MCExecContext& ctxt, MCCard *p_card, int p_mode, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack, bool p_wait_while_open);
 void MCInterfaceExecGoCardInWindow(MCExecContext& ctxt, MCCard *p_card, MCStringRef p_window, MCInterfaceExecGoVisibility p_visibility_type, bool p_this_stack);
 void MCInterfaceExecGoRecentCard(MCExecContext& ctxt);
 void MCInterfaceExecGoCardRelative(MCExecContext& ctxt, bool p_forward, real8 p_amount);

--- a/engine/src/hc.cpp
+++ b/engine/src/hc.cpp
@@ -2505,7 +2505,7 @@ IO_stat hc_import(MCStringRef name, IO_handle stream, MCStack *&sptr)
 		{
 			sptr->open();
 			tptr->openrect(MCdefaultstackptr->getrect(), WM_MODELESS,
-			               NULL, WP_DEFAULT, OP_NONE);
+			               NULL, WP_DEFAULT, OP_NONE, false);
 		}
 	}
 	return stat;

--- a/engine/src/idraw.cpp
+++ b/engine/src/idraw.cpp
@@ -487,7 +487,7 @@ void MCImage::startmag(int2 x, int2 y)
 	MCRectangle trect = MCU_intersect_rect(rect, getcard()->getrect());
 	magrect = MCU_bound_rect(magrect, trect.x - rect.x, trect.y - rect.y,
 	                         trect.width, trect.height);
-	sptr->openrect(getstack()->getrect(), WM_PALETTE, NULL, WP_DEFAULT, OP_NONE);
+	sptr->openrect(getstack()->getrect(), WM_PALETTE, NULL, WP_DEFAULT, OP_NONE, false);
 	MCscreen->addtimer(this, MCM_internal2, MCmovespeed);
 }
 

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -845,7 +845,7 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
         return s_post_waitforevent_callback(t_event != nullptr);
     }
     
-	return t_event != nil;
+	return t_event != nil || t_modal;
 }
 
 void MCMacPlatformClearLastMouseEvent(void)

--- a/engine/src/player-platform.cpp
+++ b/engine/src/player-platform.cpp
@@ -445,7 +445,7 @@ public:
         
         MCdispatcher -> addmenu(this);
         
-        openrect(t_rect, WM_POPUP, NULL, WP_ASRECT, OP_NONE);
+        openrect(t_rect, WM_POPUP, NULL, WP_ASRECT, OP_NONE, false);
     }
     
 private:
@@ -753,7 +753,7 @@ public:
         
         MCdispatcher -> addmenu(this);
         
-        openrect(t_rect, WM_POPUP, NULL, WP_ASRECT, OP_NONE);
+        openrect(t_rect, WM_POPUP, NULL, WP_ASRECT, OP_NONE, false);
     }
     
 private:

--- a/engine/src/redraw.cpp
+++ b/engine/src/redraw.cpp
@@ -1461,7 +1461,7 @@ void MCRedrawDoUpdateScreen(void)
 		if (sptr->getstate(CS_NEED_RESIZE))
 		{
 			sptr->setgeom();
-            sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE);
+            sptr->openrect(sptr->getrect(), WM_LAST, NULL, WP_DEFAULT, OP_NONE, false);
 
             // SN-2015-08-31: [[ Bug 15705 ]] From 6.7.7, MCRedrawUpdateScreen
             //  also removes kMCActionUpdateScreen from MCactionsrequired,

--- a/engine/src/stack.cpp
+++ b/engine/src/stack.cpp
@@ -718,7 +718,7 @@ bool MCStack::visit_children(MCObjectVisitorOptions p_options, uint32_t p_part, 
 
 void MCStack::open()
 {
-	openrect(rect, WM_LAST, NULL, WP_DEFAULT,OP_NONE);
+	openrect(rect, WM_LAST, NULL, WP_DEFAULT,OP_NONE, false);
 }
 
 void MCStack::close()

--- a/engine/src/stack.h
+++ b/engine/src/stack.h
@@ -769,7 +769,7 @@ public:
 	
 	void reopenwindow();
 	Exec_stat openrect(const MCRectangle &rel, Window_mode wm, MCStack *parentwindow,
-	                   Window_position wpos,  Object_pos walign);
+	                   Window_position wpos,  Object_pos walign, bool p_wait_while_open);
 
 	bool getstackfiles(MCStringRef& r_sf);
 	bool stringtostackfiles(MCStringRef d, MCStackfile **sf, uint2 &nf);

--- a/engine/src/stack2.cpp
+++ b/engine/src/stack2.cpp
@@ -2013,7 +2013,8 @@ void MCStack::reopenwindow()
 		openwindow(mode >= WM_PULLDOWN);
 }
 
-Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *parentptr, Window_position wpos,  Object_pos walign)
+Exec_stat MCStack::
+openrect(const MCRectangle &rel, Window_mode wm, MCStack *parentptr, Window_position wpos,  Object_pos walign, bool p_wait_while_open)
 {
 	if (state & (CS_IGNORE_CLOSE | CS_NO_FOCUS | CS_DELETE_STACK))
 		return ES_NORMAL;
@@ -2030,6 +2031,7 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 			else
 				wm = (Window_mode)(getstyleint(flags) + WM_TOP_LEVEL_LOCKED);
         }
+		p_wait_while_open = wm == WM_MODAL || wm == WM_SHEET;
     }
 	if (wm == WM_TOP_LEVEL
 	        && (flags & F_CANT_MODIFY || m_is_ide_stack || !MCdispatcher->cut(True)))
@@ -2533,14 +2535,15 @@ Exec_stat MCStack::openrect(const MCRectangle &rel, Window_mode wm, MCStack *par
 
 		// Only enter a modal loop if we are making local windows.
 		// the rev supplied answer/ask dialogs.
-		if ((mode == WM_MODAL || mode == WM_SHEET) &&
+		if (p_wait_while_open &&
 			MCModeMakeLocalWindows())
 		{
+			Window_mode t_mode = mode;
 			// If opening the dialog failed for some reason, this will return false.
 			if (mode_openasdialog())
 			{
 				while (opened &&
-                       (mode == WM_MODAL || mode == WM_SHEET) &&
+                       (mode == t_mode) &&
                        !MCquit &&
                        !MCabortscript)
 				{

--- a/engine/src/tooltip.cpp
+++ b/engine/src/tooltip.cpp
@@ -150,7 +150,7 @@ void MCTooltip::opentip()
 				MCttsize, (t_color . red >> 8) | (t_color . green & 0xFF00) | ((t_color . blue & 0xFF00) << 8), MCttfont,
 				tip);
 		MCscreen->addtimer(this, MCM_internal2, MCtooltime);
-		openrect(trect, WM_TOOLTIP, NULL, WP_DEFAULT,OP_NONE);
+		openrect(trect, WM_TOOLTIP, NULL, WP_DEFAULT,OP_NONE, false);
 		state |= CS_NO_FOCUS;
 		return;
 	}
@@ -203,7 +203,7 @@ void MCTooltip::opentip()
 		rect.height += t_fheight +3;
 	}
 
-	openrect(trect, WM_TOOLTIP, NULL, WP_DEFAULT,OP_NONE);
+	openrect(trect, WM_TOOLTIP, NULL, WP_DEFAULT,OP_NONE, false);
 	state |= CS_NO_FOCUS;
 
 	if (MCcurtheme != NULL && window != NULL)

--- a/engine/src/widget-popup.cpp
+++ b/engine/src/widget-popup.cpp
@@ -148,7 +148,7 @@ public:
 		MCdispatcher -> addmenu(this);
 		m_widget->setrect(MCRectangleMake(0, 0, t_width, t_height));
 		
-		return ES_NORMAL == openrect(MCRectangleMake(p_at.x, p_at.y, t_width, t_height), WM_POPUP, NULL, WP_ASRECT, OP_NONE);
+		return ES_NORMAL == openrect(MCRectangleMake(p_at.x, p_at.y, t_width, t_height), WM_POPUP, NULL, WP_ASRECT, OP_NONE, false);
 	}
 	
 	const MCWidget *getpopupwidget() const

--- a/tests/lcs/core/interface/subwindow.livecodescript
+++ b/tests/lcs/core/interface/subwindow.livecodescript
@@ -25,3 +25,13 @@ on TestSubwindowPropagatesErrors
 	end try
 	TestAssert "Error during subwindow propagates to caller", tError is "red"
 end TestSubwindowPropagatesErrors
+
+on TestSubwindowWithoutWaiting
+	local tName
+	put "Test" && uuid() into tName
+	create stack tName
+	set the script of stack tName to format("on openStack; send \"close this stack\" to me in 0;end openStack")
+	modal tName without waiting
+	TestAssert "Subwindow without waiting does not wait for close", tName is among the lines of the openStacks
+	delete stack tName
+end TestSubwindowWithoutWaiting


### PR DESCRIPTION
This patch implements:

`{modal | sheet} <stack> without waiting` and `go <stack> as {modal | sheet} without waiting`