### PR TITLE
[[ Bug 23176 ]] Fixed typo in mac.gypi

### DIFF
--- a/config/mac.gypi
+++ b/config/mac.gypi
@@ -76,7 +76,7 @@
 				{
 					'xcode_settings':
 					{
-						'OTHER_LD_FLAGS':
+						'OTHER_LDFLAGS':
 						[
 							'-Wl,-platform_version',
 							'-Wl,macos',


### PR DESCRIPTION
This patch fixes a typo in one of the Xcode settings, that resulted in an invalid setting name, thus this setting was not applied.