### PR TITLE
[[ Bug 22999 ]] Fix background location updates on iOS

### DIFF
--- a/docs/dictionary/command/iphoneAllowBackgroundLocationUpdates.lcdoc
+++ b/docs/dictionary/command/iphoneAllowBackgroundLocationUpdates.lcdoc
@@ -1,0 +1,40 @@
+Name: iphoneAllowBackgroundLocationUpdates
+
+Type: command
+
+Syntax: iphoneAllowBackgroundLocationUpdates <pAllow>
+
+Summary:
+Allows the app to receive location updates when it is suspended 
+
+Introduced: 9.6.3
+
+OS: ios
+
+Platforms: mobile
+
+Example:
+mobileStartTrackingSensor "location"
+iphoneAllowBackgroundLocationUpdates "true"
+
+Example:
+iphoneAllowBackgroundLocationUpdates "false"
+
+Parameters:
+pAllow (boolean):
+A boolean value specifying if the app should continue to receive
+location updates when put in the background.
+
+
+Description:
+Use the <iphoneAllowBackgroundLocationUpdates> command to allow (or disallow) the app
+receiving location updates when it is suspended. 
+
+This command has an effect only if "Location Update" is checked in the 
+"Background Execution" section in the iOS standalone settings. 
+
+
+
+References: mobileStartTrackingSensor (command), mobileStopTrackingSensor (command),
+
+

--- a/docs/notes/bugfix-22999.md
+++ b/docs/notes/bugfix-22999.md
@@ -1,0 +1,1 @@
+# Fix background location updates on iOS

--- a/docs/notes/feature-allow_background_location_updates.md
+++ b/docs/notes/feature-allow_background_location_updates.md
@@ -1,0 +1,6 @@
+# Allow background location updates
+
+A new command `iphoneAllowBackgroundLocationUpdates` has been added, which can be used to
+allow/disallow location updates when the app is suspended. This command has an effect only
+if "Location Update" is checked in the "Background Execution" section in the iOS standalone
+settings. 

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -52,6 +52,14 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		${PLAY_AUDIO_WHEN_IN_BACKGROUND}
+		${BACKGROUND_LOCATION_UPDATE}
+		${BACKGROUND_VOIP}
+		${BACKGROUND_NEWSSTAND_DOWNLOADS}
+		${EXTERNAL_ACC_COMM}
+		${USE_BT_LE}
+		${ACTS_AS_BT_LE}
+		${BACKGROUND_FETCH}
+		${REMOTE_NOTIFICATIONS}
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>

--- a/engine/src/exec-sensor.cpp
+++ b/engine/src/exec-sensor.cpp
@@ -101,6 +101,11 @@ void MCSensorExecStopTrackingSensor(MCExecContext& ctxt, intenum_t p_sensor)
     }
 }
 
+void MCSensorAllowBackgroundLocationUpdates(MCExecContext& ctxt, bool p_allow)
+{
+    MCSystemAllowBackgroundLocationUpdates(p_allow);
+}
+
 void MCSensorGetSensorAvailable(MCExecContext& ctxt, intenum_t p_sensor, bool& r_available)
 {
     MCSystemGetSensorAvailable((MCSensorType)p_sensor, r_available);

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -3914,6 +3914,7 @@ extern MCExecEnumTypeInfo *kMCSensorTypeTypeInfo;
 void MCSensorExecStartTrackingSensor(MCExecContext& ctxt, intenum_t p_sensor, bool p_loosely);
 void MCSensorExecStopTrackingSensor(MCExecContext& ctxt, intenum_t p_sensor);
 void MCSensorGetSensorAvailable(MCExecContext& ctxt, intenum_t p_sensor, bool& r_available);
+void MCSensorAllowBackgroundLocationUpdates(MCExecContext& ctxt, bool p_allow);
 
 void MCSensorGetDetailedLocationOfDevice(MCExecContext& ctxt, MCArrayRef &r_detailed_location);
 void MCSensorGetLocationOfDevice(MCExecContext& ctxt, MCStringRef &r_location);

--- a/engine/src/mblandroidsensor.cpp
+++ b/engine/src/mblandroidsensor.cpp
@@ -74,6 +74,11 @@ bool MCSystemGetSensorAvailable(MCSensorType p_sensor, bool& r_available)
     return true;
 }
 
+void MCSystemAllowBackgroundLocationUpdates(bool p_allow)
+{
+    // not implemented
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /*
 bool MCSystemStartTrackingSensor(MCSensorType p_sensor, bool p_loosely)

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -1336,6 +1336,30 @@ Exec_stat MCHandleSensorAvailable(void *p_context, MCParameter *p_parameters)
 	return ES_ERROR;
 }
 
+Exec_stat MCHandleAllowBackgroundLocationUpdates(void *p_context, MCParameter *p_parameters)
+{
+    MCExecContext ctxt(nil, nil, nil);
+    ctxt . SetTheResultToEmpty();
+    
+    bool t_allow_background_location_updates = false;
+    
+    if (p_parameters)
+    {
+        MCAutoValueRef t_value;
+        MCAutoBooleanRef t_bool;
+        p_parameters->eval_argument(ctxt, &t_value);
+        if(ctxt . ConvertToBoolean(*t_value, &t_bool))
+            t_allow_background_location_updates = MCValueIsEqualTo(*t_bool, kMCTrue);
+    }
+    
+    MCSensorAllowBackgroundLocationUpdates(ctxt, t_allow_background_location_updates);
+    
+    if (!ctxt . HasError())
+        return ES_NORMAL;
+    
+    return ES_ERROR;
+}
+
 Exec_stat MCHandleCanTrackLocation(void *p_context, MCParameter *p_parameters)
 {
     MCExecContext ctxt(nil, nil, nil);
@@ -4555,6 +4579,7 @@ static const MCPlatformMessageSpec s_platform_messages[] =
     
     // MM-2012-02-11: Added support old style senseor syntax (iPhoneEnableAcceleromter etc)
 	/* DEPRECATED */ {false, "iphoneCanTrackLocation", MCHandleCanTrackLocation, nil},
+    {false, "iphoneAllowBackgroundLocationUpdates", MCHandleAllowBackgroundLocationUpdates, nil},
 
     // PM-2014-10-07: [[ Bug 13590 ]] StartTrackingLocation and StopTrackingLocation must run on the script thread
     /* DEPRECATED */ {true, "iphoneStartTrackingLocation", MCHandleLocationTrackingState, (void *)true},

--- a/engine/src/mbliphonesensor.mm
+++ b/engine/src/mbliphonesensor.mm
@@ -255,7 +255,7 @@ static void requestAlwaysAuthorization(void)
         
         NSString *t_location_authorization_when_in_use;
         t_location_authorization_when_in_use = [t_info_dict objectForKey: @"NSLocationWhenInUseUsageDescription"];
-        
+
         if (t_location_authorization_always)
         {
             [s_location_manager requestAlwaysAuthorization];
@@ -293,6 +293,27 @@ static void initialize_core_location(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void MCSystemAllowBackgroundLocationUpdates(bool p_allow)
+{
+    NSDictionary *t_info_dict;
+    t_info_dict = [[NSBundle mainBundle] infoDictionary];
+    
+    NSArray *t_background_modes_array;
+    t_background_modes_array = [t_info_dict objectForKey: @"UIBackgroundModes"];
+    
+    BOOL t_plist_can_allow_background_location_updates = [t_background_modes_array containsObject: @"location"];
+    
+    if (t_plist_can_allow_background_location_updates)
+    {
+        initialize_core_location();
+        
+        if (p_allow)
+            s_location_manager.allowsBackgroundLocationUpdates = YES;
+        else
+            s_location_manager.allowsBackgroundLocationUpdates = NO;
+    }    
+}
 
 bool MCSystemGetSensorAvailable(MCSensorType p_sensor, bool& r_available)
 {    

--- a/engine/src/mblsensor.h
+++ b/engine/src/mblsensor.h
@@ -80,6 +80,7 @@ bool MCSystemStartTrackingRotationRate(bool p_loosely);
 bool MCSystemStopTrackingRotationRate();
 
 bool MCSystemGetSensorAvailable(MCSensorType p_sensor, bool& r_available);
+void MCSystemAllowBackgroundLocationUpdates(bool p_allow);
 
 bool MCSystemStartTrackingSensor(MCSensorType p_sensor, bool p_loosely);
 bool MCSystemStopTrackingSensor(MCSensorType p_sensor);


### PR DESCRIPTION
This patch ensures that the app can still receive location updates when suspended, if the "location" is among the chosen UIBackgroundModes.