### PR TITLE
[[ Bug 21471 ]] Fix revIsSpeaking function on Windows

### DIFF
--- a/docs/notes/bugfix-21471.md
+++ b/docs/notes/bugfix-21471.md
@@ -1,0 +1,1 @@
+# Fix revIsSpeaking returning incorrect values on Windows

--- a/revspeech/src/w32sapi5speech.h
+++ b/revspeech/src/w32sapi5speech.h
@@ -62,6 +62,9 @@ private:
 	// Last Error Message
 	char m_strLastError[256];
 
+	// Process events to track speech output status
+	bool ProcessEvents(void);
+
 	// Internal Error Message
 	void Error( WCHAR* pText ){wcscpy((WCHAR *)m_strLastError, pText); };
 	void Error( WCHAR* pText, HRESULT hr){ sprintf(m_strLastError,"%s Error Code:0x%x", pText, hr); };


### PR DESCRIPTION
This patch updates the implementation of revIsSpeaking on Windows to
replace the use of ISpVoice::GetStatus which does not return correct
values when streaming speech to an audio output device. Instead, we now
process speech events to determine when speaking starts & stops.

Fixes https://quality.livecode.com/show_bug.cgi?id=21471