### PR TITLE
[[ Bug 23019 ]] Request Mac window redraw in bounds of dirty region

### DIFF
--- a/docs/notes/bugfix-23019.md
+++ b/docs/notes/bugfix-23019.md
@@ -1,0 +1,1 @@
+# Fix window redraw issue on MacOS X when making changes to a card immediately after switching to it

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -2216,7 +2216,7 @@ void MCMacPlatformWindow::DoUpdate(void)
 	
 	// Force a re-display, this will cause drawRect to be invoked on our view
 	// which in term will result in a redraw window callback being sent.
-	[m_view displayIfNeeded];
+	[m_view displayIfNeededInRect: [m_view mapMCRectangleToNSRect:MCRegionGetBoundingBox(m_dirty_region)]];
 	
 	// Re-enable screen updates if needed.
 	if (t_shadow_changed)


### PR DESCRIPTION
This patch fixes bug 23019, where modifying a card
immediately after switching to it could leave parts of the previous
card visible around the modified area.

Fixes https://quality.livecode.com/show_bug.cgi?id=23019