### PR TITLE
[[ Bug 22854 ]] Fix crash deleting touch target on mobile

### DIFF
--- a/docs/notes/bugfix-22854.md
+++ b/docs/notes/bugfix-22854.md
@@ -1,0 +1,1 @@
+# Fix crash deleting the touch target on mobile

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -1261,12 +1261,17 @@ static void handle_touch(MCStack *p_stack, MCEventTouchPhase p_phase, uint32_t p
          * is ending or cancelling a touch. */
         if (t_touch != nil)
         {
-            t_target = t_touch -> target;
-            
+			if ((t_touch -> target).IsValid())
+			{
+				t_target = t_touch -> target;
+			}
+			
             // MW-2011-09-05: [[ Bug 9683 ]] Make sure we remove (and delete the touch) here if
             //   it is 'end' or 'cancelled' so that a cleartouches inside an invoked handler
             //   doesn't cause a crash.			
-            if (p_phase == kMCEventTouchPhaseEnded || p_phase == kMCEventTouchPhaseCancelled)
+            if (p_phase == kMCEventTouchPhaseEnded ||
+				p_phase == kMCEventTouchPhaseCancelled ||
+				!(t_touch -> target).IsValid())
             {
                 if (t_previous_touch == nil)
                     s_touches = t_touch -> next;


### PR DESCRIPTION
This patch fixes a crash caused because the touch queue on mobile retains a
reference to the target object handle, however, if the target is deleted the
handle will be invalid.