### PR TITLE
[[ 14436 ]] Ensure valid custom fonts can be loaded on Android

### DIFF
--- a/docs/notes/bugfix-14436.md
+++ b/docs/notes/bugfix-14436.md
@@ -1,0 +1,1 @@
+# Ensure valid custom fonts can be loaded on Android

--- a/engine/src/mblandroidfont.cpp
+++ b/engine/src/mblandroidfont.cpp
@@ -457,9 +457,8 @@ static bool create_custom_font_from_path(MCStringRef p_path, FT_Library p_librar
         for (uint32_t i = 0; i < FT_Get_Sfnt_Name_Count(t_font_face); i++)
         {
             // Attempt to fetch the name of the font.  The name is name id 4 as defined in https://developer.apple.com/fonts/TTRefMan/RM06/Chap6name.html
-            // It appears that the platform to use here is 1 (Macintosh according to the spec).
             FT_Get_Sfnt_Name(t_font_face, i, &t_sft_name);
-            if (t_sft_name.name_id == 4 && t_sft_name.platform_id == 1 && t_sft_name.encoding_id == 0 && t_sft_name.language_id == 0 && t_sft_name.string_len != 0)
+            if (t_sft_name.name_id == 4 && t_sft_name.string_len != 0)
             {
                 t_success = MCStringCreateWithNativeChars((char_t *)t_sft_name.string, t_sft_name.string_len, t_font->name);
                 break;


### PR DESCRIPTION
This patch makes the validity check for Android custom fonts less strict. Previously the code was allowing only fonts that had specific values for `name_id`, `platform_id`, `encoding_id` and `language_id`.

This was too strict and resulted in valid fonts being rejected. The patched code only checks for `name_id`.

Tested on an Android 10 physical device.

Before:

![before](https://user-images.githubusercontent.com/5111835/90142328-e8d64700-dd84-11ea-8a8b-be29a1899a4e.jpg)

After:

![after](https://user-images.githubusercontent.com/5111835/90142360-effd5500-dd84-11ea-9d3f-d7b2979ad013.jpg)

