### PR TITLE
[[ Bug 23096 ]] Return compiler error for osascript script errors

### DIFF
--- a/engine/src/dskmac.cpp
+++ b/engine/src/dskmac.cpp
@@ -4672,7 +4672,12 @@ struct MCMacDesktop: public MCSystemInterface, public MCMacSystemService
 			"delete the last char of tValue;" \
 		"end if;" \
 	"else;" \
-		"put \"execution error\" into tValue;" \
+		"put url (\"binfile:\" & tStderr) into tValue;" \
+		"if tValue contains \"script error\" then;" \
+			"put \"compiler error\" into tValue;" \
+		"else;" \
+			"put \"execution error\" into tValue;" \
+		"end if;" \
 	"end if;" \
 	"delete file tStdout;" \
 	"delete file tStderr;" \


### PR DESCRIPTION
This patch updates the translated environment AppleScript workaround to
return `compiler error` if `osascript` stderr output contains `script error`
rather than `execution error`.