### PR TITLE
[[ Bug 22816 ]] Fix permissions when loading a local html file

### DIFF
--- a/docs/notes/bugfix-22816.md
+++ b/docs/notes/bugfix-22816.md
@@ -1,0 +1,1 @@
+# Fix permissions when loading a local html file on iOS 12

--- a/libbrowser/src/libbrowser_wkwebview.mm
+++ b/libbrowser/src/libbrowser_wkwebview.mm
@@ -1618,7 +1618,16 @@ void MCWKWebViewBrowserNavigationRequest::Cancel()
 	MCBrowserRunBlockOnMainFiber(^{
 		if (request.htmlText == nil)
 		{
-			[webView loadRequest:[NSURLRequest requestWithURL:request.url]];
+			if (![request.url isFileURL])
+				[webView loadRequest:[NSURLRequest requestWithURL:request.url]];
+			else
+			{
+				NSURL *t_docs_dir_url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+				if ([request.url.absoluteString hasPrefix:t_docs_dir_url.absoluteString])
+					[webView loadFileURL:request.url allowingReadAccessToURL:t_docs_dir_url];
+				else
+					[webView loadFileURL:request.url allowingReadAccessToURL:request.url.URLByDeletingLastPathComponent];
+			}
 		}
 		else
 		{


### PR DESCRIPTION
This patch uses the `loadFileURL:allowingReadAccessToURL:` instance method of the WKWebView class to load a local html file. 

This fixes an issue with insufficient permissions on iOS 12 devices that prevented the html file from being loaded.

Tested on iOS 12,13 and 14 devices.