### PR TITLE
[[ Bug 23173 ]] Fix inset of rectangles when printing to PDF

### DIFF
--- a/docs/notes/bugfix-23173.md
+++ b/docs/notes/bugfix-23173.md
@@ -1,0 +1,1 @@
+# Fix rectangle border inset too much when printing on Windows or to PDF

--- a/engine/src/customprinter.cpp
+++ b/engine/src/customprinter.cpp
@@ -357,6 +357,15 @@ bool MCCustomMetaContext::candomark(MCMark *p_mark)
 	MCUnreachableReturn(false);
 }
 
+MCRectangle MCCustomPrinterInsetRectangle(const MCRectangle &p_rect, uint32_t p_inset)
+{
+	/* TODO - fix half pixels lost when insetting by odd integers */
+	return MCRectangleMake(p_rect.x + p_inset / 2,
+							 p_rect.y + p_inset / 2,
+							 MCMax(0, (int32_t)p_rect.width - p_inset),
+							 MCMax(0, (int32_t)p_rect.height - p_inset));
+}
+
 void MCCustomMetaContext::domark(MCMark *p_mark)
 {
 	// If an error has occurred, we do nothing.
@@ -399,16 +408,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
 		break;
 	case MARK_TYPE_RECTANGLE:
 		{
-            // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
-            // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-            // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-            if (p_mark -> rectangle . inset && (p_mark -> rectangle . inset % 2))
-				p_mark -> rectangle . inset ++;
-            // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
-			p_mark -> rectangle . bounds = MCRectangleMake(p_mark -> rectangle . bounds . x + p_mark -> rectangle . inset / 2,
-														   p_mark -> rectangle . bounds . y + p_mark -> rectangle . inset / 2, 
-                                                           MCMin(p_mark -> rectangle . bounds . width, p_mark -> rectangle . bounds . width - p_mark -> rectangle . inset),
-                                                           MCMin(p_mark -> rectangle . bounds . height, p_mark -> rectangle . bounds . height - p_mark -> rectangle . inset));
+			p_mark -> rectangle . bounds = MCCustomPrinterInsetRectangle(p_mark -> rectangle . bounds, p_mark -> rectangle . inset);
 			
 			MCPath *t_path;
 			if (p_mark -> stroke != nil && p_mark -> rectangle . bounds . height == 1)
@@ -428,16 +428,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
 		break;
 	case MARK_TYPE_ROUND_RECTANGLE:
 		{
-            // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
-            // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-            // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-			if (p_mark -> round_rectangle . inset % 2)
-				p_mark -> round_rectangle . inset ++;
-            // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
-			p_mark -> round_rectangle . bounds = MCRectangleMake(p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . inset / 2,
-														   p_mark -> round_rectangle . bounds . y + p_mark -> round_rectangle . inset / 2, 
-                                                           MCMin(p_mark -> round_rectangle . bounds . width, p_mark -> round_rectangle . bounds . width - p_mark -> round_rectangle . inset),
-                                                           MCMin(p_mark -> round_rectangle . bounds . height, p_mark -> round_rectangle . bounds . height - p_mark -> round_rectangle . inset));
+			p_mark -> round_rectangle . bounds = MCCustomPrinterInsetRectangle(p_mark -> round_rectangle . bounds, p_mark -> round_rectangle . inset);
 			
 			MCPath *t_path;
 			t_path = MCPath::create_rounded_rectangle(p_mark -> round_rectangle . bounds, p_mark -> round_rectangle . radius / 2, p_mark -> stroke != nil);
@@ -452,16 +443,7 @@ void MCCustomMetaContext::domark(MCMark *p_mark)
 		break;
 	case MARK_TYPE_ARC:
 		{
-            // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since MCPath only accepts ints, if the inset value is uneven,
-            // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-            // SN-2014-10-17: [[ Bug 13351 ]] Only round up existing inset
-			if (p_mark -> arc . inset % 2)
-				p_mark -> arc . inset ++;
-            // SN-2014-10-17: [[ Bug 13351 ]] Be careful not to underflow the bounds
-			p_mark -> arc . bounds = MCRectangleMake(p_mark -> arc . bounds . x + p_mark -> arc . inset / 2,
-														   p_mark -> arc . bounds . y + p_mark -> arc . inset / 2, 
-                                                           MCMin(p_mark -> arc . bounds . width, p_mark -> arc . bounds . width - p_mark -> arc . inset),
-                                                           MCMin(p_mark -> arc . bounds . height, p_mark -> arc . bounds . height - p_mark -> arc . inset));
+			p_mark -> arc . bounds = MCCustomPrinterInsetRectangle(p_mark -> arc . bounds, p_mark -> arc . inset);
 			
 			MCPath *t_path;
 			if (p_mark -> arc . complete)

--- a/engine/src/w32printer.cpp
+++ b/engine/src/w32printer.cpp
@@ -534,6 +534,15 @@ bool MCGDIMetaContext::candomark(MCMark *mark)
 	return mark -> type != MARK_TYPE_GROUP;
 }
 
+inline MCRectangle MCGDIInsetRectangle(const MCRectangle &p_rect, uint32_t p_inset)
+{
+	/* TODO - fix half pixels lost when insetting by odd integers */
+	return MCRectangleMake(p_rect.x + p_inset / 2,
+		p_rect.y + p_inset / 2,
+		MCMax(0, (int32_t)p_rect.width - p_inset),
+		MCMax(0, (int32_t)p_rect.height - p_inset));
+}
+
 void MCGDIMetaContext::domark(MCMark *p_mark)
 {
 	HDC t_dc;
@@ -826,16 +835,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 		case MARK_TYPE_RECTANGLE:
 		{
 			if (t_should_inset)
-			{
-                // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
-                // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (p_mark -> rectangle . inset % 2)
-					p_mark -> rectangle . inset ++;
-				p_mark -> rectangle . bounds = MCRectangleMake(p_mark -> rectangle . bounds . x + p_mark -> rectangle . inset / 2,
-															   p_mark -> rectangle . bounds . y + p_mark -> rectangle . inset / 2, 
-															   p_mark -> rectangle . bounds . width - p_mark -> rectangle . inset, 
-															   p_mark -> rectangle . bounds . height - p_mark -> rectangle . inset);
-			}
+				p_mark->rectangle.bounds = MCGDIInsetRectangle(p_mark->rectangle.bounds, p_mark->rectangle.inset);
 			
 			Rectangle(t_dc, p_mark -> rectangle . bounds . x, p_mark -> rectangle . bounds . y,
 											p_mark -> rectangle . bounds . x + p_mark -> rectangle . bounds . width,
@@ -846,16 +846,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 		case MARK_TYPE_ROUND_RECTANGLE:
 		{
 			if (t_should_inset)
-			{
-                // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
-                // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (p_mark -> round_rectangle . inset % 2)
-					p_mark -> round_rectangle . inset ++;
-				p_mark -> round_rectangle . bounds = MCRectangleMake(p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . inset / 2,
-																	 p_mark -> round_rectangle . bounds . y + p_mark -> round_rectangle . inset / 2, 
-																	 p_mark -> round_rectangle . bounds . width - p_mark -> round_rectangle . inset, 
-																	 p_mark -> round_rectangle . bounds . height - p_mark -> round_rectangle . inset);
-			}
+				p_mark->round_rectangle.bounds = MCGDIInsetRectangle(p_mark->round_rectangle.bounds, p_mark->round_rectangle.inset);
 			
 			RoundRect(t_dc, p_mark -> round_rectangle . bounds . x, p_mark -> round_rectangle . bounds . y,
 											p_mark -> round_rectangle . bounds . x + p_mark -> round_rectangle . bounds . width,
@@ -866,16 +857,7 @@ void MCGDIMetaContext::domark(MCMark *p_mark)
 
 		case MARK_TYPE_ARC:
 			if (t_should_inset)
-			{
-                // MM-2014-04-23: [[ Bug 11884 ]] Inset the bounds. Since GDI only accepts ints, if the inset value is uneven,
-                // round up to the nearest even value, keeping behaviour as close to that of the graphics context as possible.
-				if (p_mark -> arc . inset % 2)
-					p_mark -> arc . inset ++;
-				p_mark -> arc . bounds = MCRectangleMake(p_mark -> arc . bounds . x + p_mark -> arc . inset / 2,
-														 p_mark -> arc . bounds . y + p_mark -> arc . inset / 2, 
-														 p_mark -> arc . bounds . width - p_mark -> arc . inset, 
-														 p_mark -> arc . bounds . height - p_mark -> arc . inset);				
-			}
+				p_mark->arc.bounds = MCGDIInsetRectangle(p_mark->arc.bounds, p_mark->arc.inset);
 			
 			gdi_do_arc(t_dc, NULL, p_mark -> stroke == NULL, p_mark -> arc . bounds . x, p_mark -> arc . bounds . y, p_mark -> arc . bounds . x + p_mark -> arc . bounds . width, p_mark -> arc . bounds . y + p_mark -> arc . bounds . height, p_mark -> arc . start, p_mark -> arc . start + p_mark -> arc . angle);
 			if (p_mark -> stroke != NULL)


### PR DESCRIPTION
This patch fixes a bug where rectangles with an inset value would be
resized incorrectly when printed to PDF

Fixes https://quality.livecode.com/show_bug.cgi?id=23173