### PR TITLE
[[ Bug 22918 ]] Fix crash when deleting object target of messages

### DIFF
--- a/docs/notes/bugfix-22918.md
+++ b/docs/notes/bugfix-22918.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting an object while handling a message sent to that object


### PR DESCRIPTION
This patch fixes a crash that can occur when an object is deleted while
handling a message sent to that object.

Fixes https://quality.livecode.com/show_bug.cgi?id=22918