### PR TITLE
[[ Bug 22974 ]] Set exported attribute of content provider to false

### DIFF
--- a/docs/notes/bugfix-22974.md
+++ b/docs/notes/bugfix-22974.md
@@ -1,0 +1,1 @@
+# Fix crash in mobilePickPhoto on Android 11

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -574,7 +574,7 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       put "<provider " & return into tProvider
       put "      android:name=" & quote & pSettings["android,identifier"] & ".AppProvider" & quote & return after tProvider
       put "      android:authorities=" & quote & pSettings["android,identifier"] & ".fileprovider" & quote & return after tProvider
-      put "      android:exported=" & quote & "true" & quote & return after tProvider
+      put "      android:exported=" & quote & "false" & quote & return after tProvider
       put "      android:grantUriPermissions=" & quote & "true" & quote & " >" & return after tProvider
       // Add meta-data tag
       put "      <meta-data" & return after tProvider


### PR DESCRIPTION
This patch changes the exported attribute of the content provider used to share
read and write access to files. An exported content provider causes a crash
when the camera app tries to use the content uri.