### PR TITLE
[[ Bug 23168 ]] Fix memory leak when rendering "good" quality gradients

### DIFF
--- a/docs/notes/bugfix-23168.md
+++ b/docs/notes/bugfix-23168.md
@@ -1,0 +1,1 @@
+# Fix memory leak when rendering gradients where the quality is set to "good"

--- a/libgraphics/src/legacygradients.cpp
+++ b/libgraphics/src/legacygradients.cpp
@@ -315,12 +315,13 @@ public:
             m_buffer = nullptr;
             m_buffer_width = 0;
         }
-        
-        ~Context()
-        {
-            MCMemoryDeleteArray(m_ramp);
-        }
-        
+
+		~Context()
+		{
+			MCMemoryDeleteArray(m_buffer);
+			MCMemoryDeleteArray(m_ramp);
+		}
+
         virtual void shadeSpan(int x, int y, SkPMColor dstC[], int count) override
         {
             if (m_combine == nullptr)
@@ -339,7 +340,7 @@ public:
             {
                 if ((int)m_buffer_width < count * GRADIENT_AA_SCALE)
                 {
-                    uindex_t t_size = m_buffer_width * GRADIENT_AA_SCALE * GRADIENT_AA_SCALE;
+                    uindex_t t_size = m_buffer_width * GRADIENT_AA_SCALE;
                     if (!MCMemoryResizeArray(count * GRADIENT_AA_SCALE * GRADIENT_AA_SCALE, m_buffer, t_size))
                     {
                         return;


### PR DESCRIPTION
This patch fixes a memory leak in the engine when rendering gradients
with the quality parameter set to "good". This is due to an unreleased
buffer used by the legacy gradient renderer when using a bilinear
filter.

Fixes https://quality.livecode.com/show_bug.cgi?id=23168