### PR TITLE
[[ Bug 21906 ]] Fix copying data from clipboard via IStream objects on Windows

### DIFF
--- a/docs/notes/bugfix-21906.md
+++ b/docs/notes/bugfix-21906.md
@@ -1,0 +1,1 @@
+# Fix blank image created when pasting image data from some applications on Windows

--- a/engine/src/w32-clipboard.cpp
+++ b/engine/src/w32-clipboard.cpp
@@ -1155,29 +1155,43 @@ MCDataRef MCWin32RawClipboardItemRep::CopyData() const
 			// The data is available via an IStream interface
 			IStream* t_stream = p_medium.pstm;
 
+			HRESULT t_stream_hresult = S_OK;
+			if (SUCCEEDED(t_stream_hresult))
+			{
+				// Reset stream cursor to the beginning of the stream
+				LARGE_INTEGER t_seek_position = { 0 };
+				t_stream_hresult = t_stream->Seek(t_seek_position, STREAM_SEEK_SET, NULL);
+			}
+
 			// Find the size of the data represented by the stream
 			STATSTG t_statstg;
-			if (t_stream->Stat(&t_statstg, STATFLAG_NONAME) == S_OK)
+			if (SUCCEEDED(t_stream_hresult))
+				t_stream_hresult = t_stream->Stat(&t_statstg, STATFLAG_NONAME);
+
+			if (SUCCEEDED(t_stream_hresult))
 			{
+				uindex_t t_bytes_read = 0;
 				// Allocate memory for the data
 				MCAutoArray<byte_t> t_bytes;
 				if (t_statstg.cbSize.QuadPart <= UINDEX_MAX && t_bytes.Extend(t_statstg.cbSize.QuadPart))
 				{
 					// Loop until all the data has been read
-					uindex_t t_cursor = 0;
-					while (t_cursor < t_bytes.Size())
+					while (t_bytes_read < t_bytes.Size())
 					{
 						// Read the next block of data
 						ULONG t_read = 0;
-						HRESULT t_result = t_stream->Read(t_bytes.Ptr(), t_bytes.Size()-t_cursor, &t_read);
+						HRESULT t_result = t_stream->Read(t_bytes.Ptr() + t_bytes_read, t_bytes.Size() - t_bytes_read, &t_read);
 
 						// If the result is S_OK, then all data was sucessfully
 						// read. If it was S_FALSE, we only had a partial read.
 						// Otherwise, an error occurred.
 						if (t_result == S_OK)
+						{
+							t_bytes_read += t_read;
 							break;
+						}
 						else if (t_result == S_FALSE)
-							t_cursor += t_read;
+							t_bytes_read += t_read;
 						else
 							break;
 					}
@@ -1185,7 +1199,7 @@ MCDataRef MCWin32RawClipboardItemRep::CopyData() const
 
 				// If all data was read successfully, turn the bytes into a
 				// DataRef.
-				if (t_bytes.Size() == t_statstg.cbSize.QuadPart)
+				if (t_bytes_read == t_statstg.cbSize.QuadPart)
 				{
 					// Take the storage from the autoarray and hand it directly
 					// to the dataref to save a reallocation of (what is likely
@@ -1260,7 +1274,8 @@ MCDataRef MCWin32RawClipboardItemRep::CopyData() const
     }
     
 	// Update the data cache and return it
-	m_bytes = t_data;
+	if (t_data != nil)
+		m_bytes = t_data;
 	return t_data;
 }
 


### PR DESCRIPTION
This patch fixes bug 21906, where pasting image data from some applications would fail, resulting in an empty image control. This happens when the data is transferred via an IStream object, and is fixed by ensuring the stream pointer is reset to the beginning of the stream before reading from it.

Fixes https://quality.livecode.com/show_bug.cgi?id=21906