### PR TITLE
[[ Bug 22544 ]] Enable text editing options in CEF context menu

### DIFF
--- a/docs/notes/bugfix-22544.md
+++ b/docs/notes/bugfix-22544.md
@@ -1,0 +1,1 @@
+# Enabled right-click context menu in browser widget on Windows & Linux


### PR DESCRIPTION
This patch updates the libbrowser CEF implementation to allow the
right-click context menu to be shown with standard text editing options
(Cut, Copy, Paste, Select All, etc.) and spellchecking replacement
suggestions.

Fixes https://quality.livecode.com/show_bug.cgi?id=22544