### PR TITLE
[[ Bug 23079 ]] Include mergLA in mergExt

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2020-10-27"
+constant kMergExtVersion = "2021-2-1"
 constant kTSNetVersion = "1.4.3"
 
 local sEngineDir

--- a/docs/notes/bugfix-23079.md
+++ b/docs/notes/bugfix-23079.md
@@ -1,0 +1,1 @@
+# Include missing mergLA builds


### PR DESCRIPTION
This patch updates the mergExt pointer to a build including builds of mergLA
which was missing in the last build.