### PR TITLE
[[ Bug 23154 ]] Fix lockup on Big Sur when restoring window after maximizing

### DIFF
--- a/docs/notes/bugfix-23154.md
+++ b/docs/notes/bugfix-23154.md
@@ -1,0 +1,1 @@
+# Fix engine lockup when restoring window after maximizing on Macos Big Sur

--- a/engine/src/mac-window.mm
+++ b/engine/src/mac-window.mm
@@ -2249,7 +2249,7 @@ void MCMacPlatformWindow::DoUpdate(void)
 		// we enter the runloop to trigger a redraw. This will cause drawRect to be invoked on our view
 		// which in turn will result in a redraw window callback being sent.
 		// The timeout value of 0.02ms is specified to avoid hitting the 60hz redraw limit.
-		if (!s_inside_focus_event && !s_showing_sheet && ![m_delegate inUserReshape])
+		if (MCMacPlatformIsEventCheckingEnabled() && !s_inside_focus_event)
 		{
 			// Since we remove all ApplicationDefined events from the queue we need to
 			// re-queue the events we're not interested in once the redraw has occured.


### PR DESCRIPTION
Avoid lockup in MCMacPlatformWindow::DoUpdate by ensuring we don't
poll for events when event checking has been disabled.

*Note* this allows us to remove the individual tests for user
resizing and showing dialog as sheet as both of these actions also
disable event checking.

Fixes https://quality.livecode.com/show_bug.cgi?id=23154