### PR TITLE
[[ Bug 23075 ]] Process events while waiting in a modal session on Macos

### DIFF
--- a/docs/notes/bugfix-23075.md
+++ b/docs/notes/bugfix-23075.md
@@ -1,0 +1,1 @@
+# Fix 'ask ... as sheet' dialog unresponsive when launched from a modal stack


### PR DESCRIPTION
This patch fixes bug 23075 where a sheet launched from a modal stack
would not respond to user input on Macos. This was due to events not
being processed while waiting in a modal session.

Fixes https://quality.livecode.com/show_bug.cgi?id=23075