### PR TITLE
[[ Bug 23104 ]] Fix calculation of player's native layer rect when stack is resized

### DIFF
--- a/docs/notes/bugfix-23104.md
+++ b/docs/notes/bugfix-23104.md
@@ -1,0 +1,1 @@
+# Ensure player's native layer rectangle does not change when stack is resized

--- a/engine/src/native-layer-mac.mm
+++ b/engine/src/native-layer-mac.mm
@@ -157,7 +157,7 @@ NSRect MCNativeLayerMac::calculateFrameRect(const MCRectangle &p_rect)
 
 void MCNativeLayerMac::doSetViewportGeometry(const MCRectangle &p_rect)
 {
-    doSetGeometry(m_object->getrect());
+    doSetGeometry(m_rect);
 }
 
 void MCNativeLayerMac::doSetGeometry(const MCRectangle &p_rect)


### PR DESCRIPTION
This patch ensures the player's native layer rect is calculated correctly when the stack is resized.