### PR TITLE
[[ Bug 22927 ]] Reimplement MCMacPlatformClearLastMouseEvent

### DIFF
--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -1195,6 +1195,11 @@ NSEvent *MCMacPlatformGetLastMouseEvent(void)
 	return s_last_mouse_event;
 }
 
+void MCMacPlatformClearLastMouseEvent(void)
+{
+	MCMacPlatformSetLastMouseEvent(nil);
+}
+
 void MCPlatformFlushEvents(MCPlatformEventMask p_mask)
 {
 	NSUInteger t_ns_mask;

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -615,6 +615,7 @@ MCPlatformModifiers MCMacPlatformMapNSModifiersToModifiers(NSUInteger p_modifier
 
 void MCMacPlatformSetLastMouseEvent(NSEvent *p_event);
 NSEvent *MCMacPlatformGetLastMouseEvent(void);
+void MCMacPlatformClearLastMouseEvent(void);
 
 NSMenu *MCMacPlatformGetIconMenu(void);
 


### PR DESCRIPTION
This patch reimplements MCMacPlatformClearLastMouseEvent, which was
removed in a previous commit.