### PR TITLE
[[ WIP ]] Don't force new layer when drawing widget

### DIFF
--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -970,7 +970,7 @@ void MCWidget::draw(MCDC *dc, const MCRectangle& p_dirty, bool p_isolated, bool 
 		}
 		
 		if (m_bitmap_effects == nil)
-			dc -> begin(true);
+			dc -> begin(false);
 		else
 		{
 			if (!dc -> begin_with_effects(m_bitmap_effects, MCU_reduce_rect(rect, -gettransient())))


### PR DESCRIPTION
This patch replaces the value passed to MCDC::begin from true to false
in MCWidget::draw so that a new graphics layer is only created if
necessary.