### PR TITLE
[[ Bug 21982 ]] Ensure 'the printersettings' return the correct value

### DIFF
--- a/docs/notes/bugfix-21982.md
+++ b/docs/notes/bugfix-21982.md
@@ -1,0 +1,1 @@
+# Ensure `the printersettings` always return the user's choice


### PR DESCRIPTION
This patch fixes an error in pointer arithmetic, that resulted in the chosen `printersettings` not being found, thus default values were used instead.

Closes https://quality.livecode.com/show_bug.cgi?id=21982

Tested on Windows 7.