### PR TITLE
[[ Bug 23150 ]] Ensure urlWakeUp is sent in any case

### DIFF
--- a/docs/notes/bugfix-23150.md
+++ b/docs/notes/bugfix-23150.md
@@ -1,0 +1,1 @@
+# Ensure `urlWakeUp` message is sent when `LSSupportsOpeningDocumentsInPlace` is set to `true` in `Info.plist`

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -558,14 +558,14 @@ static UIDeviceOrientation patch_device_orientation(id self, SEL _cmd)
 
 // Check if we have received a custom URL
 // This handler is called at runtime, for example if the application tries to launch itself
-- (BOOL)application:(UIApplication *)p_application openURL:(NSURL*)p_url sourceApplication:(NSString *)p_source_application annotation:(id)p_annotation
+- (BOOL)application:(UIApplication *)p_application openURL:(NSURL *)p_url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)p_options
 {
     BOOL t_result = NO;
     if (p_url != nil)
     {
         MCAutoStringRef t_url_text;
-		/* UNCHECKED */ MCStringCreateWithCFStringRef((CFStringRef)[p_url absoluteString], &t_url_text);
-		MCValueAssign(m_launch_url, *t_url_text);
+        /* UNCHECKED */ MCStringCreateWithCFStringRef((CFStringRef)[p_url absoluteString], &t_url_text);
+        MCValueAssign(m_launch_url, *t_url_text);
         if (m_did_become_active)
             MCNotificationPostUrlWakeUp(m_launch_url);
         t_result = YES;


### PR DESCRIPTION
This patch ensures that the urlWakeUp message is sent to the app when `LSSupportsOpeningDocumentsInPlace` is `true` in the `Info.plist`.

Previously we were using a deprecated handler in the engine, which was not triggered in recent iOS versions. Replacing this handler with the suggested replacement fixes the problem.