### PR TITLE
[[ Bug 23148 ]] Cleanup access to keyword tables

### DIFF
--- a/engine/src/exec-engine.cpp
+++ b/engine/src/exec-engine.cpp
@@ -119,12 +119,8 @@ MCExecSetTypeInfo *kMCEngineSecurityCategoriesTypeInfo = &_kMCEngineSecurityCate
 
 ////////////////////////////////////////////////////////////////////////////////
 
-extern const LT command_table[];
-extern const uint4 command_table_size;
 extern const Cvalue *constant_table;
 extern const uint4 constant_table_size;
-extern const LT factor_table[];
-extern const uint4 factor_table_size;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -180,12 +176,17 @@ void MCEngineEvalCommandNames(MCExecContext& ctxt, MCStringRef& r_string)
 {
 	bool t_success = true;
 
+	const uint4 t_command_table_size
+		= MCkeywordtablesizes[SP_COMMAND];
+	const LT *t_command_table
+		= MCkeywordtablepointers[SP_COMMAND];
+
 	MCAutoListRef t_list;
 	t_success = MCListCreateMutable('\n', &t_list);
 
-	for (uint32_t i = 0 ; t_success && i < command_table_size ; i++)
-		if (command_table[i].type == TT_STATEMENT)
-			t_success = MCListAppendCString(*t_list, command_table[i].token);
+	for (uint32_t i = 0 ; t_success && i < t_command_table_size ; i++)
+		if (t_command_table[i].type == TT_STATEMENT)
+			t_success = MCListAppendCString(*t_list, t_command_table[i].token);
 
 	if (t_success)
 		t_success = MCListCopyAsString(*t_list, r_string);
@@ -223,12 +224,17 @@ void MCEngineEvalFunctionNames(MCExecContext& ctxt, MCStringRef& r_string)
 {
 	bool t_success = true;
 
+	const uint4 t_factor_table_size
+		= MCkeywordtablesizes[SP_FACTOR];
+	const LT *t_factor_table
+		= MCkeywordtablepointers[SP_FACTOR];
+
 	MCAutoListRef t_list;
 	t_success = MCListCreateMutable('\n', &t_list);
 
-	for (uint32_t i = 0 ; t_success && i < factor_table_size ; i++)
-		if (factor_table[i].type == TT_FUNCTION)
-			t_success = MCListAppendCString(*t_list, factor_table[i].token);
+	for (uint32_t i = 0 ; t_success && i < t_factor_table_size ; i++)
+		if (t_factor_table[i].type == TT_FUNCTION)
+			t_success = MCListAppendCString(*t_list, t_factor_table[i].token);
 
 	if (t_success)
 		t_success = MCListCopyAsString(*t_list, r_string);
@@ -245,12 +251,17 @@ void MCEngineEvalPropertyNames(MCExecContext& ctxt, MCStringRef& r_string)
 {
 	bool t_success = true;
 
+	const uint4 t_factor_table_size
+		= MCkeywordtablesizes[SP_FACTOR];
+	const LT *t_factor_table
+		= MCkeywordtablepointers[SP_FACTOR];
+
 	MCAutoListRef t_list;
 	t_success = MCListCreateMutable('\n', &t_list);
 
-	for (uint32_t i = 0 ; t_success && i < factor_table_size ; i++)
-		if (factor_table[i].type == TT_PROPERTY)
-			t_success = MCListAppendCString(*t_list, factor_table[i].token);
+	for (uint32_t i = 0 ; t_success && i < t_factor_table_size ; i++)
+		if (t_factor_table[i].type == TT_PROPERTY)
+			t_success = MCListAppendCString(*t_list, t_factor_table[i].token);
 
 	if (t_success)
 		t_success = MCListCopyAsString(*t_list, r_string);

--- a/engine/src/lextable.cpp
+++ b/engine/src/lextable.cpp
@@ -30,18 +30,12 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #define ST_MNB ST_ID
 #endif
 
-
 // Some of these tables need to be accessed from other compilation units and C++
 // mandates that variables declared as "const" have internal linkage unless also
 // declared as "extern".
-extern const LT command_table[];
 extern const Cvalue *constant_table;
-extern const LT factor_table[];
-extern const LT * const table_pointers[];
-extern const uint2 table_sizes[];
 extern const uint8_t type_table[];
 extern const uint8_t unicode_type_table[];
-
 
 // MW-2011-06-22: [[ SERVER ]] We mark '?' as ST_TAG so we can parse server
 //   style scripts. If the SP's tagged property is false, it reverts to ST_ID.
@@ -296,7 +290,7 @@ const static LT ask_table[] =
         {"warning", TT_UNDEFINED, AT_WARNING}
     };
 
-const LT command_table[] =
+const static LT command_table[] =
     {
 		{"_internal", TT_STATEMENT, S_INTERNAL},
         {"accept", TT_STATEMENT, S_ACCEPT},
@@ -452,7 +446,6 @@ const LT command_table[] =
         {"wait", TT_STATEMENT, S_WAIT},
         {"write", TT_STATEMENT, S_WRITE}
     };
-extern const uint4 command_table_size = ELEMENTS(command_table);
 
 const static LT convert_table[] =
     {
@@ -534,7 +527,7 @@ const static LT export_table[] =
         {"xwd", TT_UNDEFINED, EX_XWD}
     };
 
-const LT factor_table[] =
+const static LT factor_table[] =
     {
         {"&", TT_BINOP, O_CONCAT},
         {"&&", TT_BINOP, O_CONCAT_SPACE},
@@ -1879,8 +1872,6 @@ const LT factor_table[] =
         {"\263", TT_BINOP, O_GE}
     };
 
-extern const uint4 factor_table_size = ELEMENTS(factor_table);
-
 const static LT find_table[] =
     {
         {"characters", TT_CHUNK, FM_CHARACTERS},
@@ -2382,7 +2373,7 @@ const static LT server_table[] =
 	{"unicode", TT_SERVER, SK_UNICODE},
 };
 
-const LT * const table_pointers[] =
+const static LT * const table_pointers[] =
 {
     accept_table,
     ae_table,
@@ -2419,9 +2410,9 @@ const LT * const table_pointers[] =
     visual_table,
 	server_table
 };
-extern const uint4 table_pointers_size = ELEMENTS(table_pointers);
+const static uint4 table_pointers_size = ELEMENTS(table_pointers);
 
-const uint2 table_sizes[] =
+const static uint2 table_sizes[] =
 {
     ELEMENTS(accept_table),
     ELEMENTS(ae_table),
@@ -2458,4 +2449,11 @@ const uint2 table_sizes[] =
     ELEMENTS(visual_table),
 	ELEMENTS(server_table),
 };
-extern const uint4 table_sizes_size = ELEMENTS(table_sizes);
+const static uint4 table_sizes_size = ELEMENTS(table_sizes);
+
+/* All keyword tables are const static in this translation unit, but we allow
+ * access to them through well-defined global variables. */
+LT **MCkeywordtablepointers = (LT **)table_pointers;
+uint4 MCkeywordtablepointerssize = table_pointers_size;
+uint2 *MCkeywordtablesizes = (uint2 *)table_sizes;
+uint4 MCkeywordtablesizessize = table_sizes_size;

--- a/engine/src/scriptpt.cpp
+++ b/engine/src/scriptpt.cpp
@@ -45,12 +45,6 @@ extern const uint8_t type_table[];
 extern const uint8_t unicode_type_table[];
 extern const Cvalue *constant_table;
 extern const uint4 constant_table_size;
-extern const LT * const table_pointers[];
-extern const uint2 table_sizes[];
-extern const LT command_table[];
-extern const uint4 command_table_size;
-extern const LT factor_table[];
-extern const uint4 factor_table_size;
 
 static struct { codepoint_t codepoint; Symbol_type type; } remainder_table[] =
 {
@@ -1302,8 +1296,8 @@ Parse_stat MCScriptPoint::lookup(Script_point t, const LT *&dlt)
 	
 	if (token.getlength())
 	{
-		const LT *table = table_pointers[t];
-		uint2 high = table_sizes[t];
+		const LT *table = MCkeywordtablepointers[t];
+		uint2 high = MCkeywordtablesizes[t];
 		uint2 low = 0;
 		int4 cond;
         MCAutoStringRefAsCString t_token;

--- a/engine/src/scriptpt.h
+++ b/engine/src/scriptpt.h
@@ -28,6 +28,11 @@ typedef struct
 }
 LT;
 
+extern LT **MCkeywordtablepointers;
+extern uint4 MCkeywordtablepointerssize;
+extern uint2 *MCkeywordtablesizes;
+extern uint4 MCkeywordtablesizessize;
+
 typedef enum {
     kCValueTypeReal,
     kCValueTypeInteger,

--- a/engine/src/widget.cpp
+++ b/engine/src/widget.cpp
@@ -358,12 +358,16 @@ void MCWidget::recompute(void)
 
 static void lookup_name_for_prop(Properties p_which, MCNameRef& r_name)
 {
-    extern const LT factor_table[];
-    extern const uint4 factor_table_size;
-    for(uindex_t i = 0; i < factor_table_size; i++)
-        if (factor_table[i] . type == TT_PROPERTY && factor_table[i] . which == p_which)
+	const uint4 t_factor_table_size
+		= MCkeywordtablesizes[SP_FACTOR];
+	const LT *t_factor_table
+		= MCkeywordtablepointers[SP_FACTOR];
+
+    for(uindex_t i = 0; i < t_factor_table_size; i++)
+        if (t_factor_table[i] . type == TT_PROPERTY &&
+        		t_factor_table[i] . which == p_which)
         {
-            r_name = MCNAME(factor_table[i] . token);
+            r_name = MCNAME(t_factor_table[i] . token);
             return;
         }
 	

--- a/engine/test/test_lextable.cpp
+++ b/engine/test/test_lextable.cpp
@@ -44,18 +44,12 @@ TEST(lextable, table_pointer)
 // Checks that the entries of factor_table are in alphabetical order.
 //
 {
-	extern const LT * const table_pointers[];
-	extern const uint4 table_pointers_size;
+	ASSERT_EQ(MCkeywordtablepointerssize, MCkeywordtablesizessize);
 
-	extern const uint2 table_sizes[];
-	extern const uint4 table_sizes_size;
+	for (uint4 i = 0; i < MCkeywordtablepointerssize; i++) {
 
-	ASSERT_EQ(table_pointers_size, table_sizes_size);
-
-	for (uint4 i = 0; i < table_pointers_size; i++) {
-
-		const LT* table = table_pointers[i];
-		const uint4 table_size = table_sizes[i];
+		const LT* table = MCkeywordtablepointers[i];
+		const uint4 table_size = MCkeywordtablesizes[i];
 
 		ASSERT_GE(table_size, (unsigned)1);
 


### PR DESCRIPTION
This patch cleans up access to the keyword tables, used by the script parser
and syntax such as `the commandNames`. The tables are now accessible via
global variables `MCkeywordtablepointers` and `MCkeywordtablesizes` which are
defined in `scriptpt.h`; and all direct access to the underlying tables in
other files have been updated to use them.

Closes https://quality.livecode.com/show_bug.cgi?id=23148