### PR TITLE
[[ Bug 23055 ]] Reset EOF marker when seeking in a file on macOS

### DIFF
--- a/docs/notes/bugfix-23055.md
+++ b/docs/notes/bugfix-23055.md
@@ -1,0 +1,2 @@
+# Allow seek command to reset "eof" result after read command reaches the end of a file on macOS
+

--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -1601,6 +1601,11 @@ public:
 	virtual bool Seek(int64_t offset, int p_dir)
 	{
         // TODO Add MCSystemFileHandle::SetStream(char *newptr) ?
+		if (m_is_eof)
+		{
+			clearerr(m_stream);
+			m_is_eof = false;
+		}
 		return fseeko(m_stream, offset, p_dir < 0 ? SEEK_END : (p_dir > 0 ? SEEK_SET : SEEK_CUR)) == 0;
 	}
 	


### PR DESCRIPTION
This patch fixes an issue where if a previous read from a filehandle has
resulted in an END-OF-FILE then subsequent reads would always fail with
EOF result even after seeking to another location within the file.

Fixes https://quality.livecode.com/show_bug.cgi?id=23055