### PR TITLE
[[ Tests ]] Increase socket timeout in liburl status codes test

### DIFF
--- a/tests/lcs/liburl/status_codes.livecodescript
+++ b/tests/lcs/liburl/status_codes.livecodescript
@@ -16,10 +16,10 @@ end TestSetup
 
 on TestStatusCodes
    # Response Code 204
-   set the socketTimeoutInterval to 10000
+   set the socketTimeoutInterval to 60000
    put the milliseconds into tStartTime
    put URL "http://httpstat.us/204" into tData
    TestAssert "no error is reported", the result is empty
-   TestAssert "response is not delayed until socket timeout", the milliseconds - tStartTime < 9000
+   TestAssert "response is not delayed until socket timeout", the milliseconds - tStartTime < 59000
    TestAssert "data is empty", tData is empty
 end TestStatusCodes


### PR DESCRIPTION
This patch prevents a test failure in the liburl status codes test by
increasing the socket timeout to 60 seconds, as the server used may
take longer than 10 seconds to respond.