### PR TITLE
[[ Bug 19016 ]] Fix printing with vGrid enabled on Windows

### DIFF
--- a/docs/notes/bugfix-19016.md
+++ b/docs/notes/bugfix-19016.md
@@ -1,0 +1,1 @@
+# Ensure printing a field with vGrid enabled does not print black rectangles on Windows

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -402,7 +402,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
             // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
             // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
             // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-            if (p_mark -> rectangle . inset && !(p_mark -> rectangle . inset % 2))
+            if (p_mark -> rectangle . inset && (p_mark -> rectangle . inset % 2))
 				p_mark -> rectangle . inset ++;
             // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
 			p_mark -> rectangle . bounds = MCRectangleMake(p_mark -> rectangle . bounds . x + p_mark -> rectangle . inset / 2,
@@ -431,7 +431,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
             // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
             // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
             // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-			if (!(p_mark -> round_rectangle . inset % 2))
+			if (p_mark -> round_rectangle . inset % 2)
 				p_mark -> round_rectangle . inset ++;
             // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
 			p_mark -> round_rectangle . bounds = MCRectangleMake(p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . inset / 2,
@@ -455,7 +455,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
             // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
             // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
             // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-			if (!(p_mark -> arc . inset % 2))
+			if (p_mark -> arc . inset % 2)
 				p_mark -> arc . inset ++;
             // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
 			p_mark -> arc . bounds = MCRectangleMake(p_mark -> arc . bounds . x + p_mark -> arc . inset / 2,

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -829,7 +829,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 			{
                 // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
                 // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (!(p_mark -> rectangle . inset % 2))
+				if (p_mark -> rectangle . inset % 2)
 					p_mark -> rectangle . inset ++;
 				p_mark -> rectangle . bounds = MCRectangleMake(p_mark -> rectangle . bounds . x + p_mark -> rectangle . inset / 2,
 															   p_mark -> rectangle . bounds . y + p_mark -> rectangle . inset / 2, 
@@ -849,7 +849,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 			{
                 // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
                 // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (!(p_mark -> round_rectangle . inset % 2))
+				if (p_mark -> round_rectangle . inset % 2)
 					p_mark -> round_rectangle . inset ++;
 				p_mark -> round_rectangle . bounds = MCRectangleMake(p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . inset / 2,
 																	 p_mark -> round_rectangle . bounds . y + p_mark -> round_rectangle . inset / 2, 
@@ -857,8 +857,6 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 																	 p_mark -> round_rectangle . bounds . height - p_mark -> round_rectangle . inset);
 			}
 			
-			int4 t_adjust;
-			t_adjust = p_mark -> stroke != NULL ? 0 : 1;
 			RoundRect(t_dc, p_mark -> round_rectangle . bounds . x, p_mark -> round_rectangle . bounds . y,
 											p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . bounds . width,
 											p_mark -> round_rectangle . bounds . y + p_mark -> round_rectangle . bounds . height, p_mark -> round_rectangle . radius,
@@ -871,7 +869,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 			{
                 // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
                 // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (!(p_mark -> arc . inset % 2))
+				if (p_mark -> arc . inset % 2)
 					p_mark -> arc . inset ++;
 				p_mark -> arc . bounds = MCRectangleMake(p_mark -> arc . bounds . x + p_mark -> arc . inset / 2,
 														 p_mark -> arc . bounds . y + p_mark -> arc . inset / 2, 


### PR DESCRIPTION
This patch ensures the check for evenness of inset is correct when printing a field. This was causing black rectangles to be printed when vGid was enabled.

Closes https://quality.livecode.com/show_bug.cgi?id=19016