### PR TITLE
[[ Bug 23053 ]] Fix frozen color picker launched from modal stack on macOS

### DIFF
--- a/docs/notes/bugfix-23053.md
+++ b/docs/notes/bugfix-23053.md
@@ -1,0 +1,1 @@
+# Fix the color dialog failing to respond to input events when launched from a modal stack on macOS

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -788,13 +788,17 @@ bool MCPlatformWaitForEvent(double p_duration, bool p_blocking)
 	// Track whether a modal session was closed or not
 	bool t_modal_closed = false;
 	
+	// Pseudo-modal views require event dispatching, even when launched within a modal session
+	bool t_pseudo_modal;
+	t_pseudo_modal = MCMacPlatformApplicationPseudoModalFor() != nil;
+	
 	NSAutoreleasePool *t_pool;
 	t_pool = [[NSAutoreleasePool alloc] init];
 	
     // MW-2014-07-24: [[ Bug 12939 ]] If we are running a modal session, then don't then wait
     //   for events - event handling happens inside the modal session.
     NSEvent *t_event = nil;
-	if (s_modal_sessions.Size() > 0)
+	if (s_modal_sessions.Size() > 0 && !t_pseudo_modal)
 	{
 		// Wait for an event, but leave on the queue
 		t_event = [NSApp nextEventMatchingMask: p_blocking ? NSApplicationDefinedMask : NSAnyEventMask


### PR DESCRIPTION
This patch fixes a bug on macOS where a color picker launched from a modal dialog would be unresponsive to input events, leaving the engine stuck in an infinite loop. This is fixed by dispatching events from the event queue in the usual way rather than by running the modal session.

Fixes https://quality.livecode.com/show_bug.cgi?id=23053