### PR TITLE
[[ TileCache ]] Add GLES3.x tilecache implementation to iOS and Android

### DIFF
--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -32,6 +32,8 @@
 			'src/customprinter.cpp',
 			'src/font.cpp',
 			'src/fonttable.cpp',
+			'src/glcontext.cpp',
+			'src/glcontext.h',
 			'src/gradient.cpp',
 			'src/graphics_util.cpp',
 			'src/graphicscontext.cpp',
@@ -1151,6 +1153,7 @@
 					[
 						'src/fiber.cpp',
 						'src/tilecachegl.cpp',
+						'src/glcontext.cpp',
 						'src/player-legacy.cpp',
 						
 						'src/desktop-ans.cpp',
@@ -1175,6 +1178,7 @@
 						'src/sysunxrandom.cpp',
 						'src/sysunxregion.cpp',
 						'src/tilecachegl.cpp',
+						'src/glcontext.cpp',
 					],
 				},
 			],
@@ -1205,6 +1209,7 @@
 					[
 						'src/player-platform.cpp',
 						'src/tilecachegl.cpp',
+						'src/glcontext.cpp',
 						
 						'src/desktop.cpp',
 						'src/desktop-ans.cpp',
@@ -1283,6 +1288,7 @@
 						'src/notify.cpp',
 						'src/player-platform.cpp',
 						'src/tilecachegl.cpp',
+						'src/glcontext.cpp',
 						
 						'src/desktop.cpp',
 						'src/desktop-ans.cpp',

--- a/engine/engine-sources.gypi
+++ b/engine/engine-sources.gypi
@@ -50,6 +50,7 @@
 			'src/tilecache.cpp',
 			'src/tilecachecg.cpp',
 			'src/tilecachegl.cpp',
+			'src/tilecachegl3.x.cpp',
 			'src/tilecachesw.cpp',
 			'src/mcsemaphore.h',
 			'src/mctristate.h',
@@ -1153,6 +1154,7 @@
 					[
 						'src/fiber.cpp',
 						'src/tilecachegl.cpp',
+						'src/tilecachegl3.x.cpp',
 						'src/glcontext.cpp',
 						'src/player-legacy.cpp',
 						
@@ -1178,6 +1180,7 @@
 						'src/sysunxrandom.cpp',
 						'src/sysunxregion.cpp',
 						'src/tilecachegl.cpp',
+						'src/tilecachegl3.x.cpp',
 						'src/glcontext.cpp',
 					],
 				},
@@ -1209,6 +1212,7 @@
 					[
 						'src/player-platform.cpp',
 						'src/tilecachegl.cpp',
+						'src/tilecachegl3.x.cpp',
 						'src/glcontext.cpp',
 						
 						'src/desktop.cpp',
@@ -1231,6 +1235,7 @@
 					[
 						'src/player-platform.cpp',
 						'src/sysunxnetwork.cpp',
+						'src/tilecachegl.cpp',
 
 						'src/desktop.cpp',
 						'src/desktop-ans.cpp',
@@ -1254,6 +1259,7 @@
 						'src/stacke.cpp',
 						'src/sysunxdate.cpp',
 						'src/sysunxrandom.cpp',
+						'src/tilecachegl.cpp',
 						
 						'src/mbliphoneembedded.mm',
 						'src/mbliphoneembeddedtest.mm',
@@ -1288,6 +1294,7 @@
 						'src/notify.cpp',
 						'src/player-platform.cpp',
 						'src/tilecachegl.cpp',
+						'src/tilecachegl3.x.cpp',
 						'src/glcontext.cpp',
 						
 						'src/desktop.cpp',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -236,7 +236,7 @@
 						{
 							'libraries':
 							[
-								'-lGLESv1_CM',
+								'-lGLESv3',
 								'-lEGL',
 								'-ljnigraphics',
 								'-llog',

--- a/engine/rsrc/android-manifest.xml
+++ b/engine/rsrc/android-manifest.xml
@@ -6,6 +6,7 @@
           ${INSTALL_LOCATION}>
 ${PUSH_PERMISSIONS}
 ${USES_PERMISSION}${USES_FEATURE}
+  <uses-feature android:glEsVersion="0x00030000"/>
   <uses-sdk android:minSdkVersion="${MIN_SDK_VERSION}" android:targetSdkVersion="${TARGET_SDK_VERSION}"/>
   <supports-screens
       android:largeScreens="true"

--- a/engine/src/glcontext.cpp
+++ b/engine/src/glcontext.cpp
@@ -1,0 +1,588 @@
+/* Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "prefix.h"
+
+#if defined(_IOS_MOBILE)
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+#elif defined(TARGET_SUBPLATFORM_ANDROID)
+#define GL_GLEXT_PROTOTYPES
+#include <GLES3/gl3.h>
+#include <GLES3/gl3ext.h>
+#else
+#error GLContext not supported on this platform
+#endif
+
+#include "glcontext.h"
+#include "packed.h"
+
+#ifdef DEBUG_GL
+#define MCGLDebugCheckError(p_prefix) MCGLCheckError(p_prefix)
+#else
+#define MCGLDebugCheckError(p_prefix) (true)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct MCGLProgramConfig
+{
+	MCGLProgramType program;
+
+	MCGAffineTransform projection_transform;
+	MCGAffineTransform world_transform;
+	MCGAffineTransform texture_transform;
+};
+
+struct __MCGLContext
+{
+	// The version of OpenGL in use.
+	GLint opengl_major_version;
+	GLint opengl_minor_version;
+	
+	// Context initialization
+	bool is_initialized;
+
+	// programs
+	GLuint color_program;
+	GLuint texture_program;
+
+	// uniforms
+	GLuint c_transform;
+	GLuint t_transform;
+	GLuint t_texture_transform;
+
+	// buffer
+	GLuint buffer;
+
+	// Vertex Array Objects
+	GLuint color_vao;
+	GLuint texture_vao;
+
+	// current context state
+	MCGLProgramConfig config;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+static bool MCGLUniformAffineTransform(GLuint p_uniform, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLUniformAffineTransform(%d, {%f, %f, %f, %f, %f, %f})", p_uniform, p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	GLfloat t_matrix[] = {
+		p_transform.a,
+		p_transform.b,
+		p_transform.c,
+		p_transform.d,
+		p_transform.tx,
+		p_transform.ty,
+	};
+	glUniformMatrix3x2fv(p_uniform, 1, false, t_matrix);
+	return MCGLDebugCheckError("uniform transform: ");
+}
+
+bool MCGLCheckError(const char *p_prefix)
+{
+	if (p_prefix == nil)
+		p_prefix = "";
+
+	GLenum t_error;
+	t_error = glGetError();
+
+	if (t_error == GL_NO_ERROR)
+		return true;
+
+	while (t_error != GL_NO_ERROR)
+	{
+		MCLog("%sGL error: %d", p_prefix, t_error);
+		t_error = glGetError();
+	}
+
+	return true;
+}
+
+static bool MCGLCompileShader(GLuint p_shader_type, const char *p_source, GLuint &r_shader)
+{
+	bool t_success;
+	t_success = true;
+
+	GLuint t_shader;
+	t_shader = 0;
+
+	if (t_success)
+	{
+		t_shader = glCreateShader(p_shader_type);
+		t_success = t_shader != 0;
+	}
+
+	if (t_success)
+	{
+		glShaderSource(t_shader, 1, &p_source, nil);
+		glCompileShader(t_shader);
+
+		/* DEBUG */
+		GLint t_status;
+		glGetShaderiv(t_shader, GL_COMPILE_STATUS, &t_status);
+		t_success = t_status == GL_TRUE;
+		if (!t_success)
+		{
+			char t_buffer[512];
+			glGetShaderInfoLog(t_shader, 512, nil, t_buffer);
+			MCLog("shader compile failed: %s\n%s", t_buffer, p_source);
+		}
+	}
+
+	if (t_success)
+		r_shader = t_shader;
+	else
+		glDeleteShader(t_shader);
+
+	return t_success;
+}
+
+struct MCGLShaderSourceInfo
+{
+	GLuint type;
+	const char *source;
+};
+
+static bool MCGLCompileProgram(const MCGLShaderSourceInfo *p_shaders, uindex_t p_shader_count, GLuint &r_program)
+{
+	bool t_success;
+	t_success = true;
+
+	GLuint t_program;
+	t_program = 0;
+
+	if (t_success)
+	{
+		t_program = glCreateProgram();
+		t_success = t_program != 0;
+	}
+
+	for (uindex_t i = 0; t_success && (i < p_shader_count); i++)
+	{
+		GLuint t_shader;
+		t_success = MCGLCompileShader(p_shaders[i].type, p_shaders[i].source, t_shader);
+		if (t_success)
+		{
+			glAttachShader(t_program, t_shader);
+			glDeleteShader(t_shader);
+		}
+	}
+
+	if (t_success)
+	{
+		glLinkProgram(t_program);
+
+		GLint t_status;
+		glGetProgramiv(t_program, GL_LINK_STATUS, &t_status);
+		t_success = t_status == GL_TRUE;
+		if (!t_success)
+		{
+			char t_buffer[512];
+			glGetProgramInfoLog(t_program, 512, nil, t_buffer);
+			MCLog("program link failed: %s", t_buffer);
+		}
+	}
+
+	if (t_success)
+		r_program = t_program;
+	else
+		glDeleteProgram(t_program);
+
+	return t_success;
+}
+
+static const char *s_color_vertex_shader_source =
+R"glsl(#version 300 es
+
+uniform mat3x2 pTransform;
+
+in vec2 pPosition;
+in vec4 pColor;
+
+out vec4 pFragColor;
+
+void main()
+{
+	pFragColor = pColor;
+	gl_Position = vec4(pTransform * vec3(pPosition, 1.0), 0.0, 1.0);
+}
+)glsl";
+
+static const char *s_color_fragment_shader_source =
+R"glsl(#version 300 es
+
+precision mediump float;
+in vec4 pFragColor;
+
+out vec4 outColor;
+
+void main()
+{
+	outColor = pFragColor;
+}
+)glsl";
+
+static MCGLShaderSourceInfo s_color_shaders[] = {
+	{GL_VERTEX_SHADER, s_color_vertex_shader_source},
+	{GL_FRAGMENT_SHADER, s_color_fragment_shader_source},
+};
+
+static const char *s_texture_vertex_shader_source =
+R"glsl(#version 300 es
+
+uniform mat3x2 pTransform;
+
+in vec2 pPosition;
+in vec2 pTextureCoord;
+
+out vec2 pVertexTextureCoord;
+void main()
+{
+	gl_Position = vec4(pTransform * vec3(pPosition, 1.0), 0.0, 1.0);
+	pVertexTextureCoord = pTextureCoord;
+}
+)glsl";
+
+static const char *s_texture_fragment_shader_source =
+R"glsl(#version 300 es
+
+precision mediump float;
+uniform mat3x2 pTextureTransform;
+
+in vec2 pVertexTextureCoord;
+
+out vec4 outColor;
+
+uniform sampler2D tex;
+
+void main()
+{
+	outColor = texture(tex, pTextureTransform * vec3(pVertexTextureCoord, 1.0));
+}
+)glsl";
+
+static MCGLShaderSourceInfo s_texture_shaders[] = {
+	{GL_VERTEX_SHADER, s_texture_vertex_shader_source},
+	{GL_FRAGMENT_SHADER, s_texture_fragment_shader_source},
+};
+
+bool MCGLContextInit(MCGLContextRef self)
+{
+	MCLog("MCGLContextInit(<%p>)");
+	if (self == nil)
+		return false;
+
+	if (self->is_initialized)
+		return true;
+
+	/* UNCHECKED */ MCGLCheckError("pre-init: ");
+	bool t_success;
+	t_success = true;
+
+	MCLog("gl Version String: %s", glGetString(GL_VERSION));
+	
+	// Get the OpenGL version.
+	glGetIntegerv(GL_MAJOR_VERSION, &self->opengl_major_version);
+	glGetIntegerv(GL_MINOR_VERSION, &self->opengl_minor_version);
+	/* UNCHECKED */ MCGLDebugCheckError("get version: ");
+	
+	/* Compile shader programs for drawing solid color & texture */
+	GLuint t_color_program;
+	t_color_program = 0;
+	if (t_success)
+		t_success = MCGLCompileProgram(s_color_shaders, 2, t_color_program);
+	/* UNCHECKED */ MCGLDebugCheckError("compile color shaders: ");
+
+	GLuint t_texture_program;
+	t_texture_program = 0;
+	if (t_success)
+		t_success = MCGLCompileProgram(s_texture_shaders, 2, t_texture_program);
+	/* UNCHECKED */ MCGLDebugCheckError("compile texture shaders: ");
+
+	/* Fetch uniform values */
+	GLuint t_cprog_world_transform;
+	t_cprog_world_transform = 0;
+	GLuint t_tprog_world_transform;
+	t_tprog_world_transform = 0;
+	GLuint t_tprog_texture_transform;
+	t_tprog_texture_transform = 0;
+	if (t_success)
+	{
+		t_cprog_world_transform = glGetUniformLocation(t_color_program, "pTransform");
+		t_tprog_world_transform = glGetUniformLocation(t_texture_program, "pTransform");
+		t_tprog_texture_transform = glGetUniformLocation(t_texture_program, "pTextureTransform");
+		/* UNCHECKED */ MCGLDebugCheckError("get uniform locations: ");
+	}
+
+	/* Create input buffers */
+	GLuint t_buffer;
+	t_buffer = 0;
+	if (t_success)
+	{
+		glGenBuffers(1, &t_buffer);
+		/* UNCHECKED */ MCGLDebugCheckError("create buffers: ");
+	}
+
+	/* Create vertex arrays to manage attributes */
+	GLuint t_color_vao;
+	t_color_vao = 0;
+	GLuint t_texture_vao;
+	t_texture_vao = 0;
+	if (t_success)
+	{
+		glGenVertexArrays(1, &t_color_vao);
+		glGenVertexArrays(1, &t_texture_vao);
+		/* UNCHECKED */ MCGLDebugCheckError("create VAOs: ");
+	}
+
+	/* Set up vertex attributes */
+	if (t_success)
+	{
+		GLint t_position;
+		GLint t_color;
+		t_position = glGetAttribLocation(t_color_program, "pPosition");
+		t_color = glGetAttribLocation(t_color_program, "pColor");
+		t_success = t_position != -1 && t_color != -1;
+		if (t_success)
+		{
+			glBindVertexArray(t_color_vao);
+			glBindBuffer(GL_ARRAY_BUFFER, t_buffer);
+			glEnableVertexAttribArray(t_position);
+			glVertexAttribPointer(t_position, 2, GL_SHORT, GL_FALSE, sizeof(MCGLColorVertex), 0);
+			glEnableVertexAttribArray(t_color);
+			glVertexAttribPointer(t_color, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(MCGLColorVertex), (void*)(2 * sizeof(GLshort)));
+		}
+		/* UNCHECKED */ MCGLDebugCheckError("set up color VAO: ");
+	}
+
+	if (t_success)
+	{
+		GLint t_position;
+		GLint t_texture_coord;
+		t_position = glGetAttribLocation(t_texture_program, "pPosition");
+		t_texture_coord = glGetAttribLocation(t_texture_program, "pTextureCoord");
+		t_success = t_position != -1 && t_texture_coord != -1;
+		if (t_success)
+		{
+			glBindVertexArray(t_texture_vao);
+			glBindBuffer(GL_ARRAY_BUFFER, t_buffer);
+			glEnableVertexAttribArray(t_position);
+			glVertexAttribPointer(t_position, 2, GL_SHORT, GL_FALSE, sizeof(MCGLTextureVertex), nil);
+			glEnableVertexAttribArray(t_texture_coord);
+			glVertexAttribPointer(t_texture_coord, 2, GL_UNSIGNED_BYTE, GL_FALSE, sizeof(MCGLTextureVertex), (void*)(2 * sizeof(GLshort)));
+		}
+		/* UNCHECKED */ MCGLDebugCheckError("set up texture VAO: ");
+	}
+
+	if (t_success)
+	{
+		self->color_program = t_color_program;
+		self->texture_program = t_texture_program;
+
+		self->c_transform = t_cprog_world_transform;
+		self->t_transform = t_tprog_world_transform;
+		self->t_texture_transform = t_tprog_texture_transform;
+
+		MCLog("uniforms: %d, %d, %d",
+			self->c_transform,
+			self->t_transform,
+			self->t_texture_transform);
+		self->buffer = t_buffer;
+
+		self->color_vao = t_color_vao;
+		self->texture_vao = t_texture_vao;
+
+		self->is_initialized = true;
+	}
+	else
+	{
+		glDeleteProgram(t_color_program);
+		glDeleteProgram(t_texture_program);
+		glDeleteVertexArrays(1, &t_color_vao);
+		glDeleteVertexArrays(1, &t_texture_vao);
+		glDeleteBuffers(1, &t_buffer);
+		/* UNCHECKED */ MCGLDebugCheckError("init cleanup: ");
+	}
+
+	return t_success && MCGLCheckError("Init: ");
+}
+
+static void MCGLContextFinalize(MCGLContextRef p_context)
+{
+	MCGLContextSelectProgram(p_context, kMCGLProgramTypeNone);
+
+	glDeleteProgram(p_context->color_program);
+	glDeleteProgram(p_context->texture_program);
+	glDeleteVertexArrays(1, &p_context->color_vao);
+	glDeleteVertexArrays(1, &p_context->texture_vao);
+	glDeleteBuffers(1, &p_context->buffer);
+}
+
+bool MCGLContextCreate(MCGLContextRef &r_context)
+{
+	MCGLContextRef t_context;
+	if (!MCMemoryNew(t_context))
+		return false;
+
+	MCLog("created GL context <%p>", t_context);
+	r_context = t_context;
+	return true;
+}
+
+void MCGLContextDestroy(MCGLContextRef p_context)
+{
+	if (p_context == nil)
+		return;
+
+	MCLog("destroying GL context <%p>", p_context);
+	MCGLContextReset(p_context);
+	MCMemoryDelete(p_context);
+}
+
+void MCGLContextReset(MCGLContextRef p_context)
+{
+	if (p_context == nil)
+		return;
+	if (!p_context->is_initialized)
+		return;
+	MCGLContextFinalize(p_context);
+	MCMemoryClear(p_context, sizeof(__MCGLContext));
+}
+
+bool MCGLContextSelectProgram(MCGLContextRef p_context, MCGLProgramType p_program)
+{
+	if (p_context == nil)
+		return false;
+
+	p_context->config.program = p_program;
+
+	switch (p_program)
+	{
+		case kMCGLProgramTypeNone:
+			glUseProgram(0);
+			glBindVertexArray(0);
+			glBindBuffer(GL_ARRAY_BUFFER, 0);
+			break;
+
+		case kMCGLProgramTypeColor:
+			// select color program and related vao and buffer
+			glUseProgram(p_context->color_program);
+			glBindVertexArray(p_context->color_vao);
+			glBindBuffer(GL_ARRAY_BUFFER, p_context->buffer);
+			break;
+
+		case kMCGLProgramTypeTexture:
+			// select texture program and related vao and buffer
+			glUseProgram(p_context->texture_program);
+			glBindVertexArray(p_context->texture_vao);
+			glBindBuffer(GL_ARRAY_BUFFER, p_context->buffer);
+			break;
+	}
+
+	return MCGLDebugCheckError("switch program: ");
+}
+
+static inline bool MCGLContextUpdateTransform(MCGLContextRef p_context)
+{
+	MCGAffineTransform t_transform;
+	t_transform = MCGAffineTransformConcat(p_context->config.projection_transform, p_context->config.world_transform);
+
+	switch (p_context->config.program)
+	{
+		case kMCGLProgramTypeNone:
+			return false;
+
+		case kMCGLProgramTypeColor:
+			return MCGLUniformAffineTransform(p_context->c_transform, t_transform);
+
+		case kMCGLProgramTypeTexture:
+			return MCGLUniformAffineTransform(p_context->t_transform, t_transform);
+	}
+}
+
+bool MCGLContextSetProjectionTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextSetProjectionTransform(<%p>, {%f, %f, %f, %f, %f, %f})", p_context, p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	p_context->config.projection_transform = p_transform;
+
+	return MCGLContextUpdateTransform(p_context);
+}
+
+bool MCGLContextConcatProjectionTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextConcatProjectionTransform({%f, %f, %f, %f, %f, %f})", p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	p_context->config.projection_transform = MCGAffineTransformConcat(p_context->config.projection_transform, p_transform);
+
+	return MCGLContextUpdateTransform(p_context);
+}
+
+bool MCGLContextSetWorldTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextSetWorldTransform({%f, %f, %f, %f, %f, %f})", p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	p_context->config.world_transform = p_transform;
+
+	return MCGLContextUpdateTransform(p_context);
+}
+
+bool MCGLContextConcatWorldTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextConcatWorldTransform({%f, %f, %f, %f, %f, %f})", p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	p_context->config.world_transform = MCGAffineTransformConcat(p_context->config.world_transform, p_transform);
+	
+	return MCGLContextUpdateTransform(p_context);
+}
+
+bool MCGLContextSetTextureTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextSetTextureTransform({%f, %f, %f, %f, %f, %f})", p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	if (p_context->config.program != kMCGLProgramTypeTexture)
+		return false;
+
+	p_context->config.texture_transform = p_transform;
+
+	return MCGLUniformAffineTransform(p_context->t_texture_transform, p_context->config.texture_transform);
+}
+
+bool MCGLContextConcatTextureTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform)
+{
+	MCLog("MCGLContextConcatTextureTransform({%f, %f, %f, %f, %f, %f})", p_transform.a, p_transform.b, p_transform.c, p_transform.d, p_transform.tx, p_transform.ty);
+	if (p_context == nil)
+		return false;
+
+	if (p_context->config.program != kMCGLProgramTypeTexture)
+		return false;
+
+	p_context->config.texture_transform = MCGAffineTransformConcat(p_context->config.texture_transform, p_transform);
+
+	return MCGLUniformAffineTransform(p_context->t_texture_transform, p_context->config.texture_transform);
+}

--- a/engine/src/glcontext.h
+++ b/engine/src/glcontext.h
@@ -1,0 +1,67 @@
+/* Copyright (C) 2019 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#ifndef __GLCONTEXT_H__
+#define __GLCONTEXT_H__
+
+#include <graphics.h>
+
+struct __MCGLContext;
+typedef __MCGLContext* MCGLContextRef;
+
+struct MCGLColorVertex
+{
+	GLshort position[2];
+	// color in RGBA byte order
+	uint32_t color;
+};
+
+struct MCGLTextureVertex
+{
+	GLshort position[2];
+	GLubyte texture_position[2];
+};
+
+enum MCGLProgramType
+{
+	kMCGLProgramTypeNone,
+	kMCGLProgramTypeColor,
+	kMCGLProgramTypeTexture,
+};
+
+extern bool MCGLCheckError(const char *p_prefix);
+
+extern bool MCGLContextCreate(MCGLContextRef &r_context);
+extern void MCGLContextDestroy(MCGLContextRef p_context);
+extern bool MCGLContextInit(MCGLContextRef p_context);
+extern void MCGLContextReset(MCGLContextRef p_context);
+
+extern bool MCGLContextSetProjectionTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+extern bool MCGLContextConcatProjectionTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+extern bool MCGLContextSetWorldTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+extern bool MCGLContextConcatWorldTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+extern bool MCGLContextSetTextureTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+extern bool MCGLContextConcatTextureTransform(MCGLContextRef p_context, const MCGAffineTransform &p_transform);
+
+extern bool MCGLContextSelectProgram(MCGLContextRef p_context, MCGLProgramType p_program);
+
+
+extern void MCPlatformEnableOpenGLMode(void);
+extern void MCPlatformDisableOpenGLMode(void);
+extern MCGLContextRef MCPlatformGetOpenGLContext(void);
+
+
+#endif // __GLCONTEXT_H__

--- a/engine/src/java/com/runrev/android/OpenGLView.java
+++ b/engine/src/java/com/runrev/android/OpenGLView.java
@@ -34,6 +34,8 @@ public class OpenGLView extends SurfaceView implements SurfaceHolder.Callback
 {
 	// Instance variables
 	
+	private static final int EGL_CONTEXT_CLIENT_VERSION = 0x00003098;
+	
 	private EGL10 m_egl;
 	private EGLDisplay m_egl_display;
 	private EGLSurface m_egl_surface;
@@ -127,8 +129,13 @@ public class OpenGLView extends SurfaceView implements SurfaceHolder.Callback
 		// For debugging.
 		dumpConfig("Using EGLConfig", m_egl, m_egl_display, m_egl_config);
 		
+		int[] t_attr = new int[] {
+			EGL_CONTEXT_CLIENT_VERSION, 3,
+			EGL10.EGL_NONE,
+		};
+		
 		// Now create the OpenGL ES context.
-		m_egl_context = m_egl . eglCreateContext(m_egl_display, m_egl_config, EGL10 . EGL_NO_CONTEXT, null);
+		m_egl_context = m_egl . eglCreateContext(m_egl_display, m_egl_config, EGL10 . EGL_NO_CONTEXT, t_attr);
 		
 		// We don't have a surface (just yet).
 		m_egl_surface = null;

--- a/engine/src/mbliphonegfx.mm
+++ b/engine/src/mbliphonegfx.mm
@@ -34,8 +34,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/EAGLDrawable.h>
-#import <OpenGLES/ES1/gl.h>
-#import <OpenGLES/ES1/glext.h>
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+
+#include "glcontext.h"
 
 #include "mbliphoneview.h"
 
@@ -536,27 +538,20 @@ protected:
 		// IM_2013-08-21: [[ RefactorGraphics ]] set iOS pixel format to RGBA
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
 		
-		glMatrixMode(GL_MODELVIEW);
-		glLoadIdentity();
-		glMatrixMode(GL_TEXTURE);
-		glLoadIdentity();
+		MCGLContextRef t_glcontext;
+		t_glcontext = MCPlatformGetOpenGLContext();
 		
-		glEnable(GL_TEXTURE_2D);
+		MCGLContextSelectProgram(t_glcontext, kMCGLProgramTypeTexture);
+		MCGLContextSetWorldTransform(t_glcontext, MCGAffineTransformMakeIdentity());
+		MCGLContextSetTextureTransform(t_glcontext, MCGAffineTransformMakeIdentity());
+		
 		glDisable(GL_BLEND);
-		glColor4ub(255, 255, 255, 255);
 		
-		GLfloat t_vertices[8];
-		
-		GLfloat t_coords[8] =
-		{
-			0, 0,
-			1.0, 0.0,
-			0.0, 1.0,
-			1.0, 1.0
-		};
-		
-		glVertexPointer(2, GL_FLOAT, 0, t_vertices);
-		glTexCoordPointer(2, GL_FLOAT, 0, t_coords);
+		MCGLTextureVertex t_vertices[4];
+		t_vertices[0].texture_position[0] = 0.0; t_vertices[0].texture_position[1] = 0.0;
+		t_vertices[1].texture_position[0] = 1.0; t_vertices[1].texture_position[1] = 0.0;
+		t_vertices[2].texture_position[0] = 0.0; t_vertices[2].texture_position[1] = 1.0;
+		t_vertices[3].texture_position[0] = 1.0; t_vertices[3].texture_position[1] = 1.0;
 		
 		for(int32_t y = 0; y < (m_height + 255) / 256; y++)
 			for(int32_t x = 0; x < (m_width + 255) / 256; x++)
@@ -575,11 +570,12 @@ protected:
 				t_py = m_height - y * 256 - 256;
 				
 				// Setup co-ords.
-				t_vertices[0] = t_px, t_vertices[1] = t_py + 256;
-				t_vertices[2] = t_px + 256, t_vertices[3] = t_py + 256;
-				t_vertices[4] = t_px, t_vertices[5] = t_py;
-				t_vertices[6] = t_px + 256, t_vertices[7] = t_py;
+				t_vertices[0].position[0] = t_px, t_vertices[0].position[1] = t_py + 256;
+				t_vertices[1].position[0] = t_px + 256, t_vertices[1].position[1] = t_py + 256;
+				t_vertices[2].position[0] = t_px, t_vertices[2].position[1] = t_py;
+				t_vertices[3].position[0] = t_px + 256, t_vertices[3].position[1] = t_py;
 				
+				glBufferData(GL_ARRAY_BUFFER, sizeof(MCGLTextureVertex) * 4, t_vertices, GL_STREAM_DRAW);
 				glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 			}
 		
@@ -609,25 +605,22 @@ protected:
 	t_layer = (CAEAGLLayer *)[self layer];
 	
 	[t_layer setOpaque: YES];
-	[t_layer setDrawableProperties:
-				[NSDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithBool:FALSE], kEAGLDrawablePropertyRetainedBacking, kEAGLColorFormatRGBA8, kEAGLDrawablePropertyColorFormat, nil]];
+	[t_layer setDrawableProperties: @{kEAGLDrawablePropertyRetainedBacking: @NO, kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8}];
 	
 	// Initialize the context
 	
-	m_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1];
+	m_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
 	[EAGLContext setCurrentContext: m_context];
 	
-	glGenFramebuffersOES(1, &m_framebuffer);
-	glGenRenderbuffersOES(1, &m_renderbuffer);
-	glBindFramebufferOES(GL_FRAMEBUFFER_OES, m_framebuffer);
-	glBindRenderbufferOES(GL_RENDERBUFFER_OES, m_renderbuffer);
-	glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_COLOR_ATTACHMENT0_OES, GL_RENDERBUFFER_OES, m_renderbuffer);
+	/* UNCHECKED */ MCGLContextInit(MCPlatformGetOpenGLContext());
+
+	glGenFramebuffers(1, &m_framebuffer);
+	glGenRenderbuffers(1, &m_renderbuffer);
+	glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+	glBindRenderbuffer(GL_RENDERBUFFER, m_renderbuffer);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_renderbuffer);
 
 	glDisable(GL_DEPTH_TEST);
-	glDisableClientState(GL_COLOR_ARRAY);
-	glEnable(GL_TEXTURE_2D);
-	glEnableClientState(GL_VERTEX_ARRAY);
-	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     
 	return self;
 }
@@ -653,14 +646,14 @@ protected:
 
 - (BOOL)resizeFromLayer:(CAEAGLLayer *)layer
 {
-    glBindRenderbufferOES(GL_RENDERBUFFER_OES, m_renderbuffer);
-    [m_context renderbufferStorage:GL_RENDERBUFFER_OES fromDrawable:layer];
-	glGetRenderbufferParameterivOES(GL_RENDERBUFFER_OES, GL_RENDERBUFFER_WIDTH_OES, &m_backing_width);
-    glGetRenderbufferParameterivOES(GL_RENDERBUFFER_OES, GL_RENDERBUFFER_HEIGHT_OES, &m_backing_height);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_renderbuffer);
+    [m_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer];
+	glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &m_backing_width);
+    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &m_backing_height);
 	
-    if (glCheckFramebufferStatusOES(GL_FRAMEBUFFER_OES) != GL_FRAMEBUFFER_COMPLETE_OES)
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
 	{
-		NSLog(@"Failed to make complete framebuffer object %x", glCheckFramebufferStatusOES(GL_FRAMEBUFFER_OES));
+		NSLog(@"Failed to make complete framebuffer object %x", glCheckFramebufferStatus(GL_FRAMEBUFFER));
         return NO;
     }
     
@@ -678,16 +671,20 @@ protected:
 	
     [EAGLContext setCurrentContext: m_context];
 	
-    glBindFramebufferOES(GL_FRAMEBUFFER_OES, m_framebuffer);
+    MCGLContextRef t_glcontext;
+    t_glcontext = MCPlatformGetOpenGLContext();
+	
+    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
     glClear(GL_COLOR_BUFFER_BIT);
 	
 	glViewport(0, 0, m_backing_width, m_backing_height);
-	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
-	glOrthof(0, (GLfloat)m_backing_width, 0, (GLfloat)m_backing_height, 0, 1);
-	glMatrixMode(GL_MODELVIEW);
-	glLoadIdentity();
 	
+	// create transform from {0, 0, surface_width, surface_height} to GL normaized coords
+	MCGAffineTransform t_projection;
+	t_projection = MCGAffineTransformFromRectangles(MCGRectangleMake(0, 0, m_backing_width, m_backing_height), MCGRectangleMake(-1,-1,2,2));
+	MCGLContextSetProjectionTransform(t_glcontext, t_projection);
+	MCGLContextSetWorldTransform(t_glcontext, MCGAffineTransformMakeIdentity());
+	MCGLContextSetTextureTransform(t_glcontext, MCGAffineTransformMakeIdentity());
 	MCOpenGLStackSurface t_surface([self layer], m_backing_width, m_backing_height);
 	   
 	MCGRegionRef t_dirty_rgn;
@@ -702,8 +699,8 @@ protected:
 	
 	MCGRegionDestroy(t_dirty_rgn);
 	
-    glBindRenderbufferOES(GL_RENDERBUFFER_OES, m_renderbuffer);
-    [m_context presentRenderbuffer:GL_RENDERBUFFER_OES];
+    glBindRenderbuffer(GL_RENDERBUFFER, m_renderbuffer);
+    [m_context presentRenderbuffer:GL_RENDERBUFFER];
 }
 
 @end

--- a/engine/src/mbliphoneview.h
+++ b/engine/src/mbliphoneview.h
@@ -26,8 +26,8 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGLES/EAGL.h>
 #import <OpenGLES/EAGLDrawable.h>
-#import <OpenGLES/ES1/gl.h>
-#import <OpenGLES/ES1/glext.h>
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/engine/src/tilecachegl.cpp
+++ b/engine/src/tilecachegl.cpp
@@ -34,18 +34,17 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include <CoreGraphics/CoreGraphics.h>
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
-extern void MCIPhoneSwitchToUIKit(void);
-extern void MCIPhoneSwitchToOpenGL(void);
 #elif defined(TARGET_SUBPLATFORM_ANDROID)
 #define GL_GLEXT_PROTOTYPES
 #include <GLES/gl.h>
 #include <GLES/glext.h>
 #include <EGL/egl.h>
-extern void MCAndroidEnableOpenGLMode(void);
-extern void MCAndroidDisableOpenGLMode(void);
 #else
 #error tilecachegl.cpp not supported on this platform
 #endif
+
+extern void MCPlatformEnableOpenGLMode(void);
+extern void MCPlatformDisableOpenGLMode(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -692,11 +691,7 @@ void MCTileCacheOpenGLCompositor_Cleanup(void *p_context)
 	MCMemoryDeleteArray(self -> super_tiles);
 	MCMemoryDelete(self);
 	
-#ifdef _IOS_MOBILE
-	MCIPhoneSwitchToUIKit();
-#else
-	MCAndroidDisableOpenGLMode();
-#endif
+	MCPlatformDisableOpenGLMode();
 }
 
 void MCTileCacheOpenGLCompositor_Flush(void *p_context)
@@ -733,11 +728,7 @@ bool MCTileCacheOpenGLCompositorConfigure(MCTileCacheRef p_tilecache, MCTileCach
 	r_compositor . begin_snapshot = MCTileCacheOpenGLCompositor_BeginSnapshot;
 	r_compositor . end_snapshot = MCTileCacheOpenGLCompositor_EndSnapshot;
 	
-#ifdef _IOS_MOBILE
-	MCIPhoneSwitchToOpenGL();
-#else
-	MCAndroidEnableOpenGLMode();
-#endif
+	MCPlatformEnableOpenGLMode();
 	
 	return true;
 }

--- a/engine/src/tilecachegl3.x.cpp
+++ b/engine/src/tilecachegl3.x.cpp
@@ -1,0 +1,681 @@
+/* Copyright (C) 2003-2015 LiveCode Ltd.
+
+This file is part of LiveCode.
+
+LiveCode is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License v3 as published by the Free
+Software Foundation.
+
+LiveCode is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
+
+#include "prefix.h"
+
+#include "globdefs.h"
+#include "filedefs.h"
+#include "objdefs.h"
+#include "parsedef.h"
+
+#include "util.h"
+#include "stack.h"
+#include "region.h"
+#include "tilecache.h"
+#include "packed.h"
+#include "mbldc.h"
+
+#include <pthread.h>
+
+#if defined(_IOS_MOBILE)
+
+#import <OpenGLES/ES3/gl.h>
+#import <OpenGLES/ES3/glext.h>
+
+#elif defined(TARGET_SUBPLATFORM_ANDROID)
+
+#define GL_GLEXT_PROTOTYPES
+#include <GLES3/gl3.h>
+#include <GLES3/gl3ext.h>
+#include <EGL/egl.h>
+
+#else
+#error tilecachegl3.x.cpp not supported on this platform
+#endif
+
+#include "glcontext.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+#define kSuperTileSize 256
+
+struct super_tile
+{
+	GLuint texture;
+	uint32_t free_count;
+	uint8_t free_list[1];
+};
+
+struct MCTileCacheOpenGLCompositorContext
+{
+	// The tilecache
+	MCTileCacheRef tilecache;
+	
+	// The tilesize in use.
+	int32_t tile_size;
+	
+	// The number of tiles per super-tile.
+	uint32_t super_tile_arity;
+	
+	// The array of super-tiles currently allocated.
+	super_tile **super_tiles;
+	uint32_t super_tile_count;
+	
+	// The currently bound texture.
+	uint32_t current_texture;
+	
+	// The height of the viewport.
+	int32_t viewport_height;
+	
+	// The current opacity (only needed for rects)
+	uint32_t current_opacity;
+	
+	// If true, then blending is enabled.
+	bool is_blending : 1;
+	
+	// If true, then we are configured for filling rather than texturing.
+	bool is_filling : 1;
+	
+	// The vertex data that is used.
+	GLshort vertex_data[16];
+
+	// This is set to true if the super tiles need to be forced flushed
+	// (due to a Flush call).
+	bool needs_flush;
+	
+	// If this is true, rendering is flipped in the y direction (relative to
+	// 'normal' for LiveCode origin).
+	bool flip_y;
+	
+	// The gl context
+	MCGLContextRef gl_context;
+
+	// The original framebuffer (used when doing a snapshot).
+	GLuint original_draw_framebuffer;
+	GLuint original_read_framebuffer;
+	
+	// The snapshot framebuffer and renderbuffer (only valid between
+	// BeginSnapshot and EndSnapshot).
+	GLuint snapshot_framebuffer;
+	GLuint snapshot_renderbuffer;
+	
+	// The origin of the current render (used by snapshot).
+	GLint origin_x, origin_y;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void MCTileCacheOpenGLCompositorDecodeTile(MCTileCacheOpenGLCompositorContext *self, uintptr_t p_tile, uint32_t& r_super_tile, uint32_t& r_sub_tile)
+{
+	r_super_tile = (p_tile & 0xffff) - 1;
+	r_sub_tile = (p_tile >> 16) - 1;
+}
+
+static inline void MCTileCacheOpenGLCompositorEncodeTile(MCTileCacheOpenGLCompositorContext *self, uint32_t p_super_tile, uint32_t p_sub_tile, uint32_t& r_tile)
+{
+	r_tile = (p_super_tile + 1) | ((p_sub_tile + 1) << 16);
+}
+
+static bool MCTileCacheOpenGLCompositorCreateTile(MCTileCacheOpenGLCompositorContext *self, uint32_t& r_tile)
+{
+	// Loop through backwards and find the first super_tile with free space. (We loop
+	// backwards under the assumption that more recently allocated tiles are less
+	// likely to be freed soon).
+	for(uint32_t i = self -> super_tile_count; i > 0; i--)
+	{
+		super_tile *t_super_tile;
+		t_super_tile = self -> super_tiles[i - 1];
+		if (t_super_tile == nil)
+			continue;
+		
+		// We found a free tile.
+		if (t_super_tile -> free_count > 0)
+		{
+			// Compute the id.
+			MCTileCacheOpenGLCompositorEncodeTile(self, i - 1, t_super_tile -> free_list[--t_super_tile -> free_count], r_tile);
+			return true;
+		}
+	}
+	
+	// First look for an empty slot.
+	uint32_t t_super_tile_index;
+	t_super_tile_index = self -> super_tile_count;
+	for(uint32_t i = 0; i < self -> super_tile_count; i++)
+		if (self -> super_tiles[i] == nil)
+		{
+			t_super_tile_index = i;
+			break;
+		}
+	
+	// Extend the array if needed.
+	if (t_super_tile_index == self -> super_tile_count)
+	{
+		if (!MCMemoryResizeArray(self -> super_tile_count + 1, self -> super_tiles, self -> super_tile_count))
+			return false;
+	}
+	
+	// We failed to find an empty super-tile so we must allocate a new one.
+	super_tile *t_super_tile;
+	if (!MCMemoryAllocate(8 + self -> super_tile_arity, t_super_tile))
+		return false;
+	
+	
+	// Generate a texture id, and bind an empty texture.
+	glGenTextures(1, &t_super_tile -> texture);
+	glBindTexture(GL_TEXTURE_2D, t_super_tile -> texture);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	
+	// IM_2013-08-21: [[ RefactorGraphics ]] set iOS pixel format to RGBA
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, kSuperTileSize, kSuperTileSize, 0, GL_RGBA, GL_UNSIGNED_BYTE, nil);
+	
+	// Fill in the free list - subtile 0 is the one we will allocate.
+	for(uint32_t i = 1; i < self -> super_tile_arity; i++)
+		t_super_tile -> free_list[i - 1] = i;
+	t_super_tile -> free_count = self -> super_tile_arity - 1;
+	
+	// Set the slot.
+	self -> super_tiles[t_super_tile_index] = t_super_tile;
+	
+	// Make sure we don't make redundent bind calls.
+	self -> current_texture = t_super_tile -> texture;
+
+	// And compute the id (note the subtile index is 0!).
+	MCTileCacheOpenGLCompositorEncodeTile(self, t_super_tile_index, 0, r_tile);
+
+	return true;
+}
+
+static void MCTileCacheOpenGLCompositorDestroyTile(MCTileCacheOpenGLCompositorContext *self, uintptr_t p_tile)
+{
+	// Fetch the super/sub indices of the tile.
+	uint32_t t_super_tile_index, t_sub_tile_index;
+	MCTileCacheOpenGLCompositorDecodeTile(self, p_tile, t_super_tile_index, t_sub_tile_index);
+	
+	// Fetch the super tile structure.
+	super_tile *t_super_tile;
+	t_super_tile = self -> super_tiles[t_super_tile_index];
+
+	// Push the sub tile index onto the free list. We will free any unused textures
+	// at the next 'endtiling' point since we may not be in a OpenGL call safe
+	// environment at the moment. (DestroyTile occurs whenever layer mutation occurs
+	// not when processing frames).
+	t_super_tile -> free_list[t_super_tile -> free_count++] = t_sub_tile_index;
+}
+
+static void MCTileCacheOpenGLCompositorFlushSuperTiles(MCTileCacheOpenGLCompositorContext *self, bool p_force)
+{
+	// Loop through all our supertiles, discarding any which are empty.
+	for(uint32_t i = 0; i < self -> super_tile_count; i++)
+	{
+		if (self -> super_tiles[i] == nil)
+			continue;
+		
+		if (p_force || self -> super_tiles[i] -> free_count == self -> super_tile_arity)
+		{
+			// deleting the currently bound texture reverts the binding to zero
+			if (self->current_texture == self->super_tiles[i]->texture)
+				self->current_texture = 0;
+			glDeleteTextures(1, &self -> super_tiles[i] -> texture);
+			MCMemoryDelete(self -> super_tiles[i]);
+			self -> super_tiles[i] = nil;
+			
+		}
+	}
+}
+
+bool MCTileCacheOpenGLCompositor_BeginTiling(void *p_context)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	// Reset the current texture.
+	self -> current_texture = 0;
+	
+	// Update the tile size.
+	self -> tile_size = MCTileCacheGetTileSize(self -> tilecache);
+	
+	// Compute the super tile arity.
+	uint32_t t_super_tile_arity;
+	t_super_tile_arity = (kSuperTileSize * kSuperTileSize) / (self -> tile_size * self -> tile_size);
+	
+	// If the arity has changed or needs flush is set, flush all existing (what must be empty)
+	// super_tiles.
+	if (t_super_tile_arity != self -> super_tile_arity ||
+		self -> needs_flush)
+	{
+		// MW-2013-06-26: [[ Bug 10991 ]] Don't force flushing of the tilecache, otherwise
+		//   we end up discarding tiles that are still needed after a 'compact()' operation.
+		MCTileCacheOpenGLCompositorFlushSuperTiles(self, false);
+	
+		self -> super_tile_arity = t_super_tile_arity;
+		self -> needs_flush = false;
+	}
+	
+	// Clear any error flags from OpenGL so we can detect failure.
+	/* UNCHECKED */ MCGLCheckError(nil);
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_EndTiling(void *p_context)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	// Flush any empty textures.
+	MCTileCacheOpenGLCompositorFlushSuperTiles(self, false);
+	
+	// If an OpenGL error occurred, then return false.
+	return MCGLCheckError("EndTiling - ");
+}
+
+bool MCTileCacheOpenGLCompositor_AllocateTile(void *p_context, int32_t p_size, const void *p_bits, uint32_t p_stride, void*& r_tile)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+
+	// If the stride is exactly one tile wide, we don't need a copy.
+	void *t_data;
+	t_data = nil;
+	if (p_stride == p_size * sizeof(uint32_t))
+		t_data = (void *)p_bits;
+	else if (MCMemoryAllocate(p_size * p_size * sizeof(uint32_t), t_data))
+	{
+		// Copy across each scanline of the tile into the buffer.
+		for(int32_t y = 0; y < p_size; y++)
+			memcpy((uint8_t *)t_data + y * p_size * sizeof(uint32_t), (uint8_t *)p_bits + p_stride * y, p_size * sizeof(uint32_t));
+	}
+	
+	void *t_tile;
+	uint32_t t_tile_id;
+	t_tile = nil;
+	if (t_data != nil && MCTileCacheOpenGLCompositorCreateTile(self, t_tile_id))
+	{
+		// Fetch the super/sub indices of the tile.
+		uint32_t t_super_tile_index, t_sub_tile_index;
+		MCTileCacheOpenGLCompositorDecodeTile(self, t_tile_id, t_super_tile_index, t_sub_tile_index);
+		
+		// Now fetch the texture and bind it if necessary.
+		GLuint t_texture;
+		t_texture = self -> super_tiles[t_super_tile_index] -> texture;
+		if (t_texture != self -> current_texture)
+		{
+			glBindTexture(GL_TEXTURE_2D, t_texture);
+			self -> current_texture = t_texture;
+		}
+		
+		// Calculate its location.
+		GLint t_x, t_y;
+		t_x = t_sub_tile_index % (kSuperTileSize / self -> tile_size);
+		t_y = t_sub_tile_index / (kSuperTileSize / self -> tile_size);
+		
+		// Fill the texture.
+		// IM_2013-08-21: [[ RefactorGraphics ]] set iOS pixel format to RGBA
+		glTexSubImage2D(GL_TEXTURE_2D, 0, t_x * self -> tile_size, t_y * self -> tile_size, self -> tile_size, self -> tile_size, GL_RGBA, GL_UNSIGNED_BYTE, t_data);
+		// SN-2015-04-13: [[ Bug 14879 ]] This function seems to fail sometimes,
+		//  and we want to get the error here, not in
+		//  MCTileCacheOpenGLCompositorFlushSuperTiles as it happens in the
+		//  stack attached to the bug report.
+		GLenum t_error = glGetError();
+		if (t_error != GL_NO_ERROR)
+			MCLog("glTextSubImage2D(x,x,%d,%d,%d,%d,...) returned error 0x%X", t_x * self -> tile_size, t_y * self -> tile_size, self -> tile_size, self -> tile_size, t_error);
+
+		// Set the tile id.
+		t_tile = (void *)t_tile_id;
+	}
+	
+	if (t_data != p_bits)
+		MCMemoryDeallocate(t_data);
+	
+	if (t_tile == nil)
+		return false;
+	
+	r_tile = t_tile;
+	
+	return true;
+}
+
+void MCTileCacheOpenGLCompositor_DeallocateTile(void *p_context, void *p_tile)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	MCTileCacheOpenGLCompositorDestroyTile(self, (uintptr_t)p_tile);
+}
+
+static void MCTileCacheOpenGLCompositor_PrepareFrame(MCTileCacheOpenGLCompositorContext *self, MCGAffineTransform p_world_transform)
+{
+#if defined(_ANDROID_MOBILE)
+	/* On android the soft keyboard changes the surface height but we do not
+	 * update the tilecache height to match. To handle this we get the current
+	 * surface height to enusre the correct transform is applied. */
+	EGLint t_height;
+	eglQuerySurface(eglGetCurrentDisplay(),
+					eglGetCurrentSurface(EGL_DRAW),
+					EGL_HEIGHT,
+					&t_height);
+
+	self -> viewport_height = t_height;
+#else
+	self -> viewport_height = MCTileCacheGetViewport(self -> tilecache) . height;
+#endif
+	self -> current_texture = 0;
+	self -> current_opacity = 255;
+	self -> is_filling = false;
+	self -> is_blending = false;
+	
+	// Set the texture matrix.
+	MCGFloat t_texture_scale;
+	t_texture_scale = ((float)self->tile_size) / ((float)kSuperTileSize);
+	MCGAffineTransform t_texture_transform;
+	t_texture_transform = MCGAffineTransformMakeScale(t_texture_scale, t_texture_scale);
+
+	MCGAffineTransform t_world_transform;
+	t_world_transform = MCGAffineTransformMakeIdentity();
+	if (!self->flip_y)
+	{
+		t_world_transform = MCGAffineTransformPostTranslate(t_world_transform, 0.0, self->viewport_height);
+		t_world_transform = MCGAffineTransformPostScale(t_world_transform, 1.0, -1.0);
+	}
+	t_world_transform = MCGAffineTransformConcat(t_world_transform, p_world_transform);
+
+	// initialize variables of color & texture shader programs
+	MCGLContextSelectProgram(self->gl_context, kMCGLProgramTypeColor);
+	MCGLContextSetWorldTransform(self->gl_context, t_world_transform);
+
+	MCGLContextSelectProgram(self->gl_context, kMCGLProgramTypeTexture);
+	MCGLContextSetWorldTransform(self->gl_context, t_world_transform);
+	MCGLContextSetTextureTransform(self->gl_context, t_texture_transform);
+	
+	// Initialize the blend function we would use.
+	glDisable(GL_BLEND);
+	glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+}
+
+bool MCTileCacheOpenGLCompositor_BeginFrame(void *p_context, MCStackSurface *p_surface, MCGRegionRef p_dirty)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	void *t_target;
+	if (!p_surface -> LockTarget(kMCStackSurfaceTargetEAGLContext, t_target))
+		return false;
+	
+	// MW-2013-03-12: [[ Bug 10705 ]] Reset the origin to 0.
+	self -> flip_y = false;
+	self -> origin_x = 0;
+	self -> origin_y = 0;
+	
+	MCTileCacheOpenGLCompositor_PrepareFrame(self, MCGAffineTransformMakeIdentity());
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_EndFrame(void *p_context, MCStackSurface *p_surface)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	p_surface -> UnlockTarget();
+	
+	return MCGLCheckError("EndFrame - ");
+}
+
+bool MCTileCacheOpenGLCompositor_BeginSnapshot(void *p_context, MCRectangle p_area, MCGRaster &p_target)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, (GLint *)&self -> original_draw_framebuffer);
+	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, (GLint *)&self -> original_read_framebuffer);
+	
+	glGenFramebuffers(1, &self -> snapshot_framebuffer);
+	glBindFramebuffer(GL_FRAMEBUFFER, self -> snapshot_framebuffer);
+	
+	glGenRenderbuffers(1, &self -> snapshot_renderbuffer);
+	glBindRenderbuffer(GL_RENDERBUFFER, self -> snapshot_renderbuffer);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, p_area . width, p_area . height);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, self -> snapshot_renderbuffer);
+
+	GLenum t_status;
+	t_status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if (t_status != GL_FRAMEBUFFER_COMPLETE)
+	{
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, self -> original_draw_framebuffer);
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, self -> original_read_framebuffer);
+		glDeleteRenderbuffers(1, &self -> snapshot_renderbuffer);
+		glDeleteFramebuffers(1, &self -> snapshot_framebuffer);
+		return false;
+	}
+	
+	// MW-2013-03-12: [[ Bug 10705 ]] Set the origin of the snapshot so layer clipping works
+	self -> flip_y = true;
+	self -> origin_x = -p_area . x;
+	self -> origin_y = -p_area . y;
+	
+	// MW-2013-06-07: [[ Bug 10705 ]] Make sure we translate the viewport so the correct area
+	//   gets rendered (and snapshotted).
+	MCGAffineTransform t_world_transform;
+	t_world_transform = MCGAffineTransformMakeTranslation(-p_area.x, -p_area.y);
+
+	MCTileCacheOpenGLCompositor_PrepareFrame(self, t_world_transform);
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_EndSnapshot(void *p_context, MCRectangle p_area, MCGRaster &p_target)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	/* OVERHAUL - REVISIT: check byte order? */
+	// t_bitmap -> is_swapped = true;
+	glReadPixels(0, 0, p_area . width, p_area . height, GL_RGBA, GL_UNSIGNED_BYTE, p_target . pixels);
+	
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, self -> original_draw_framebuffer);
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, self -> original_read_framebuffer);
+
+	glDeleteRenderbuffers(1, &self -> snapshot_renderbuffer);
+	glDeleteFramebuffers(1, &self -> snapshot_framebuffer);
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_BeginLayer(void *p_context, const MCRectangle& p_clip, uint32_t p_opacity, uint32_t p_ink)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+
+	glEnable(GL_SCISSOR_TEST);
+	
+	// MW-2012-09-18: [[ Bug 10202 ]] If the ink is no-op then ensure nothing happens.
+	if (p_ink == GXnoop)
+		glScissor(0, 0, 0, 0);
+	else
+	{
+		// MW-2013-03-12: [[ Bug 10705 ]] Adjust the scissor rect by the origin of the snapshot (scissor is in device, not user space).
+		if (!self -> flip_y)
+			glScissor(p_clip . x + self -> origin_x, self -> viewport_height - (p_clip . y + p_clip . height) + self -> origin_y, p_clip . width, p_clip . height);
+		else
+			glScissor(p_clip . x + self -> origin_x, p_clip . y + self -> origin_y, p_clip . width, p_clip . height);
+	}
+	
+	if (!self -> is_blending)
+	{
+		self -> is_blending = true;
+		glEnable(GL_BLEND);
+	}
+		
+	self -> current_opacity = p_opacity;
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_EndLayer(void *p_context)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	self -> current_opacity = 255;
+	
+	glDisable(GL_SCISSOR_TEST);
+	
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_CompositeTile(void *p_context, int32_t p_x, int32_t p_y, void *p_tile)
+{
+	if (p_tile == nil)
+		return false;
+	
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+
+	uint32_t t_super_tile_index, t_sub_tile_index;
+	MCTileCacheOpenGLCompositorDecodeTile(self, (uintptr_t)p_tile, t_super_tile_index, t_sub_tile_index);
+	
+	GLuint t_texture;
+	t_texture = self -> super_tiles[t_super_tile_index] -> texture;
+	if (t_texture != self -> current_texture)
+	{
+		glBindTexture(GL_TEXTURE_2D, t_texture);
+		self -> current_texture = t_texture;
+	}
+
+	if (self->is_filling)
+	{
+		self->is_filling = false;
+		MCGLContextSelectProgram(self->gl_context, kMCGLProgramTypeTexture);
+	}
+	
+	int32_t t_tile_x, t_tile_y;
+	t_tile_x = t_sub_tile_index % (kSuperTileSize / self -> tile_size);
+	t_tile_y = t_sub_tile_index / (kSuperTileSize / self -> tile_size);
+	
+	MCGLTextureVertex *t_vertices;
+	t_vertices = (MCGLTextureVertex*)(self->vertex_data);
+	t_vertices[0].position[0] = p_x;                   t_vertices[0].position[1] = p_y + self->tile_size;
+	t_vertices[0].texture_position[0] = t_tile_x;      t_vertices[0].texture_position[1] = t_tile_y + 1;
+	t_vertices[1].position[0] = p_x + self->tile_size; t_vertices[1].position[1] = p_y + self->tile_size;
+	t_vertices[1].texture_position[0] = t_tile_x + 1;  t_vertices[1].texture_position[1] = t_tile_y + 1;
+	t_vertices[2].position[0] = p_x;                   t_vertices[2].position[1] = p_y;
+	t_vertices[2].texture_position[0] = t_tile_x;      t_vertices[2].texture_position[1] = t_tile_y;
+	t_vertices[3].position[0] = p_x + self->tile_size; t_vertices[3].position[1] = p_y;
+	t_vertices[3].texture_position[0] = t_tile_x + 1;  t_vertices[3].texture_position[1] = t_tile_y;
+
+	glBufferData(GL_ARRAY_BUFFER, sizeof(MCGLTextureVertex) * 4, self->vertex_data, GL_STREAM_DRAW);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	return true;
+}
+
+bool MCTileCacheOpenGLCompositor_CompositeRect(void *p_context, int32_t p_x, int32_t p_y, uint32_t p_color)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	if (!self->is_filling)
+	{
+		self->is_filling = true;
+		MCGLContextSelectProgram(self->gl_context, kMCGLProgramTypeColor);
+	}
+
+	// MW-2014-03-14: [[ Bug 11880 ]] The color field we store is premultiplied by the current
+	//   opacity.
+	uint32_t t_new_color;
+	t_new_color = packed_scale_bounded(p_color, self->current_opacity);
+	uint32_t t_rgba_color;
+	{
+		uint8_t r, g, b, a;
+		MCGPixelUnpackNative(t_new_color, r, g, b, a);
+		t_rgba_color = MCGPixelPack(kMCGPixelFormatRGBA, r, g, b, a);
+	}
+
+	MCGLColorVertex *t_vectors;
+	t_vectors = (MCGLColorVertex*)self->vertex_data;
+	t_vectors[0].position[0] = p_x; t_vectors[0].position[1] = p_y + self->tile_size;
+	t_vectors[0].color = t_rgba_color;
+	t_vectors[1].position[0] = p_x + self->tile_size; t_vectors[1].position[1] = p_y + self->tile_size;
+	t_vectors[1].color = t_rgba_color;
+	t_vectors[2].position[0] = p_x; t_vectors[2].position[1] = p_y;
+	t_vectors[2].color = t_rgba_color;
+	t_vectors[3].position[0] = p_x + self->tile_size; t_vectors[3].position[1] = p_y;
+	t_vectors[3].color = t_rgba_color;
+
+	glBufferData(GL_ARRAY_BUFFER, sizeof(MCGLColorVertex) * 4, self->vertex_data, GL_STREAM_DRAW);
+	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+	return true;
+}
+
+void MCTileCacheOpenGLCompositor_Cleanup(void *p_context)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+	
+	MCTileCacheOpenGLCompositorFlushSuperTiles(self, true);
+	MCMemoryDeleteArray(self -> super_tiles);
+	MCMemoryDelete(self);
+	
+	MCPlatformDisableOpenGLMode();
+}
+
+void MCTileCacheOpenGLCompositor_Flush(void *p_context)
+{
+	MCTileCacheOpenGLCompositorContext *self;
+	self = (MCTileCacheOpenGLCompositorContext *)p_context;
+
+	self -> needs_flush = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool MCTileCacheOpenGLCompositorConfigure(MCTileCacheRef p_tilecache, MCTileCacheCompositor& r_compositor)
+{
+	MCTileCacheOpenGLCompositorContext *t_context;
+	if (!MCMemoryNew(t_context))
+		return false;
+	
+	t_context -> tilecache = p_tilecache;
+	
+	r_compositor . context = t_context;
+	r_compositor . cleanup = MCTileCacheOpenGLCompositor_Cleanup;
+	r_compositor . flush = MCTileCacheOpenGLCompositor_Flush;
+	r_compositor . begin_tiling = MCTileCacheOpenGLCompositor_BeginTiling;
+	r_compositor . end_tiling = MCTileCacheOpenGLCompositor_EndTiling;
+	r_compositor . allocate_tile = MCTileCacheOpenGLCompositor_AllocateTile;
+	r_compositor . deallocate_tile = MCTileCacheOpenGLCompositor_DeallocateTile;
+	r_compositor . begin_frame = MCTileCacheOpenGLCompositor_BeginFrame;
+	r_compositor . end_frame = MCTileCacheOpenGLCompositor_EndFrame;
+	r_compositor . begin_layer = MCTileCacheOpenGLCompositor_BeginLayer;
+	r_compositor . end_layer = MCTileCacheOpenGLCompositor_EndLayer;
+	r_compositor . composite_tile = MCTileCacheOpenGLCompositor_CompositeTile;
+	r_compositor . composite_rect = MCTileCacheOpenGLCompositor_CompositeRect;
+	r_compositor . begin_snapshot = MCTileCacheOpenGLCompositor_BeginSnapshot;
+	r_compositor . end_snapshot = MCTileCacheOpenGLCompositor_EndSnapshot;
+	
+	MCPlatformEnableOpenGLMode();
+	t_context->gl_context = MCPlatformGetOpenGLContext();
+
+	MCAssert(t_context->gl_context != nil);
+	
+	return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch adds a new tilecache implementation for iOS and Android based on GLES3.x.

In addition, vertex data is buffered to be sent to the GPU in batches, improving rendering performance