### PR TITLE
[[ Bug 22942 ]] Ensure the shellcommand defaults to COMSPEC on Windows

### DIFF
--- a/docs/dictionary/property/shellCommand.lcdoc
+++ b/docs/dictionary/property/shellCommand.lcdoc
@@ -22,8 +22,8 @@ set the shellCommand to "/bin/sh/ksh"
 Value:
 The <shellCommand> is a string.
 By default, the <shellCommand> <property> is set to "/bin/sh" (the
-Bourne shell) on <Unix|Unix systems>, and "command.com" on Windows
-systems. 
+Bourne shell) on <Unix|Unix systems>, and to the value of the COMSPEC
+environment variable on <Windows|Windows systems>. 
 
 Description:
 Use the <shellCommand> <property> to <execute> a command with a

--- a/docs/notes/bugfix-22942.md
+++ b/docs/notes/bugfix-22942.md
@@ -1,0 +1,1 @@
+# Ensure the shellCommand defaults to COMSPEC on Windows

--- a/engine/src/dskw32.cpp
+++ b/engine/src/dskw32.cpp
@@ -1534,8 +1534,17 @@ struct MCWindowsDesktop: public MCSystemInterface, public MCWindowsSystemService
 			}
 		}
 
-		// On NT systems 'cmd.exe' is the command processor
-		MCValueAssign(MCshellcmd, MCSTR("cmd.exe"));
+		/* Default the shellCommand to the value of the COMSPEC environment
+		 * variable. */
+		MCAutoStringRef t_comspec;
+		if (MCS_getenv(MCSTR("COMSPEC"), &t_comspec))
+		{
+			MCValueAssign(MCshellcmd, *t_comspec);
+		}
+		else
+		{
+			MCValueAssign(MCshellcmd, kMCEmptyString);
+		}
 
 		// MW-2005-05-26: Store a global variable containing major OS version...
 		OSVERSIONINFOA osv;

--- a/engine/src/exec-files.cpp
+++ b/engine/src/exec-files.cpp
@@ -645,6 +645,13 @@ void MCFilesEvalShell(MCExecContext& ctxt, MCStringRef p_command, MCStringRef& r
 		return;
 	}
 
+	if (MCStringIsEmpty(MCshellcmd))
+	{
+		MCeerror->add(EE_SHELL_BADCOMMAND, 0, 0, "no shell");
+		ctxt . Throw();
+		return;
+	}
+
 	if (MCS_runcmd(p_command, r_output) != IO_NORMAL)
 	{
 		MCeerror->add(EE_SHELL_BADCOMMAND, 0, 0, p_command);


### PR DESCRIPTION
Goes together with https://github.com/livecode/livecode-ide/pull/2145