### PR TITLE
[[ Bug 22894 ]] Android Manifest: Allow merging <activity> children

### DIFF
--- a/docs/notes/bugfix-22894.md
+++ b/docs/notes/bugfix-22894.md
@@ -1,0 +1,1 @@
+# Ensure children nodes of the <activity> tag can be merged when additional android manifests are added  

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -1905,6 +1905,10 @@ command MergeManifestArray @xManifestArrayA, pAdditionalsA
                put tNewA[tKey] into tExistingA[tKey]
             end repeat
             put tExistingA into xManifestArrayA[tActivityIndex]["@attributes"]
+            if tData["@children"] is an array then
+               MergeManifestArray xManifestArrayA[tActivityIndex]["@children"], \
+                     tData["@children"]
+            end if
             break
          default
             insertIntoList tData, xManifestArrayA, tEndOfBlock


### PR DESCRIPTION
This patch ensures that the android manifest merging algorith will merge the children nodes of the <activity> tag as well.