### PR TITLE
[[ Bug 22914 ]] Call doProcess in updateKeyboardVisible

### DIFF
--- a/docs/notes/bugfix-22914.md
+++ b/docs/notes/bugfix-22914.md
@@ -1,0 +1,1 @@
+# Fix `keyboardActivated` and `keyboardDeactivated` not breaking `wait for messages` on Android.

--- a/engine/src/java/com/runrev/android/Engine.java
+++ b/engine/src/java/com/runrev/android/Engine.java
@@ -1557,6 +1557,10 @@ public class Engine extends View implements EngineApi
 			doKeyboardHidden();
 		
 		m_keyboard_sizechange = true;
+
+		// Make sure we trigger handling
+		if (m_wake_on_event)
+			doProcess(false);
 	}
 	
 	void updateOrientation(int p_orientation)


### PR DESCRIPTION
This patch adds a call to `doProcess` to `updateKeyboardVisible` so that we
yield to the engine thread after sending the `keyboardActivated` or
`keyboardDeactivated` messages. This ensures the yield to android thread in
`wait` is broken.