### PR TITLE
[[ Bug 23085 ]] Fix Macos Big Sur visual effect rendering

### DIFF
--- a/docs/notes/bugfix-23085.md
+++ b/docs/notes/bugfix-23085.md
@@ -1,0 +1,1 @@
+# Fix visual effect rendering on Macos Big Sur

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -48,6 +48,7 @@ enum
 {
 	kMCMacPlatformBreakEvent = 0,
 	kMCMacPlatformMouseSyncEvent = 1,
+	kMCMacPlatformDrawSyncEvent = 2,
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -70,6 +71,13 @@ bool MCMacPlatformApplicationSendEvent(NSEvent *p_event)
         [p_event subtype] == kMCMacPlatformMouseSyncEvent)
 	{
         MCMacPlatformHandleMouseSync();
+		return true;
+	}
+
+    if ([p_event type] == NSApplicationDefined &&
+        [p_event subtype] == kMCMacPlatformDrawSyncEvent)
+	{
+		MCMacPlatformHandleDrawSync([p_event window]);
 		return true;
 	}
 
@@ -1980,6 +1988,21 @@ void MCMacPlatformSyncMouseBeforeDragging(void)
             s_mouse_window = nil;
         }
 	}
+}
+
+void MCMacPlatformSyncUpdateAfterDraw(NSInteger windowNumber)
+{
+	NSEvent *t_event;
+	t_event = [NSEvent otherEventWithType:NSApplicationDefined
+								 location:NSMakePoint(0,0)
+							modifierFlags:0
+								timestamp:0
+							 windowNumber:windowNumber
+								  context:NULL
+								  subtype:kMCMacPlatformDrawSyncEvent
+									data1:0
+									data2:0];
+	[NSApp postEvent:t_event atStart:YES];
 }
 
 void MCMacPlatformSyncMouseAfterTracking(void)

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -584,6 +584,7 @@ private:
 	static bool s_hiding;
 	static MCMacPlatformWindow *s_hiding_focused;
 	static MCMacPlatformWindow *s_hiding_unfocused;
+	static bool s_showing_sheet;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -592,6 +592,7 @@ void MCMacPlatformHandleMousePress(uint32_t p_button, bool p_is_down);
 void MCMacPlatformHandleMouseMove(MCPoint p_screen_location);
 void MCMacPlatformHandleMouseScroll(CGFloat dx, CGFloat dy);
 void MCMacPlatformHandleMouseSync(void);
+void MCMacPlatformHandleDrawSync(NSWindow *window);
 void MCMacPlatformHandleMouseAfterWindowHidden(void);
 
 void MCMacPlatformHandleMouseForResizeStart(void);
@@ -599,6 +600,8 @@ void MCMacPlatformHandleMouseForResizeEnd(void);
 
 void MCMacPlatformSyncMouseBeforeDragging(void);
 void MCMacPlatformSyncMouseAfterTracking(void);
+
+void MCMacPlatformSyncUpdateAfterDraw(NSInteger windowNumber);
 
 void MCMacPlatformHandleModifiersChanged(MCPlatformModifiers modifiers);
 

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -505,6 +505,8 @@ public:
 	// IM-2015-01-30: [[ Bug 14140 ]] Locking the frame will prevent the window from being moved or resized
 	void SetFrameLocked(bool p_locked);
 	
+	void DrawSync(void);
+	
 protected:
 	virtual void DoRealize(void);
 	virtual void DoSynchronize(void);
@@ -542,7 +544,7 @@ private:
 	
     // The window's content view.
     MCWindowView *m_view;
-    
+	
 	struct
 	{
 		// When the mask changes and the window has a shadow we have to
@@ -559,6 +561,10 @@ private:
 		
 		// When the frame is locked, any changes to the window rect will be prevented.
 		bool m_frame_locked : 1;
+
+		// This is used to signal to DoUpdate that a redraw has been performed
+		// in response to an update request.
+		bool m_waiting_for_draw : 1;
 	};
 	
 	// A window might map to one of several different classes, so we use a

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -22,6 +22,7 @@
 #include "region.h"
 #include "graphics.h"
 #include "unicode.h"
+#include "globals.h"
 
 #include "platform.h"
 #include "platform-internal.h"
@@ -1589,9 +1590,12 @@ static void map_key_event(NSEvent *event, MCPlatformKeyCode& r_key_code, codepoi
 	
 	MCGRegionDestroy(t_update_region);
 	
-	// Send event to break wait in NSApp::nextEventMatchingMask in MCMacPlatformWindow::DoUpdate
-	t_window->DrawSync();
-	MCMacPlatformSyncUpdateAfterDraw(self.window.windowNumber);
+	if (MCmajorosversion >= MCOSVersionMake(10,16,0))
+	{
+		// Send event to break wait in NSApp::nextEventMatchingMask in MCMacPlatformWindow::DoUpdate
+		t_window->DrawSync();
+		MCMacPlatformSyncUpdateAfterDraw(self.window.windowNumber);
+	}
 }
 
 //////////
@@ -2219,7 +2223,7 @@ void MCMacPlatformWindow::DrawSync()
 }
 
 void MCMacPlatformWindow::DoUpdate(void)
-{	
+{
 	// If the shadow has changed (due to the mask changing) we must disable
 	// screen updates otherwise we get a flicker.
 	// IM-2015-02-23: [[ WidgetPopup ]] Assume shadow changes when redrawing a non-opaque widget
@@ -2234,23 +2238,32 @@ void MCMacPlatformWindow::DoUpdate(void)
 	s_rect_count = 0;
 	MCRegionForEachRect(m_dirty_region, MCMacDoUpdateRegionCallback, m_view);
 	
-	// Enter runloop to trigger a redraw. This will cause drawRect to be invoked on our view
-	// which in turn will result in a redraw window callback being sent.
-	// The timeout value of 0.02ms is specified to avoid hitting the 60hz redraw limit.
-	if (!s_inside_focus_event && !s_showing_sheet && ![m_delegate inUserReshape])
+	if (MCmajorosversion >= MCOSVersionMake(10,16,0))
 	{
-		m_waiting_for_draw = true;
-		while (m_waiting_for_draw)
+		// Frequent redraws with displayIfNeeded causes graphical glitches on Macos Big Sur, so instead
+		// we enter the runloop to trigger a redraw. This will cause drawRect to be invoked on our view
+		// which in turn will result in a redraw window callback being sent.
+		// The timeout value of 0.02ms is specified to avoid hitting the 60hz redraw limit.
+		if (!s_inside_focus_event && !s_showing_sheet && ![m_delegate inUserReshape])
 		{
-			NSEvent *t_event;
-			t_event = [NSApp nextEventMatchingMask: NSApplicationDefinedMask
-										 untilDate: [NSDate dateWithTimeIntervalSinceNow: 0.02]
-											inMode: NSEventTrackingRunLoopMode
-										   dequeue: NO];
-			t_event = nil;
+			m_waiting_for_draw = true;
+			while (m_waiting_for_draw)
+			{
+				NSEvent *t_event;
+				t_event = [NSApp nextEventMatchingMask: NSApplicationDefinedMask
+											 untilDate: [NSDate dateWithTimeIntervalSinceNow: 0.02]
+												inMode: NSEventTrackingRunLoopMode
+											   dequeue: NO];
+				t_event = nil;
+			}
 		}
 	}
-	
+	else
+	{
+		// Use displayIfNeeded to trigger a redraw
+		[m_view displayIfNeeded];
+	}
+
 	// Re-enable screen updates if needed.
 	if (t_shadow_changed)
     {

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -1699,6 +1699,7 @@ MCMacPlatformWindow::~MCMacPlatformWindow(void)
 bool MCMacPlatformWindow::s_hiding = false;
 MCMacPlatformWindow *MCMacPlatformWindow::s_hiding_focused = nil;
 MCMacPlatformWindow *MCMacPlatformWindow::s_hiding_unfocused = nil;
+bool MCMacPlatformWindow::s_showing_sheet = false;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2128,6 +2129,7 @@ void MCMacPlatformWindow::DoShowAsSheet(MCPlatformWindowRef p_parent)
 	m_parent -> Retain();
 	((MCMacPlatformWindow *)m_parent) -> m_has_sheet = true;
 	
+	s_showing_sheet = true;
 	[NSApp beginSheet: m_window_handle modalForWindow: t_parent -> m_window_handle modalDelegate: m_delegate didEndSelector: @selector(didEndSheet:returnCode:contextInfo:) contextInfo: nil];
 }
 
@@ -2142,6 +2144,7 @@ void MCMacPlatformWindow::DoHide(void)
 		((MCMacPlatformWindow *)m_parent) -> m_has_sheet = false;
 		m_parent -> Release();
 		m_parent = nil;
+		s_showing_sheet = false;
 	}
 	else if (m_style == kMCPlatformWindowStyleDialog)
 	{
@@ -2234,7 +2237,7 @@ void MCMacPlatformWindow::DoUpdate(void)
 	// Enter runloop to trigger a redraw. This will cause drawRect to be invoked on our view
 	// which in turn will result in a redraw window callback being sent.
 	// The timeout value of 0.02ms is specified to avoid hitting the 60hz redraw limit.
-	if (![m_delegate inUserReshape])
+	if (!s_inside_focus_event && !s_showing_sheet && ![m_delegate inUserReshape])
 	{
 		m_waiting_for_draw = true;
 		while (m_waiting_for_draw)


### PR DESCRIPTION
This patch revises the fix applied for bug 23019 to resolve a problem introduced by that patch. This changes the implementation of MCMacPlatformWindow::DoUpdate to remove the call to NSView method displayIfNeededInRect and allow window redraws to occur while in the NSApp event loop.