### PR TITLE
[[ Prebuilts ]] Disable U_HAVE_STRTOD_L when building ICU for Android

### DIFF
--- a/prebuilt/scripts/build-icu.sh
+++ b/prebuilt/scripts/build-icu.sh
@@ -151,6 +151,11 @@ function buildICU {
 				;;
 		esac	
 
+		# Make sure U_HAVE_STRTOD_L is 0 on android
+ 		if [ "${PLATFORM}" == "android" ] ; then
+ 			sed -i -e "s/U_HAVE_STRTOD_L=1/U_HAVE_STRTOD_L=0/" icudefs.mk
+ 		fi
+ 		
 		echo "Building ICU for ${NAME}"
 		export VERBOSE=1
 		${EMMAKE} make clean && \


### PR DESCRIPTION
This patch ensures that the `U_HAVE_STRTOD_L` is defined to be zero when compiling the ICU prebuilt on Android. The automake process for ICU 58.2 appears to incorrectly detect whether this function is available when using >= API 21 NDK toolchains, causing a compile error.