### PR TITLE
[[ Bug 16296 ]] Fix crash when restarting location tracker on Android

### DIFF
--- a/docs/notes/bugfix-16296.md
+++ b/docs/notes/bugfix-16296.md
@@ -1,0 +1,1 @@
+# Fix crash on Android when restarting the location tracker


### PR DESCRIPTION
This patch fixes a bug where starting the location tracker on Android
would cause a crash if the tracker had already been started.

This was caused by posting a location update to the engine while in a
Java method called from the engine and is fixed by deferring the
location update until after the method has returned.

Fixes https://quality.livecode.com/show_bug.cgi?id=16296