### PR TITLE
[[ Bug 23061 ]] Show the name of the chosen icon in the icon picker

### DIFF
--- a/extensions/widgets/iconpicker/iconpicker.lcb
+++ b/extensions/widgets/iconpicker/iconpicker.lcb
@@ -148,7 +148,7 @@ constant kMinCols is 3
 constant kMinRows is 3
 
 public handler OnCreate()
-   put "" into mFilterString
+	put "" into mFilterString
 	SetDataList()
 	put the empty array into mPaths
 	put 1 into mFirstDataItem
@@ -159,6 +159,7 @@ public handler OnCreate()
 	put 0 into mViewTopPosition
 	put true into mFrameBorder
 
+	put true into mShowSelectedElement
 	put false into mShowNames
 	put kDefaultIconSize into mIconSize
 

--- a/extensions/widgets/iconpicker/notes/23061.md
+++ b/extensions/widgets/iconpicker/notes/23061.md
@@ -1,0 +1,1 @@
+# [23061] Show name of chosen icon when opening the icon picker


### PR DESCRIPTION
This patch ensures the name of the chosen icon is shown in the icon picker. It fixes a regression introduced in LC 9.5.0