### PR TITLE
[[ Bug 23149 ]] Replace mode syntax factory functions

### DIFF
--- a/engine/src/mode.h
+++ b/engine/src/mode.h
@@ -152,13 +152,6 @@ bool MCModeCanLoadHome(void);
 //
 void MCModeSetupCrashReporting(void);
 
-// These hooks are used to create mode-specific syntax objects.
-//
-// They are called by the MCN_new_* methods.
-//
-MCStatement *MCModeNewCommand(int2 which);
-MCExpression *MCModeNewFunction(int2 which);
-
 // This hook is used to determine whether to queue stacks that are wanting to
 // be opened (e.g. via an AppleEvent OpenDoc event).
 //

--- a/engine/src/mode_development.cpp
+++ b/engine/src/mode_development.cpp
@@ -51,6 +51,7 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "player.h"
 #include "objptr.h"
 #include "osspec.h"
+#include "newobj.h"
 
 #include "globals.h"
 #include "license.h"
@@ -244,6 +245,24 @@ void MCRevRelicense::exec_ctxt(MCExecContext& ctxt)
 
 	atexit(restart_livecode);
 }
+
+/* Define the factory function handling development mode syntax. */
+static MCStatement *MCN_new_statement_development(int2 which)
+{
+	switch(which)
+	{
+	case S_REV_RELICENSE:
+		return new MCRevRelicense;
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+/* Define a new statement factory wrapping the factory function. */
+static MCNewStatementFactory
+MCdevelopmentmodestatementfactory(MCN_new_statement_development);
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -600,24 +619,6 @@ const char *MCModeGetStartupStack(void)
 bool MCModeCanLoadHome(void)
 {
 	return true;
-}
-
-MCStatement *MCModeNewCommand(int2 which)
-{
-	switch(which)
-	{
-	case S_REV_RELICENSE:
-		return new MCRevRelicense;
-	default:
-		break;
-	}
-
-	return NULL;
-}
-
-MCExpression *MCModeNewFunction(int2 which)
-{
-	return NULL;
 }
 
 bool MCModeShouldQueueOpeningStacks(void)

--- a/engine/src/mode_installer.cpp
+++ b/engine/src/mode_installer.cpp
@@ -1603,16 +1603,6 @@ bool MCModeCanLoadHome(void)
 	return false;
 }
 
-MCStatement *MCModeNewCommand(int2 which)
-{
-	return NULL;
-}
-
-MCExpression *MCModeNewFunction(int2 which)
-{
-	return NULL;
-}
-
 MCObject *MCModeGetU3MessageTarget(void)
 {
 	return MCdefaultstackptr -> getcard();

--- a/engine/src/mode_server.cpp
+++ b/engine/src/mode_server.cpp
@@ -301,16 +301,6 @@ bool MCModeCanLoadHome(void)
 	return false;
 }
 
-MCStatement *MCModeNewCommand(int2 which)
-{
-	return NULL;
-}
-
-MCExpression *MCModeNewFunction(int2 which)
-{
-	return NULL;
-}
-
 bool MCModeShouldQueueOpeningStacks(void)
 {
 	return false;

--- a/engine/src/mode_standalone.cpp
+++ b/engine/src/mode_standalone.cpp
@@ -1222,16 +1222,6 @@ bool MCModeCanLoadHome(void)
 	return false;
 }
 
-MCStatement *MCModeNewCommand(int2 which)
-{
-	return NULL;
-}
-
-MCExpression *MCModeNewFunction(int2 which)
-{
-	return NULL;
-}
-
 MCObject *MCModeGetU3MessageTarget(void)
 {
 	return MCdefaultstackptr -> getcard();

--- a/engine/src/newobj.h
+++ b/engine/src/newobj.h
@@ -17,9 +17,131 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 //
 // create new script objects
 //
+#ifndef	NEWOBJ_H
+#define	NEWOBJ_H
+
 class MCStatement;
 class MCExpression;
 
+/* The MCNewObjFactory class is designed to be derived from to form the three
+ * lists of newobj functions for statements, functions and operators.
+ *
+ * Derivations of the class are declared as global instances which automatically
+ * hook themselves into a globally-linked list via global constructors.
+ *
+ * As there is no guaranteed order to global constructors, care
+ * must be taken to ensure the syntax ids handled by each registerd function are
+ * distinct.
+ *
+ * The template base class exploits the fact that template arguments can be
+ * a derived class. This allows all the code to be in the base-class, with
+ * derived classes only needing to add a class variable `s_functions` which
+ * holds the root of the list and a constructor. */
+template<typename Derived, typename Node>
+class MCNewObjFactory
+{
+public:
+	typedef Derived Self;
+	typedef MCNewObjFactory<Derived, Node> Base;
+	typedef Node *(*Function)(int2 p_which);
+
+	MCNewObjFactory(
+			Function p_function)
+		: m_function(p_function)
+	{
+		m_next = Derived::s_functions;
+		Derived::s_functions = this;
+	}
+
+	static Node *
+	New(int2 p_which)
+	{
+		if (Derived::s_functions == nullptr)
+		{
+			return nullptr;
+		}
+		return Derived::s_functions->_New(p_which);
+	}
+
+private:
+	Node *_New(
+			int2 p_which)
+	{
+		Node *t_instance
+			= m_function(p_which);
+		if (t_instance != nullptr)
+		{
+			return t_instance;
+		}
+
+		if (m_next == nullptr)
+		{
+			return nullptr;
+		}
+
+		return m_next->New(p_which);
+	}
+
+	Base *m_next;
+	Function m_function;
+};
+
+/* The MCNewStatementFactory class should be globally instantiated with
+ * a factory function for statement ids. */
+class MCNewStatementFactory
+	: public MCNewObjFactory<MCNewStatementFactory, MCStatement>
+{
+public:
+	MCNewStatementFactory(
+			Function p_function)
+		: Base(p_function)
+	{
+	}
+
+private:
+	static Base *s_functions;
+	friend Base;
+};
+
+/* The MCNewFunctionFactory class should be globally instantiated with a factory
+ * function for function ids. */
+class MCNewFunctionFactory
+	: public MCNewObjFactory<MCNewFunctionFactory, MCExpression>
+{
+public:
+	MCNewFunctionFactory(
+			Function p_function)
+		: Base(p_function)
+	{
+	}
+
+private:
+	static Base *s_functions;
+	friend Base;
+};
+
+/* The MCNewOperatorFactory class should be globally instantiated with a factory
+ * function for operator ids. */
+class MCNewOperatorFactory
+	: public MCNewObjFactory<MCNewOperatorFactory, MCExpression>
+{
+public:
+	MCNewOperatorFactory(
+			Function p_function)
+		: Base(p_function)
+	{
+	}
+
+private:
+	static Base *s_functions;
+	friend Base;
+};
+
+/* The new methods for each type of syntax id which can be instantiated. These
+ * functions handle the main syntax ids first, and then pass on responsibility
+ * to the list of factories for the syntax type. */
 extern MCStatement *MCN_new_statement(int2 which);
 extern MCExpression *MCN_new_function(int2 which);
 extern MCExpression *MCN_new_operator(int2 which);
+
+#endif


### PR DESCRIPTION
This patch replaces the current mode syntax factory functions:
`MCModeNewCommand` and `MCModeNewFunction` with a more general mechanism based
around instantiating a class as a global-variable, constructed using a syntax
factory function pointer.

There are three global classes which can be instantiated in this manner -
`MCNewStatementFactory`, `MCNewFunctionFactory` and `MCNewOperatorFactory` -
corresponding to the top-level factory functions `MCN_new_statement`,
`MCN_new_function` and `MCN_new_operator`.

The classes 'hide' a linked list of factory functions, which are invoked
in turn if the top-level functions do not recognise an id.

Closes https://quality.livecode.com/show_bug.cgi?id=23149