### PR TITLE
[[ Bug 22855 ]] Fix hang in EvaluateJavaScript on iOS

### DIFF
--- a/docs/notes/bugfix-22855.md
+++ b/docs/notes/bugfix-22855.md
@@ -1,0 +1,1 @@
+# Fix hang executing `do in <browser widget>` on iOS

--- a/libbrowser/src/libbrowser_wkwebview.mm
+++ b/libbrowser/src/libbrowser_wkwebview.mm
@@ -1042,6 +1042,7 @@ void _SyncEvaluateJavaScript(WKWebView *p_view, NSString *p_javascript, id &r_re
 			}
 			
 			t_evaluating = false;
+			MCBrowserRunloopBreakWait();
 		}];
 	});
 	


### PR DESCRIPTION
This patch fixes a hang in `_SyncEvaluateJavaScript` on iOS by calling
`MCBrowserBreakWait` at the end of the evaluation completion handler.