### PR TITLE
[[ Bug 23094 ]] Fix android native layer rect relative to parent

### DIFF
--- a/docs/notes/bugfix-23094.md
+++ b/docs/notes/bugfix-23094.md
@@ -1,0 +1,1 @@
+# Ensure android native layer rects are updated when their parent view is resized

--- a/engine/src/native-layer-android.cpp
+++ b/engine/src/native-layer-android.cpp
@@ -141,6 +141,7 @@ bool MCNativeLayerAndroid::doPaint(MCGContextRef p_context)
 
 void MCNativeLayerAndroid::doSetViewportGeometry(const MCRectangle& p_rect)
 {
+	doSetGeometry(m_rect);
 }
 
 void MCNativeLayerAndroid::doSetGeometry(const MCRectangle &p_rect)


### PR DESCRIPTION
This patch ensures that when an android native container layer rect changes the
rect of child views is reset relative to the parent.