### PR TITLE
[[ Bug 22952 ]] Fix event handling of nested modal stacks

### DIFF
--- a/docs/notes/bugfix-22952.md
+++ b/docs/notes/bugfix-22952.md
@@ -1,0 +1,1 @@
+# Fix modal stack not responding to input events if opened in the "openStack" handler of another modal stack


### PR DESCRIPTION
This patch fixes an issue where the most deeply nested modal session would not be run if the modal stack was created by a previous modal stack before the session for that modal stack has itself been run.
This was preventing events targeted at that window from being dispatched.

Fixes https://quality.livecode.com/show_bug.cgi?id=22952