### PR TITLE
[[ Bug 22650 ]] Fix crash on iOS player

### DIFF
--- a/engine/src/mbliphoneplayer.mm
+++ b/engine/src/mbliphoneplayer.mm
@@ -1344,7 +1344,15 @@ static NSString* s_player_keys[] =
 
 - (void)setCurrentItem:(AVPlayerItem *)item
 {
-	if (item == m_player_item)
+    AVURLAsset *t_existing_asset;
+    if (m_player_item != nil)
+        t_existing_asset = (AVURLAsset *)m_player_item.asset;
+    else
+        t_existing_asset = nil;
+    
+	AVURLAsset *t_new_asset = (AVURLAsset *)item.asset;
+	
+	if ([t_existing_asset.URL isEqual: t_new_asset.URL])
 		return;
 	
 	if (m_player_item != nil)


### PR DESCRIPTION
This patch fixes a crash/freeze when repeatedly setting the **same** filename in an iOS player.

The patch ensures that two `AVPlayerItem`s are checked for equality correctly, so the rest of the `setCurrentItem` method is not executed.

However, when setting repeatedly **different** filenames, the crash/freeze is still present. It happens completely randomly, it can happen at the second attempt to change the filename, or even at the 20th one. It looks like _something_ in the `setCurrentItem` method is the culprit.

This, setting it to WIP for now.