### PR TITLE
Remove AdModule.java file from the commercial engine dependencies

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -965,7 +965,6 @@
 		# Sources only used in Commercial Android builds
 		'engine_commercial_java_files':
 		[
-			'src/java/com/runrev/android/AdModule.java',
 			'src/java/com/runrev/android/billing/amazon/AmazonBillingProvider.java',
 			'src/java/com/runrev/android/billing/amazon/MyPurchasingObserver.java',
 		],


### PR DESCRIPTION
This patch removes AdModule.java file from the commercial engine dependencies.