### PR TITLE
[[ Bug 23044 ]] Fix crash when deleting current card in closeStack handler

### DIFF
--- a/docs/notes/bugfix-23044.md
+++ b/docs/notes/bugfix-23044.md
@@ -1,0 +1,1 @@
+# Fix crash when deleting the current card of a stack within its closeStack handler

--- a/engine/src/stack3.cpp
+++ b/engine/src/stack3.cpp
@@ -1490,8 +1490,8 @@ void MCStack::removecard(MCCard *cptr)
 	if (state & CS_IGNORE_CLOSE)
 	{
 		curcard = cptr->next();
-		cptr->remove
-		(cards);
+		cptr->close();
+		cptr->remove(cards);
 		if (cards == NULL)
 		{
 			cards = curcard = MCtemplatecard->clone(False, False);


### PR DESCRIPTION
This patch fixes a crash triggered by deleting the current card within the closeStack handler.
This was caused by leaving the deleted card open instead of closing it before removal from the stack.

Fixes https://quality.livecode.com/show_bug.cgi?id=23044