### PR TITLE
[[Bug 23068]] Correct docs on how LC runs on Windows

### DIFF
--- a/docs/notes-base/platforms.md
+++ b/docs/notes-base/platforms.md
@@ -10,7 +10,7 @@ LiveCode supports the following versions of Windows:
 * Windows 8.x (Desktop)
 * Windows 10
 
-**Note:** On 64-bit Windows installations, LiveCode runs as a 32-bit application through the WoW layer.
+**Note:** On 64-bit Windows installations, LiveCode can run either as a 32-bit application through the WoW layer or as a native 64-bit Windows application, depending on the installer that is chosen.
 
 ## Linux
 

--- a/docs/notes/bugfix-23068.md
+++ b/docs/notes/bugfix-23068.md
@@ -1,0 +1,1 @@
+# Updated release notes for how LiveCode runs on Windows


### PR DESCRIPTION
Corrected release notes to account for the 64-bit Windows version of LiveCode.