### PR TITLE
[[ Bug 22143 ]] Fix interactive tutorial on Windows

### DIFF
--- a/docs/notes/bugfix-22143.md
+++ b/docs/notes/bugfix-22143.md
@@ -1,0 +1,1 @@
+# Fix interactive tutorial on Windows

--- a/engine/src/exec-interface-stack.cpp
+++ b/engine/src/exec-interface-stack.cpp
@@ -485,9 +485,9 @@ void MCStack::SetVisible(MCExecContext& ctxt, uint32_t part, bool setting)
 		MCscreen->sync(getw());
         
 #ifdef _WINDOWS_DESKTOP
-        // On Windows force a reload, otherwise a stack with a windowshape does not show
-        if (setting)
-            loadwindowshape();
+        // On Windows force a redraw, otherwise a stack with a windowshape does not show
+        if (setting && (windowshapeid != 0))
+            dirtyall();
 #endif
 	}
 }


### PR DESCRIPTION
This patch forces a redraw when showing an invisible stack that has a windowshape. Previously, to fix [bug 21805](https://github.com/livecode/livecode/pull/6860/files) we used `loadwindowshape()` for this, but this caused a problem with the interactive tutorial on Windows ([bug 22143](https://quality.livecode.com/show_bug.cgi?id=22143)). This patch ensures both bugs are addressed.