### PR TITLE
[Bugfix-23015] Fix missing text in audioClip

### DIFF
--- a/docs/dictionary/object/audioClip.lcdoc
+++ b/docs/dictionary/object/audioClip.lcdoc
@@ -63,7 +63,7 @@ To stop an audioClip, use the syntax
     play stop
 
 References: object type (glossary), card (object),
-templateAudioClip (keyword), stack (object), play (command)
+templateAudioClip (keyword), stack (object), play (command),
 audio clip (glossary), videoClip (object), control (glossary),
 stack file (glossary)
 

--- a/docs/notes/bugfix-23015.md
+++ b/docs/notes/bugfix-23015.md
@@ -1,0 +1,1 @@
+# Fixed text display issue with audioClip.


### PR DESCRIPTION
Added comma between two references to have it included in references and have a paragraph display all of its text.