### PR TITLE
[[ Bug 23100 ]] Ensure android player renders over OpenGL view

### DIFF
--- a/docs/notes/bugfix-23100.md
+++ b/docs/notes/bugfix-23100.md
@@ -1,0 +1,1 @@
+# Fix rendering of mobile player when acceleratedRendering is true

--- a/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
+++ b/engine/src/java/com/runrev/android/nativecontrol/ExtVideoView.java
@@ -188,6 +188,10 @@ public class ExtVideoView extends SurfaceView implements MediaPlayerControl {
         mVideoHeight = 0;
         getHolder().addCallback(mSHCallback);
         getHolder().setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
+
+        /* We always want the video's surface view to sit on top of any OpenGL
+         * surface view, so set this as a media overlay. */
+        setZOrderMediaOverlay(true);
         setFocusable(true);
         setFocusableInTouchMode(true);
         requestFocus();


### PR DESCRIPTION
This patch sets the `setZOrderMediaOverlay` of the android player view to
ensure the player renders over the OpenGL surface view. If not set if the
player view is created before the OpenGL view the video will not be visible.