### PR TITLE
[[ Bug 22980 ]] Initialize uninitialized MCPlatformMenuItemHighlight variable

### DIFF
--- a/docs/notes/bugfix-22980.md
+++ b/docs/notes/bugfix-22980.md
@@ -1,0 +1,1 @@
+# Menu items which don't have a mark now display correctly on Big Sur when running on ARM processors

--- a/engine/src/desktop-menu.cpp
+++ b/engine/src/desktop-menu.cpp
@@ -310,6 +310,10 @@ public:
 				else
 					t_item_highlight = kMCPlatformMenuItemHighlightTick;
 			}
+			else
+			{
+				t_item_highlight = kMCPlatformMenuItemHighlightNone;
+			}
 			
 			MCPlatformMenuItemAction t_action;
 			t_action = ComputeAction(p_menuitem -> label, p_menuitem -> tag);


### PR DESCRIPTION
This patch ensures a `MCPlatformMenuItemHighlight` variable is initialized. Previously this was not the case, and this probably resulted in menuitems having a '-' at the beginning when LC was running in an ARM Mac.