### PR TITLE
[[ Bug 23119 ]] Fix unresponsiveness of engine when scrolling on Big Sur 

### DIFF
--- a/docs/notes/bugfix-23119.md
+++ b/docs/notes/bugfix-23119.md
@@ -1,0 +1,1 @@
+# Fix script editor unresponsiveness while scrolling on Macos Big Sur

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -2005,6 +2005,11 @@ void MCMacPlatformSyncUpdateAfterDraw(NSInteger windowNumber)
 	[NSApp postEvent:t_event atStart:YES];
 }
 
+bool MCMacPlatformIsDrawSyncEvent(NSEvent *event)
+{
+	return [event type] == NSApplicationDefined && [event subtype] == kMCMacPlatformDrawSyncEvent;
+}
+
 void MCMacPlatformSyncMouseAfterTracking(void)
 {
 	NSEvent *t_event;

--- a/engine/src/mac-internal.h
+++ b/engine/src/mac-internal.h
@@ -609,6 +609,7 @@ void MCMacPlatformSyncMouseBeforeDragging(void);
 void MCMacPlatformSyncMouseAfterTracking(void);
 
 void MCMacPlatformSyncUpdateAfterDraw(NSInteger windowNumber);
+bool MCMacPlatformIsDrawSyncEvent(NSEvent *event);
 
 void MCMacPlatformHandleModifiersChanged(MCPlatformModifiers modifiers);
 


### PR DESCRIPTION
This patch fixes an issue where the engine would become unresponsive
when scrolling through text be clicking and dragging the selection
beyond the bounds of the text field.

Fixes https://quality.livecode.com/show_bug.cgi?id=23119