### PR TITLE
[[ Bug 23172 ]] Fix 100% CPU load when playing unsupported media file on Big Sur

### DIFF
--- a/docs/notes/bugfix-23172.md
+++ b/docs/notes/bugfix-23172.md
@@ -1,0 +1,1 @@
+# Fix 100% CPU usage when the player control is set to load an unplayable media file on Macos Big Sur

--- a/engine/src/mac-av-player.mm
+++ b/engine/src/mac-av-player.mm
@@ -818,6 +818,13 @@ void MCAVFoundationPlayer::Load(MCStringRef p_filename_or_url, bool p_is_url)
         Unload();
         return;
     }
+	
+	/* If there are no playable tracks then reset the player and exit */
+	if (m_player.currentItem.asset.tracks.count == 0)
+	{
+		Unload();
+		return;
+	}
 
 	/* UNCHECKED */ MCAVPlayerSetupPanningFilter(m_player, &m_panning_filter);
 


### PR DESCRIPTION
This patch fixes a bug where a media file with no playable tracks would
lead to 100% CPU usage when loaded into the player control on Macos
Big Sur.

Fixes https://quality.livecode.com/show_bug.cgi?id=23172