### PR TITLE
[[ Bug 22963 ]] Fix native split with unfound multi-char delimiter

### DIFF
--- a/docs/notes/bugfix-22586.md
+++ b/docs/notes/bugfix-22586.md
@@ -1,0 +1,1 @@
+# Fix crash in `split` command with multi-char delimiter

--- a/docs/notes/bugfix-22963.md
+++ b/docs/notes/bugfix-22963.md
@@ -1,0 +1,1 @@
+# Fix incorrect result when split does not find multi-char delimiter

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5263,9 +5263,9 @@ bool MCStringSplitNative(MCStringRef self, MCStringRef p_elem_del, MCStringRef p
 			if (!MCNameCreateWithNativeChars(t_sptr, t_key_end - t_sptr, &t_name))
 				return false;
             
-			if (t_key_end != t_element_end)
+			if (t_key_end <= t_element_end - p_key_del -> char_count)
 				t_key_end += p_key_del -> char_count;
-            
+
 			MCAutoStringRef t_string;
 			if (!MCStringCreateWithNativeChars(t_key_end, t_element_end - t_key_end, &t_string))
 				return false;

--- a/libfoundation/src/foundation-string.cpp
+++ b/libfoundation/src/foundation-string.cpp
@@ -5199,7 +5199,10 @@ static void split_find_end_of_element_and_key_native(const char_t *sptr, const c
     
     // key not found
     if (sptr == eptr - p_key_length + 1)
-        r_key_ptr = sptr;
+	{
+        r_key_ptr = eptr;
+		r_end_ptr = eptr;
+	}
     
 	split_find_end_of_element_native(sptr, eptr, del, p_del_length, r_end_ptr, p_options);
 }

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -250,3 +250,14 @@ on TestBug22586
 	split tVar by return and ":   "
 	TestAssert "unicode split by unfound multi-char delimiter does not crash", true
 end TestBug22586
+
+on TestBug22962
+	local tVar
+	put "foo" into tVar
+	split tVar by return and ": "
+	TestAssert "native split by unfound multi-char delimiter", the keys of tVar is "foo"
+
+	put "foo" & numToCodePoint(0x2192) into tVar
+	split tVar by return and ": "
+	TestAssert "unicode split by unfound multi-char delimiter", the keys of tVar is "foo" & numToCodePoint(0x2192)
+end TestBug22962

--- a/tests/lcs/core/array/split.livecodescript
+++ b/tests/lcs/core/array/split.livecodescript
@@ -239,3 +239,14 @@ on TestSplitAsSet
    split tResult with empty as set
    TestAssert "split set (native, empty)", tResult is tExpected
 end TestSplitAsSet
+
+on TestBug22586
+	local tVar
+	put "foo" into tVar
+	split tVar by return and ":   "
+	TestAssert "native split by unfound multi-char delimiter does not crash", true
+
+	put "foo" & numToCodePoint(0x2192) into tVar
+	split tVar by return and ":   "
+	TestAssert "unicode split by unfound multi-char delimiter does not crash", true
+end TestBug22586


### PR DESCRIPTION
This patch fixes an issue where the results of the split command with a multi-
char delimiter do not match between the unicode and native code paths.
Specifically the native pathway created an array with empty key and value for
element while the unicode pathway correctly creates the opposite.