### PR TITLE
[[ Bug 23050 ]] Update SQLite to v3.34.0 

### DIFF
--- a/docs/dictionary/function/revOpenDatabase.lcdoc
+++ b/docs/dictionary/function/revOpenDatabase.lcdoc
@@ -209,7 +209,7 @@ Use the <revOpenDatabase> function to start working with a database.
 > 'SSL Encryption' from among the available 'script libraries' in the
 > standalone application settings panel.
 
-The version of SQLite has been updated to 3.26.0.
+The version of SQLite has been updated to 3.34.0.
 
 The SQLite RTREE and FTS5 modules are now available.
 

--- a/docs/notes/bugfix-23050.md
+++ b/docs/notes/bugfix-23050.md
@@ -1,0 +1,1 @@
+# Updated SQLite to version 3.34.0


### PR DESCRIPTION
This patch adds a release note for the update of SQLite in the thirdparty submodule.

Also, it updates the dictionary entry of `revOpenDatabase()` function with the correct SQLite version.

Closes https://quality.livecode.com/show_bug.cgi?id=23050