### PR TITLE
[[ Bug 22990 ]] Fix emscripten crash when loading custom TTF font files

### DIFF
--- a/docs/notes/bugfix-22990.md
+++ b/docs/notes/bugfix-22990.md
@@ -1,0 +1,1 @@
+# Fix crash in HTML5 standalones when loading certain custom TTF font files


### PR DESCRIPTION
This patch adds a release note for bug 22990, where the emscripten engine would crash when attempting to load certain TTF font files.

livecode-thirdparty PR: https://github.com/livecode/livecode-thirdparty/pull/150

Fixes https://quality.livecode.com/show_bug.cgi?id=22990