### PR TITLE
[[ Bug 22908 ]] Send mouseRelease to object with mouse focus

### DIFF
--- a/docs/notes/bugfix-22908.md
+++ b/docs/notes/bugfix-22908.md
@@ -1,0 +1,1 @@
+# Ensure mouseRelease is sent to the mouse focused object when when triggered by a system mouse or touch cancel

--- a/engine/src/eventqueue.cpp
+++ b/engine/src/eventqueue.cpp
@@ -417,7 +417,13 @@ static void MCEventQueueDispatchEvent(MCEvent *p_event)
                 t_target -> mup(t_event -> mouse . press . button + 1, false);
                 MClockmessages = old_lock;
 				
-				t_target -> message_with_args(MCM_mouse_release, t_event -> mouse . press . button + 1);
+				MCObject *mfocused;
+				mfocused = MCmousestackptr->getcard()->getmfocused();
+				if (mfocused == NULL)
+					mfocused = MCmousestackptr -> getcard();
+				if (mfocused == NULL)
+					mfocused = MCmousestackptr;
+				mfocused -> message_with_args(MCM_mouse_release, t_event -> mouse . press . button + 1);
 			}
 		}
 		break;


### PR DESCRIPTION
This patch ensures `mouseRelease` sent in `MCEventQueueDispatchEvent` is sent
to the object with the mouse focus rather than the mouse stack.