### PR TITLE
[[ Bug 22889 ]] Update mergExt for iOS SDK 14.1

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2020-6-18"
+constant kMergExtVersion = "2020-10-27"
 constant kTSNetVersion = "1.4.2"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer for iOS SDK 14.1.