### PR TITLE
[Bug-23160] Correct code example in revXMLEvaluateXPath

### DIFF
--- a/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
+++ b/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
@@ -20,7 +20,7 @@ OS: mac, windows, linux, ios, android
 Platforms: desktop, server, mobile
 
 Example:
-put "/bookstore/book/[price&lt;40]/" into pXPathExpression
+put "/bookstore/book[price&lt;40]/" into pXPathExpression
 put revXMLEvaluateXPath(pDocID, pXPathExpression)
 
 Description:

--- a/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
+++ b/docs/dictionary/function/revXMLEvaluateXPath.lcdoc
@@ -63,7 +63,7 @@ instance, given xml data of
     
 then
 
-    put "/bookstore/book/[price&lt;40]/" into pXPathExpression
+    put "/bookstore/book[price&lt;40]/" into pXPathExpression
     put revXMLEvaluateXPath(pDocID, pXPathExpression)
 
 gives you 

--- a/docs/notes/bugfix-23160.md
+++ b/docs/notes/bugfix-23160.md
@@ -1,0 +1,1 @@
+# Corrected code example in the revXMLEvaluateXPath entry


### PR DESCRIPTION
Changed the expression used in the bottom code example so that it will give the correct result instead of a crash.