### PR TITLE
[[ Bug 22994 ]] Fix crash when setting the startTime of a video on iOS

### DIFF
--- a/docs/notes/bugfix-22994.md
+++ b/docs/notes/bugfix-22994.md
@@ -1,0 +1,1 @@
+# Fix crash when setting the startTime of a video on iOS

--- a/engine/src/mbliphoneplayer.mm
+++ b/engine/src/mbliphoneplayer.mm
@@ -506,7 +506,7 @@ void MCiOSPlayerControl::SetStartTime(MCExecContext& ctxt, integer_t p_time)
 		m_start_time = CMTimeMake(p_time, 1000);
 
     if (m_player != nil)
-		m_player.currentItem.reversePlaybackEndTime = m_start_time;
+		SetCurrentTime(ctxt, p_time);
 }
 
 void MCiOSPlayerControl::GetStartTime(MCExecContext& ctxt, integer_t& r_time)


### PR DESCRIPTION
This patch fixes a crash when setting the startTime of a video on iOS