### PR TITLE
[[ Bug 23106 ]] Do not remove hidden native layers on Android

### DIFF
--- a/engine/src/native-layer-android.cpp
+++ b/engine/src/native-layer-android.cpp
@@ -88,12 +88,16 @@ void MCAndroidViewSetRect(jobject p_view, const MCRectangle &p_rect, const MCRec
 void MCAndroidViewAddToContainer(jobject p_view, jobject p_view_above, jobject p_container)
 {
     MCAndroidEngineRemoteCall("addNativeViewToContainer", "vooo", nil, p_view, p_view_above, p_container);
-    MCAndroidObjectRemoteCall(p_view, "setVisibility", "vi", nil, 0);
 }
 
 void MCAndroidViewRemoveFromContainer(jobject p_view)
 {
 	MCAndroidEngineRemoteCall("removeNativeViewFromContainer", "vo", nil, p_view);
+}
+
+void MCAndroidViewSetVisible(jobject p_view, bool p_visible)
+{
+    MCAndroidObjectRemoteCall(p_view, "setVisibility", "vi", nil, p_visible ? 0 : 4);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -113,9 +117,12 @@ MCNativeLayerAndroid::~MCNativeLayerAndroid()
 
 void MCNativeLayerAndroid::doAttach()
 {
-    if (m_view == nil)
-        return;
-	
+	if (m_view == nil)
+		return;
+
+	// Act as if there was a re-layer to put the widget in the right place
+	doRelayer();
+
 	doSetVisible(ShouldShowLayer());
 }
 
@@ -161,14 +168,13 @@ void MCNativeLayerAndroid::doSetVisible(bool p_visible)
 {
     if (m_view == NULL)
         return;
-    
-    if (p_visible)
+
+	MCAndroidViewSetVisible(m_view, p_visible);
+
+	if (p_visible)
 	{
-        addToMainView();
 		doSetGeometry(m_object->getrect());
 	}
-    else
-		MCAndroidViewRemoveFromContainer(m_view);
 }
 
 void MCNativeLayerAndroid::doRelayer()
@@ -222,11 +228,6 @@ bool MCNativeLayerAndroid::getParentView(jobject &r_view)
 		r_view = t_view;
 		return true;
 	}
-}
-
-void MCNativeLayerAndroid::addToMainView()
-{
-    doRelayer();
 }
 
 bool MCNativeLayerAndroid::GetNativeView(void *&r_view)

--- a/engine/src/native-layer-android.h
+++ b/engine/src/native-layer-android.h
@@ -49,9 +49,6 @@ private:
 	
     // Performs a relayering operation
     virtual void doRelayer();
-    
-    // Show/hide operations
-    void addToMainView();
 	
 	bool getParentView(jobject &r_view);
 };


### PR DESCRIPTION
This patch changes the behavior of hiding widgets with a native layer on
Android so that the native view has its visibility set to invisible rather
then it being removed from the view hierarchy entirely. The result of this
is that native views which require window context to function (e.g. VideoView)
no longer break when made invisible and then visible again.

Closes https://quality.livecode.com/show_bug.cgi?id=23106