### PR TITLE
[[ Bug 22901 ]] Ensure commercial debug symbols for Win are copied

### DIFF
--- a/tools/windows_debug_syms.pl
+++ b/tools/windows_debug_syms.pl
@@ -22,6 +22,9 @@ while (my $line = <$FILE>)
 	# Replace the .exe or .dll suffix of each file with .pdb
 	$line =~ s/\.(exe|dll)$/\.pdb/;
 	
+	# Ensure commercial engine .pdbs have the expected filename (i.e. "LiveCode-Commercial.pdb")
+	$line =~ s/(LiveCode-Business|LiveCode-Indy|LiveCode-CommunityPlus)\.pdb$/LiveCode-Commercial\.pdb/;
+
 	# Output the filename
 	print "$line\n";
 }


### PR DESCRIPTION
This patch ensures that the script that looks for the debug symbols of the Windows commercial engine uses the correct filename in this case (i.e. `LiveCode-Commercial.pdb`)