### PR TITLE
[[ Bug 22365 ]] Fix Accelerated rendering glitch when multiple stacks are open

### DIFF
--- a/docs/notes/bugfix-22365.md
+++ b/docs/notes/bugfix-22365.md
@@ -1,0 +1,1 @@
+# Fix black screen on Android when navigating between cards with acceleratedRendering enabled

--- a/engine/src/mblandroiddc.cpp
+++ b/engine/src/mblandroiddc.cpp
@@ -1108,6 +1108,10 @@ protected:
 
 void MCStack::view_device_updatewindow(MCRegionRef p_region)
 {
+	// Check if stack should be drawn before rendering
+	if (getextendedstate(ECS_DONTDRAW))
+		return;
+
 	// IM-2014-01-31: [[ HiDPI ]] If using a callback, render to the Android bitmap view
 	if (s_updatewindow_callback != nil || !s_android_opengl_enabled)
 	{


### PR DESCRIPTION
This patch fixes a graphical glitch when updating the display when more than one stack is open and a non-visible stack requires a window update (such as being reshaped).

Fixes https://quality.livecode.com/show_bug.cgi?id=22365