### PR TITLE
[[ Bug 22947 ]] Change the behavior of the long deprecated function 'iphoneSystemIdentifier'

### DIFF
--- a/docs/dictionary/function/iphoneSystemIdentifier.lcdoc
+++ b/docs/dictionary/function/iphoneSystemIdentifier.lcdoc
@@ -29,5 +29,8 @@ system identifier.
 >*Important:* As of version 6.0 the <iPhoneSystemIdentifier> function
 > has been deprecated and must not be used in new code.
 
+>*Important:* As of version 9.6.2 the <iPhoneSystemIdentifier> function
+> is no longer supported and it returns empty.
+
 References: iphoneApplicationIdentifier (function)
 

--- a/docs/notes/bugfix-22947.md
+++ b/docs/notes/bugfix-22947.md
@@ -1,0 +1,1 @@
+# The long deprecated `iphoneSystemIdentifier` command now returns empty

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -711,13 +711,9 @@ bool MCSystemGetCurrentLocale(MCStringRef& r_current_locale)
 
 bool MCSystemGetSystemIdentifier(MCStringRef& r_identifier)
 {
-    // MM-2013-05-21: [[ Bug 10895 ]] The method uniqueIdentifier of UIDevice is now deprecated (as of May 2013).
-    //  Calling the method dynamically prevents apps from being rejected by the app store
-    //  but preserves functionality for testing and backwards compatibility.
-    NSString *t_identifier;
-    t_identifier = objc_msgSend([UIDevice currentDevice], sel_getUid("uniqueIdentifier"));
-	
-    return MCStringCreateWithCFStringRef((CFStringRef)t_identifier, r_identifier);
+	// Deprecated in LC 6.0
+	r_identifier = MCValueRetain(kMCEmptyString);
+	return true;
 }
 
 bool MCSystemGetIdentifierForVendor(MCStringRef& r_identifier)


### PR DESCRIPTION
This patch changes the behavior of the long deprecated function 'iphoneSystemIdentifier', which now returns empty. 
