### PR TITLE
[[ Issue 23087 ]] Implement onShowFileChooser in android browser

### DIFF
--- a/docs/notes/bugfix-23087.md
+++ b/docs/notes/bugfix-23087.md
@@ -1,0 +1,1 @@
+# Support file input in Android browser forms


### PR DESCRIPTION
This patch implements the `onShowFileChooser` callback in the android browser
implementation to support picking files in web forms.

Depends on #7458 