### PR TITLE
[[ Build ]] Do not sign simulator .dylib externals

### DIFF
--- a/tools/build-extension-ios.sh
+++ b/tools/build-extension-ios.sh
@@ -128,13 +128,6 @@ fi
 
 if [ $BUILD_DYLIB -eq 1 ]; then
 	ln -sf "$PRODUCT_NAME.dylib" "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.ios-extension"
-	OUTPUT=$(/usr/bin/codesign -f -s "$CODE_SIGN_IDENTITY" "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib")
-	RESULT=$?
-	if [ $RESULT -ne 0 ]; then
-		echo "Signing $BUILT_PRODUCTS_DIR/$PRODUCT_NAME.dylib failed:"
-		echo $OUTPUT
-		exit $RESULT
-	fi
 else
 	ln -sf "$PRODUCT_NAME.lcext" "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.ios-extension"
 fi


### PR DESCRIPTION
This patch removes signing of the simulator .dylib externals, since it was causing a signing error in older simulator versions (10.2, 11.2, 12.1) when trying to sign revsecurity when building with Xcode12.x. 

Note that these .dylibs do not need to be signed at this point, since they are signed during the notarization process anyway.

FYI the signing error was `no identity found`, even though the same identity worked fine in other externals (non revsecurity) and in newer simulator versions.

I have tested this fix by deploying to simulator an app that includes (and uses) revsecurity, in both a non-notarized and a notarized build of LC 9.6.2 RC-1, and it works as expected.