### PR TITLE
[[ Bug 16745 ]] Fix $_POST_RAW on Windows Server

### DIFF
--- a/docs/notes/bugfix-16745.md
+++ b/docs/notes/bugfix-16745.md
@@ -1,0 +1,1 @@
+# An issue causing `$_POST_RAW` on Windows to not be set for large uploads has been fixed.

--- a/engine/src/srvcgi.cpp
+++ b/engine/src/srvcgi.cpp
@@ -993,10 +993,16 @@ static bool cgi_compute_post_raw_var(void *p_context, MCVariable *p_var)
 		t_length = atoi(MCStringGetCString(*t_content_length));
 		
 		uint32_t t_read = 0;
+		uint32_t t_offset = 0;
 		
 		char *t_data;
 		t_data = new (nothrow) char[t_length];
-		t_success = t_stdin->Read(t_data, t_length, t_read) && t_length == t_read;
+		while (t_stdin->Read(t_data, t_length - t_offset, t_read) && t_offset < t_length)
+		{
+			/* read until length satisfied */
+			t_offset += t_read;
+		}
+		t_success = t_length == t_offset;
 
 		// Store the raw POST data
 		if (t_success)


### PR DESCRIPTION
This patch fixes an issue where `$_POST_RAW` was not set if posted data
was too large to be buffered. The issue was caused by:

* When a file was created for caching the post data it was using `OpenFd`
which only supports the stdio handles on Windows.
* When reading from the cache we need to iterate until the read either
fails or completes the required read length.