### PR TITLE
[Bugfix-22892] Add detail to "is an integer" 

### DIFF
--- a/docs/dictionary/operator/is-a.lcdoc
+++ b/docs/dictionary/operator/is-a.lcdoc
@@ -57,7 +57,9 @@ A <value> is a(n):
 * date if it is in one of the formats produced by the <date> or <time>
   functions 
 * <integer(keyword)> if it consists of digits (with an optional leading
-  minus sign), or an hexadecimal number (such as 0x0F9B)
+  minus sign), is an hexadecimal number (such as 0x0F9B) or is a number 
+  that has no fractional part (i.e. the number and the floor of the 
+  number are equal)
 * number if it consists of digits, optional leading minus sign, optional
   decimal point, and optional "E" or "e" (scientific notation), or an
   optional leading minus sign and infinity or inf

--- a/docs/notes/bugfix-22892.md
+++ b/docs/notes/bugfix-22892.md
@@ -1,0 +1,1 @@
+# Further explained the workings of is an integer


### PR DESCRIPTION
Added the detail that `is an integer` will return true if the number and the floor of it are equal, regardless of a decimal point's presence.