### PR TITLE
[[ mergExt ]] Update pointer

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2020-10-27"
+constant kMergExtVersion = "2021-2-2"
 constant kTSNetVersion = "1.4.3"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer to include iOS 14.4 builds.