### PR TITLE
[[ Bug 23098 ]] Fix native layers not relayering after object relayer

### DIFF
--- a/docs/notes/bugfix-23098.md
+++ b/docs/notes/bugfix-23098.md
@@ -1,0 +1,1 @@
+# Native layers now relayer correctly in response to the relayer command

--- a/engine/src/card.cpp
+++ b/engine/src/card.cpp
@@ -1633,6 +1633,8 @@ void MCCard::relayercontrol(MCControl *p_source, MCControl *p_target)
 	else
 		t_source_ptr -> appendto(objptrs);
 	layer_added(p_source, MCControlPreviousByLayer(p_source), MCControlNextByLayer(p_source));
+
+	p_source->layerchanged();
 }
 
 void MCCard::relayercontrol_remove(MCControl *p_control)
@@ -1688,6 +1690,8 @@ void MCCard::relayercontrol_insert(MCControl *p_control, MCControl *p_target)
 	else
 		t_control_ptr -> appendto(objptrs);
 	layer_added(p_control, MCControlPreviousByLayer(p_control), MCControlNextByLayer(p_control));
+
+	p_control->layerchanged();
 }
 
 Exec_stat MCCard::relayer(MCControl *optr, uint2 newlayer)

--- a/engine/src/group.cpp
+++ b/engine/src/group.cpp
@@ -3069,6 +3069,8 @@ void MCGroup::relayercontrol(MCControl *p_source, MCControl *p_target)
 
 	if (!computeminrect(False))
 		p_source -> layer_redrawall();
+
+	p_source->layerchanged();
 }
 
 void MCGroup::relayercontrol_remove(MCControl *p_control)
@@ -3096,6 +3098,8 @@ void MCGroup::relayercontrol_insert(MCControl *p_control, MCControl *p_target)
 
 	if (!computeminrect(False))
 		p_control -> layer_redrawall();
+
+	p_control->layerchanged();
 }
 
 bool MCGroup::getNativeContainerLayer(MCNativeLayer *&r_layer)


### PR DESCRIPTION
This patch fixes an issue where native layers do not relayer after the relayer
command should change the native layer hierarchy.