### PR TITLE
[[ Issue 22933 ]] Remove unneccessary creation and clearance of SKBitmap

### DIFF
--- a/docs/notes/bugfix-22933.md
+++ b/docs/notes/bugfix-22933.md
@@ -1,0 +1,1 @@
+# Fix excess time taken to begin new canvas layer

--- a/libgraphics/src/context.cpp
+++ b/libgraphics/src/context.cpp
@@ -686,18 +686,6 @@ void MCGContextBegin(MCGContextRef self, bool p_need_layer)
 	SkMatrix t_device_matrix;
 	t_device_matrix = self -> layer -> canvas -> getTotalMatrix();
 	
-	// Create a suitable bitmap.
-	SkBitmap t_new_bitmap;
-	t_new_bitmap.setInfo(SkImageInfo::MakeN32Premul(t_device_clip.width(), t_device_clip.height()));
-	if (!t_new_bitmap.tryAllocPixels())
-	{
-		self -> is_valid = false;
-		return;
-	}
-	
-	// Clear the pixel buffer.
-	memset(t_new_bitmap . getPixels(), 0, t_new_bitmap . rowBytes() * t_new_bitmap . height());
-	
 	// Create a new layer the same size as the device clip
 	MCGContextLayerRef t_new_layer;
 	SkIRect t_clip_rect;


### PR DESCRIPTION
This patch removes code from MCCanvasBaginLayer that was creating a new
SkBitmap object and clearing all pixels within. The SkBitmap is not
referenced in any further part of the function, so its creation and
initilaization can be safely removed.

Fixes https://quality.livecode.com/show_bug.cgi?id=22933