### PR TITLE
[[ Bug 22927 ]] Fix tracking of mouse events during modal session

### DIFF
--- a/docs/notes/bugfix-22927.md
+++ b/docs/notes/bugfix-22927.md
@@ -1,0 +1,1 @@
+# Fix drag-and-drop not working within a modal stack

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -817,26 +817,7 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
 	s_in_blocking_wait = false;
 
 	if (t_event != nil)
-	{
-		if ([t_event type] == NSLeftMouseDown || [t_event type] == NSLeftMouseDragged)
-		{
-            if (s_last_mouse_event != nullptr)
-                [s_last_mouse_event release];
-			s_last_mouse_event = t_event;
-			[t_event retain];
-			[NSApp sendEvent: t_event];
-		}
-		else
-		{
-			if ([t_event type] == NSLeftMouseUp)
-			{
-				[s_last_mouse_event release];
-				s_last_mouse_event = nil;
-			}
-			
-			[NSApp sendEvent: t_event];
-		}
-	}
+		[NSApp sendEvent: t_event];
 	
 	[t_pool release];
 	
@@ -846,17 +827,6 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
     }
     
 	return t_event != nil;
-}
-
-void MCMacPlatformClearLastMouseEvent(void)
-{
-    if (s_last_mouse_event == nil)
-    {
-        return;
-    }
-    
-    [s_last_mouse_event release];
-    s_last_mouse_event = nil;
 }
 
 void MCMacPlatformBeginModalSession(MCMacPlatformWindow *p_window)
@@ -1172,6 +1142,15 @@ bool MCPlatformGetWindowWithId(uint32_t p_id, MCPlatformWindowRef& r_window)
 uint32_t MCPlatformGetEventTime(void)
 {
 	return [[NSApp currentEvent] timestamp] * 1000.0;
+}
+
+void MCMacPlatformSetLastMouseEvent(NSEvent *p_event)
+{
+	if (p_event)
+		[p_event retain];
+	if (s_last_mouse_event)
+		[s_last_mouse_event release];
+	s_last_mouse_event = p_event;
 }
 
 NSEvent *MCMacPlatformGetLastMouseEvent(void)

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -612,6 +612,7 @@ void MCMacPlatformMapScreenNSRectToMCRectangle(NSRect rect, MCRectangle& r_rect)
 
 MCPlatformModifiers MCMacPlatformMapNSModifiersToModifiers(NSUInteger p_modifiers);
 
+void MCMacPlatformSetLastMouseEvent(NSEvent *p_event);
 NSEvent *MCMacPlatformGetLastMouseEvent(void);
 
 NSMenu *MCMacPlatformGetIconMenu(void);

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -651,6 +651,9 @@ void MCMacPlatformWindowWindowMoved(NSWindow *self, MCPlatformWindowRef p_window
 
 - (void)mouseDown: (NSEvent *)event
 {
+	// Save the mouse event for use when starting drag-drop
+	MCMacPlatformSetLastMouseEvent(event);
+	
 	if (MCMacPlatformApplicationPseudoModalFor() != nil)
         return;
     
@@ -663,6 +666,9 @@ void MCMacPlatformWindowWindowMoved(NSWindow *self, MCPlatformWindowRef p_window
 
 - (void)mouseUp: (NSEvent *)event
 {
+    // Clear the mouse event used when starting drag-drop
+    MCMacPlatformSetLastMouseEvent(nil);
+
     if (MCMacPlatformApplicationPseudoModalFor() != nil)
         return;
     
@@ -683,6 +689,9 @@ void MCMacPlatformWindowWindowMoved(NSWindow *self, MCPlatformWindowRef p_window
 
 - (void)mouseDragged: (NSEvent *)event
 {
+    // Save the mouse event for use when starting drag-drop
+    MCMacPlatformSetLastMouseEvent(event);
+
     if (MCMacPlatformApplicationPseudoModalFor() != nil)
         return;
     


### PR DESCRIPTION
This patch fixes the tracking of mouse events in modal sessions on
MacOS X by updating the last mouse event in the mouseDown and
mouseDragged methods of the window, rather than by searching through
the event queue.

Fixes https://quality.livecode.com/show_bug.cgi?id=22927