### PR TITLE
[Bugfix-29959] - Fix missing text in time docs

### DIFF
--- a/docs/dictionary/function/time.lcdoc
+++ b/docs/dictionary/function/time.lcdoc
@@ -35,7 +35,7 @@ The short time form returns the same value as the time form.
 
 The abbreviated time form returns the same value as the time form.
 
-The <long> time form returns the hour, minute, and second separated by
+The long time form returns the hour, minute, and second separated by
 colons, a space, and "AM" or "PM".
 
 Description:

--- a/docs/notes/bugfix-22959.md
+++ b/docs/notes/bugfix-22959.md
@@ -1,0 +1,1 @@
+# Corrected missing text issue in time dictionary enty.


### PR DESCRIPTION
Removed `<>` from "long" to have it display correctly.