### PR TITLE
[[ Bug 22996 ]] Fix JNI error calling methods that trigger callbacks

### DIFF
--- a/docs/lcb/notes/22996.md
+++ b/docs/lcb/notes/22996.md
@@ -1,0 +1,1 @@
+# [22996] Fix JNI error calling methods that trigger engine callbackss

--- a/libfoundation/src/foundation-java-private.cpp
+++ b/libfoundation/src/foundation-java-private.cpp
@@ -1714,6 +1714,11 @@ bool MCJavaPrivateCallJNIMethod(MCNameRef p_class_name, void *p_method_id, int p
         default:
             MCUnreachableReturn(false);
     }
+
+	/* In the event the method called resulted in engine callbacks that may have
+	 * altered s_env we need to ensure we are making calls on the correct
+	 * environment */
+	MCJavaDoAttachCurrentThread();
     
     // If we got here there were no memory errors. Check the JNI Env for
     // exceptions


### PR DESCRIPTION
This patch fixes an issue where calling a java method results in engine
callbacks that change the value of the `s_env` JNIEnv variable causing
it to be incorrect for the current thread when the method returns. The fix
restores the correct environment for the current thread.