### PR TITLE
[[ Bug 22808 ]] Use default browser to show OAuth2 dialog on Linux

### DIFF
--- a/extensions/script-libraries/oauth2/notes/22808.md
+++ b/extensions/script-libraries/oauth2/notes/22808.md
@@ -1,0 +1,1 @@
+# [22808] Use default browser instead of browser widget to show the OAuth2 dialog on Linux

--- a/extensions/script-libraries/oauth2/oauth2.livecodescript
+++ b/extensions/script-libraries/oauth2/oauth2.livecodescript
@@ -200,10 +200,14 @@ command OAuth2 pAuthURL, pTokenURL, pClientID, pClientSecret, pScopes, pPort, pP
       set the script of it to tCancelScript
       reset the templateGraphic
    end if
-   
-   create widget tUniqueRef as "com.livecode.widget.browser"
-   set the rect of widget tUniqueRef to tBrowserRect
-   set the url of widget tUniqueRef to tURL
+
+   if the platform is not "Linux" then
+      create widget tUniqueRef as "com.livecode.widget.browser"
+      set the rect of widget tUniqueRef to tBrowserRect
+      set the url of widget tUniqueRef to tURL
+   else
+      launch url tUrl
+   end if
    
    unlock screen
    


### PR DESCRIPTION
This patch uses the default browser instead of the browser widget to show OAuth2 dialog on Linux.