### PR TITLE
[[ Bug 23176 ]] Ensure the target MacOS SDK (10.9) is properly set

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -30,7 +30,7 @@
 		'STRIP_INSTALLED_PRODUCT': 'NO',
 		'CLANG_LINK_OBJC_RUNTIME': 'NO',
 		'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
-        'CLANG_CXX_LIBRARY': 'libc++'
+		'CLANG_CXX_LIBRARY': 'libc++'
 	},
 	
 	'target_defaults':
@@ -47,6 +47,7 @@
 			'debug_info_suffix': '.dSYM',
 			
 			'silence_warnings': 0,
+			'travis': '<!(echo ${TRAVIS})',
 		},
 		
 		'target_conditions':
@@ -68,6 +69,21 @@
 						'_SERVER',
 						'_MAC_SERVER',
 					],
+				},
+			],
+			[
+				'travis == ""',
+				{
+					'xcode_settings':
+					{
+						'OTHER_LD_FLAGS':
+						[
+							'-Wl,-platform_version',
+							'-Wl,macos',
+							'-Wl,10.9',
+							'-Wl,10.9',
+						],
+					},
 				},
 			],
 			[

--- a/docs/notes/bugfix-23176.md
+++ b/docs/notes/bugfix-23176.md
@@ -1,0 +1,1 @@
+# Ensure externals are not blocked by hardened runtime


### PR DESCRIPTION
This patch ensures that hardened runtime will not block externals from launching. This happened because the target sdk version was not set in the externals after building with Xcode12+.

Note: Xcode uses clang to drive ld - `-Wl`, means pass this option to the linker direct