### PR TITLE
[[ Bug 23030 ]] Enable WebRTC on CEF browser

### DIFF
--- a/docs/notes/bugfix-23030.md
+++ b/docs/notes/bugfix-23030.md
@@ -1,0 +1,1 @@
+# Enable WebRTC on CEF browser

--- a/libbrowser/src/libbrowser_cef.cpp
+++ b/libbrowser/src/libbrowser_cef.cpp
@@ -296,6 +296,12 @@ public:
 		if (MCCefPlatformGetHiDPIEnabled())
 			p_command_line->AppendSwitch(MC_CEF_HIDPI_SWITCH);
 	}
+	
+	virtual void OnBeforeCommandLineProcessing(const CefString &p_process_type, CefRefPtr<CefCommandLine> p_command_line) OVERRIDE
+	{
+		// Enable WebRTC
+		p_command_line->AppendSwitch("enable-media-stream");
+	}
 
 	IMPLEMENT_REFCOUNTING(MCCefBrowserApp);
 };


### PR DESCRIPTION
This patch appends the command line switch 'enable-media-stream' when launching an instance of the CEF browser, and this enables WebRTC.