### PR TITLE
[[ Bug 22787 ]] Fix crash when reopening modal stack in "resumeStack" handler

### DIFF
--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -664,12 +664,11 @@ struct MCModalSession
 {
 	NSModalSession session;
 	MCMacPlatformWindow *window;
-	bool is_running;
 	bool is_done;
 };
 
-static MCAutoArray<MCModalSession*> s_modal_sessions;
-static MCAutoArray<MCModalSession*> s_modal_sessions_pending_cleanup;
+static MCAutoArray<MCModalSession> s_modal_sessions;
+static MCAutoArray<NSModalSession> s_running_modal_sessions;
 
 struct MCCallback
 {
@@ -786,16 +785,13 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
 	
 	s_in_blocking_wait = true;
 	
-	bool t_modal;
-	t_modal = s_modal_sessions.Size() > 0;
-	
 	NSAutoreleasePool *t_pool;
 	t_pool = [[NSAutoreleasePool alloc] init];
 	
     // MW-2014-07-24: [[ Bug 12939 ]] If we are running a modal session, then don't then wait
     //   for events - event handling happens inside the modal session.
     NSEvent *t_event = nil;
-	if (t_modal)
+	if (s_modal_sessions.Size() > 0)
 	{
 		// Wait for an event, but leave on the queue
 		t_event = [NSApp nextEventMatchingMask: p_blocking ? NSApplicationDefinedMask : NSAnyEventMask
@@ -804,20 +800,30 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
 									   dequeue: NO];
 		
 		// Fetch the most deeply-nested modal session to run
-		MCModalSession *t_session = s_modal_sessions[s_modal_sessions.Size() - 1];
+		MCModalSession t_session = s_modal_sessions[s_modal_sessions.Size() - 1];
 
 		// Run the modal session, if it has been created yet (it might not if this
 		// wait was triggered by reacting to an event caused as part of creating
 		// the modal session, e.g. when losing window focus).
-		// Do not run the session again if it is already running.
-		if (!t_session->is_running && t_session->session != nil)
+		NSModalSession t_ns_session;
+		t_ns_session = t_session.session;
+		
+		/* Test if the session is currently running. If it is then don't run it again */
+		bool t_session_is_running = false;
+		for (uindex_t t_index = 0; t_index < s_running_modal_sessions.Size(); t_index++)
 		{
-			t_session->is_running = true;
-			[NSApp runModalSession: t_session->session];
-			t_session->is_running = false;
-			
-			// clean up modal sessions
-			MCMacPlatformCleanupModalSessions();
+			if (s_running_modal_sessions[t_index] == t_ns_session)
+			{
+				t_session_is_running = true;
+				break;
+			}
+		}
+		
+		if (!t_session_is_running && t_ns_session != nil)
+		{
+			s_running_modal_sessions.Push(t_ns_session);
+			[NSApp runModalSession: t_ns_session];
+			/* UNCHECKED */ s_running_modal_sessions.Pop(t_ns_session);
 		}
 
 		t_event = nil;
@@ -854,18 +860,15 @@ void MCMacPlatformBeginModalSession(MCMacPlatformWindow *p_window)
     //   current mouse window.
 	MCMacPlatformSyncMouseBeforeDragging();
     
-	MCModalSession *t_session = nil;
+	MCModalSession t_session;
+	MCMemoryClear(t_session);
 	
-	/* UNCHECKED */ MCMemoryNew(t_session);
-	
-	t_session->is_done = false;
-	t_session->is_running = false;
-	t_session->window = p_window;
-	p_window -> Retain();
+	t_session.is_done = false;
+	t_session.window = p_window;
 	// IM-2015-01-30: [[ Bug 14140 ]] lock the window frame to prevent it from being centered on the screen.
 	p_window->SetFrameLocked(true);
 
-	t_session->session = [NSApp beginModalSessionForWindow: (NSWindow *)(p_window -> GetHandle())];
+	t_session.session = [NSApp beginModalSessionForWindow: (NSWindow *)(p_window -> GetHandle())];
 	/* UNCHECKED */ s_modal_sessions.Push(t_session);
 
 	p_window->SetFrameLocked(false);
@@ -875,42 +878,25 @@ void MCMacPlatformEndModalSession(MCMacPlatformWindow *p_window)
 {
 	uindex_t t_index;
 	for(t_index = 0; t_index < s_modal_sessions.Size(); t_index++)
-		if (s_modal_sessions[t_index]->window == p_window)
+		if (s_modal_sessions[t_index].window == p_window)
 			break;
 	
 	if (t_index == s_modal_sessions.Size())
 		return;
 	
-	s_modal_sessions[t_index]->is_done = true;
+	s_modal_sessions[t_index].is_done = true;
 	
 	/* Pop all modal sessions which are now complete. All those which are
 	 * get pushed onto a list to be destroyed later. */
 	while (s_modal_sessions.Size() > 0)
 	{
-		if (!s_modal_sessions[s_modal_sessions.Size() - 1]->is_done)
+		if (!s_modal_sessions[s_modal_sessions.Size() - 1].is_done)
 			return;
 		
-		MCModalSession *t_session;
+		MCModalSession t_session;
 		/* UNCHECKED */ s_modal_sessions.Pop(t_session);
-		/* UNCHECKED */ s_modal_sessions_pending_cleanup.Push(t_session);
 		
-		[NSApp endModalSession: t_session->session];
-	}
-}
-
-/* Process all modal sessions which are pending destruction. This
- * ensures that windows don't get hidden and destroyed at the wrong
- * time (e.g. within a nested modal session!). */
-void MCMacPlatformCleanupModalSessions(void)
-{
-	while (s_modal_sessions_pending_cleanup.Size() > 0)
-	{
-		MCModalSession *t_session = nil;
-		/* UNCHECKED */ s_modal_sessions_pending_cleanup.Pop(t_session);
-		
-		t_session->window->Release();
-
-		MCMemoryDelete(t_session);
+		[NSApp endModalSession: t_session.session];
 	}
 }
 

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -908,7 +908,6 @@ void MCMacPlatformCleanupModalSessions(void)
 		MCModalSession *t_session = nil;
 		/* UNCHECKED */ s_modal_sessions_pending_cleanup.Pop(t_session);
 		
-		[t_session->window->GetHandle() orderOut: nil];
 		t_session->window->Release();
 
 		MCMemoryDelete(t_session);

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -574,6 +574,10 @@ private:
 	MCPlatformWindowRef m_parent;
 	
 	friend class MCMacPlatformSurface;
+	
+	static bool s_hiding;
+	static MCMacPlatformWindow *s_hiding_focused;
+	static MCMacPlatformWindow *s_hiding_unfocused;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -586,7 +586,6 @@ void MCMacPlatformScheduleCallback(void (*)(void*), void *);
 
 void MCMacPlatformBeginModalSession(MCMacPlatformWindow *window);
 void MCMacPlatformEndModalSession(MCMacPlatformWindow *window);
-void MCMacPlatformCleanupModalSessions(void);
 
 void MCMacPlatformHandleMouseCursorChange(MCPlatformWindowRef window);
 void MCMacPlatformHandleMousePress(uint32_t p_button, bool p_is_down);


### PR DESCRIPTION
This patch fixes a crash when opening, closing, then reopening a modal
stack in the "resumeStack" handler of another stack.

Previously, the "resumeStack" message would be dispatched while in the
middle of the NSWindow::orderOut message. Starting a new modal session
for the NSWindow in that handler was raising an Obj-C exception leading
to crashing & instability. We can avoid that by deferring the focus and
unfocus messages until after the NSWindow::orderOut message has
completed.