### PR TITLE
[[ Bug 22987 ]] Fix wrong operator used to combine version number components

### DIFF
--- a/engine/src/sysdefs.h
+++ b/engine/src/sysdefs.h
@@ -220,7 +220,7 @@ typedef struct MCCursor *MCCursorRef;
 
 inline uint32_t MCOSVersionMake(uint8_t p_major, uint8_t p_minor, uint8_t p_bugfix)
 {
-	return (p_major << 16) || (p_minor << 8) || p_bugfix;
+	return (p_major << 16) | (p_minor << 8) | p_bugfix;
 }
 
 inline uint8_t MCOSVersionGetMajor(uint32_t p_version)


### PR DESCRIPTION
This patch fixes a bug introduced by using the logical OR operator '||' instead of the bitwise OR operator '|' to combine version number components in MCOSVersionMake

Fixes https://quality.livecode.com/show_bug.cgi?id=22987