### PR TITLE
[Bug 23056] Tree View Widget error when values hidden

### DIFF
--- a/extensions/widgets/treeview/notes/23056.md
+++ b/extensions/widgets/treeview/notes/23056.md
@@ -1,0 +1,1 @@
+# [23056] Prevent error when values hidden and moving over right side of widget

--- a/extensions/widgets/treeview/treeview.lcb
+++ b/extensions/widgets/treeview/treeview.lcb
@@ -94,7 +94,7 @@ use com.livecode.library.widgetutils
 use com.livecode.foreign
 
 metadata author is "LiveCode"
-metadata version is "2.4.0"
+metadata version is "2.4.1"
 metadata title is "Tree View"
 metadata svgicon is "M152.4,249.7c-6.4,0-11.8,4.3-13.5,10.1h-10v-26.7h10c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1s-6.3-14.1-14.1-14.1c-6.4,0-11.8,4.3-13.5,10.1h-10v-16.1c8.4-1.8,14.8-9.3,14.8-18.3c0-10.4-8.4-18.8-18.8-18.8s-18.8,8.4-18.8,18.8c0,9,6.3,16.5,14.7,18.3v58.8h18c1.7,5.8,7.1,10.1,13.5,10.1c7.8,0,14.1-6.3,14.1-14.1S160.2,249.7,152.4,249.7z M128.7,202h-7.5v-7.5h-7.5V187h7.5v-7.5h7.5v7.5h7.5v7.5h-7.5V202z"
 metadata _ide is "true"
@@ -1404,11 +1404,13 @@ private handler xPosToIconString(in pXPos as Number, in pRow as Number) returns 
 		return ""
 	end if
 
-	variable tElement as Array
-	put element pRow of mDataList into tElement
+	if mShowValues then
+		variable tElement as Array
+		put element pRow of mDataList into tElement
 
-	if tElement["leaf"] and tElement["value_too_large"] then
-		return "inspect"
+		if tElement["leaf"] and tElement["value_too_large"] then
+			return "inspect"
+		end if
 	end if
 	
     return ""


### PR DESCRIPTION
When hovering over/past the right side of the widget when values are hidden, the `value_too_large` key was being accessed which is not populated on a recalculate in that instance.  Added a condition to check to ensure values are visible before checking that key.