### PR TITLE
[[ Bug 22929 ]] Fix high CPU usage when showing modal stack

### DIFF
--- a/docs/notes/bugfix-22929.md
+++ b/docs/notes/bugfix-22929.md
@@ -1,0 +1,1 @@
+# Fix excessive CPU usage while showing modal dialog

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -796,6 +796,12 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
     NSEvent *t_event = nil;
 	if (t_modal)
 	{
+		// Wait for an event, but leave on the queue
+		t_event = [NSApp nextEventMatchingMask: p_blocking ? NSApplicationDefinedMask : NSAnyEventMask
+									 untilDate: [NSDate dateWithTimeIntervalSinceNow: p_duration]
+										inMode: p_blocking ? NSEventTrackingRunLoopMode : NSDefaultRunLoopMode
+									   dequeue: NO];
+		
 		// Run the modal session, if it has been created yet (it might not if this
 		// wait was triggered by reacting to an event caused as part of creating
 		// the modal session, e.g. when losing window focus).


### PR DESCRIPTION
This patch fixes an issue where the modal session for a stack would be
run in a tight loop, causing excessive CPU usage

Fixes https://quality.livecode.com/show_bug.cgi?id=22929