### PR TITLE
[[ Bug 23193 ]] Add support for App Tracking Transparency

### DIFF
--- a/docs/dictionary/function/iphoneTrackingAuthorizationStatus.lcdoc
+++ b/docs/dictionary/function/iphoneTrackingAuthorizationStatus.lcdoc
@@ -1,0 +1,46 @@
+Name: iphoneTrackingAuthorizationStatus
+
+Type: function
+
+Syntax: iphoneTrackingAuthorizationStatus()
+
+Summary:
+Returns the current tracking authorization status of the calling
+application. 
+
+Introduced: 9.6.3
+
+OS: ios
+
+Platforms: mobile
+
+Example:
+local tStatus
+put iphoneTrackingAuthorizationStatus() into tStatus
+if tStatus is "denied" then
+   answer "The app cannot track you"
+end if
+
+Returns (enum):
+The <iphoneTrackingAuthorizationStatus> function returns one of the
+following strings:
+
+ -  "not determined" - The user has not yet received a request to authorize access to
+    app-related data that can be used for tracking the user or the device.
+ -  "restricted" - Authorization to access app-related data that can be used for tracking 
+    the user or the device is restricted.
+ -  "denied" - User has explicitly denied authorization to access app-related data that
+    can be used for tracking the user or the device.
+ -  "authorized" - User has granted access to app-related data that can be used for 
+    tracking the user or the device.
+-  "not supported" - Device runs a version of iOS lower than 14, where this
+    feature is not supported
+
+
+Description:
+Use the <iphoneTrackingAuthorizationStatus> function to find the current
+tracking authorization status of the calling application.
+
+This function is available in iOS 14 and above.
+
+

--- a/docs/notes/bugfix-23193.md
+++ b/docs/notes/bugfix-23193.md
@@ -1,0 +1,1 @@
+# Added support for App Tracking Transparency on iOS

--- a/docs/notes/feature-app_tracking_transparency.md
+++ b/docs/notes/feature-app_tracking_transparency.md
@@ -1,0 +1,6 @@
+# Support for App Tracking Transparency
+
+The Standalone Builder now includes a checkbox that adds support for App Tracking Transparency.
+This is a requirement if your app collects user data that is shared among apps or websites.
+Moreover, a text field is added, where you can provide the usage description string, i.e. the dialog 
+text that will be presented to the user letting them know that their data will be shared.

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -186,6 +186,15 @@
                             ],
                         },
                     ],
+                    [
+                        'OS == "ios" and target_sdk >= "14.0"',
+                        {
+                            'libraries':
+                            [
+                                '$(SDKROOT)/System/Library/Frameworks/AppTrackingTransparency.framework',
+                            ],
+                        },
+                    ],
 					[
 						'OS == "ios"',
 						{

--- a/engine/rsrc/mobile-device-template.plist
+++ b/engine/rsrc/mobile-device-template.plist
@@ -130,6 +130,7 @@
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>This application requires access to Bluetooth always</string>
 	${HEALTHKIT}
+	${APP_TRACKING_TRANSPARENCY}
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		${APP_URL_WHITELIST}

--- a/engine/rsrc/mobile-template.plist
+++ b/engine/rsrc/mobile-template.plist
@@ -94,6 +94,7 @@
 	<string>This application requires access to Photo Library</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>This application requires access to Bluetooth always</string>
+	${APP_TRACKING_TRANSPARENCY}
 	${HEALTHKIT}
 	${UI_STYLE}
 </dict>

--- a/engine/src/exec-misc.cpp
+++ b/engine/src/exec-misc.cpp
@@ -67,6 +67,14 @@ void MCMiscGetDeviceToken(MCExecContext& ctxt, MCStringRef& r_token)
     ctxt.Throw();
 }
 
+void MCMiscGetTrackingAuthorizationStatus(MCExecContext& ctxt, MCStringRef& r_status)
+{
+    if(MCSystemGetTrackingAuthorizationStatus(r_status))
+        return;
+    
+    ctxt.Throw();
+}
+
 void MCMiscGetLaunchUrl(MCExecContext& ctxt, MCStringRef& r_url)
 {
     if(MCSystemGetLaunchUrl(r_url))

--- a/engine/src/exec.h
+++ b/engine/src/exec.h
@@ -4006,6 +4006,8 @@ void MCSoundSetAudioCategory(MCExecContext &ctxt, intenum_t p_category);
 
 extern MCExecEnumTypeInfo* kMCMiscStatusBarStyleTypeInfo;
 
+void MCMiscGetTrackingAuthorizationStatus(MCExecContext& ctxt, MCStringRef &r_status);
+
 void MCMiscGetDeviceToken(MCExecContext& ctxt, MCStringRef& r_token);
 void MCMiscGetLaunchUrl(MCExecContext& ctxt, MCStringRef& r_url);
 

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -679,6 +679,12 @@ bool MCSystemGetSystemIdentifier(MCStringRef& r_identifier)
     return false;
 }
 
+bool MCSystemGetTrackingAuthorizationStatus (MCStringRef& r_status)
+{
+    // not supported on Android
+    return false;
+}
+
 bool MCSystemGetApplicationIdentifier(MCStringRef& r_identifier)
 {
     // not implemented on Android

--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -2906,6 +2906,23 @@ static Exec_stat MCHandleLocationAuthorizationStatus(void *context, MCParameter 
     return ES_ERROR;
 }
 
+static Exec_stat MCHandleTrackingAuthorizationStatus(void *context, MCParameter *p_parameters)
+{
+    MCAutoStringRef t_status;
+    MCExecContext ctxt(nil, nil,nil);
+    
+    MCMiscGetTrackingAuthorizationStatus(ctxt, &t_status);
+    
+    if (!ctxt . HasError())
+    {
+        ctxt . SetTheResultToValue(*t_status);
+        return ES_NORMAL;
+    }
+    
+    ctxt . SetTheResultToEmpty();
+    return ES_ERROR;
+}
+
 
 static MCMiscStatusBarStyle MCMiscStatusBarStyleFromString(MCStringRef p_string)
 {
@@ -4672,6 +4689,8 @@ static const MCPlatformMessageSpec s_platform_messages[] =
     {false, "mobileUseDeviceResolution", MCHandleUseDeviceResolution, nil},
     {false, "mobileDeviceScale", MCHandleDeviceScale, nil},
     {false, "mobilePixelDensity", MCHandlePixelDensity, nil},
+    
+    {false, "iphoneTrackingAuthorizationStatus", MCHandleTrackingAuthorizationStatus, nil},
 
     // SN-2014-10-15: [[ Merge-6.7.0-rc-3 ]]
     {false, "iphoneLocationAuthorizationStatus", MCHandleLocationAuthorizationStatus, nil},

--- a/engine/src/mbliphoneapp.mm
+++ b/engine/src/mbliphoneapp.mm
@@ -30,6 +30,11 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 #include "mblnotification.h"
 #import <sys/utsname.h>
 
+#ifdef __IPHONE_14_0
+#import <AppTrackingTransparency/AppTrackingTransparency.h>
+#endif
+
+
 #include "libscript/script.h"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -416,6 +421,16 @@ static UIDeviceOrientation patch_device_orientation(id self, SEL _cmd)
 	// Get the info dictionary.
 	NSDictionary *t_info_dict;
 	t_info_dict = [[NSBundle mainBundle] infoDictionary];
+    
+    // Show dialog about app tracking transparency
+#ifdef __IPHONE_14_0
+    if (@available(iOS 14, *))
+    {
+        NSString *t_app_tracking_transparency_key = [t_info_dict objectForKey: @"NSUserTrackingUsageDescription"];
+        if (t_app_tracking_transparency_key != nil)
+            [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(ATTrackingManagerAuthorizationStatus status) {}];
+    }
+#endif
     
     // Read the allowed notification types from the plist.
     NSArray *t_allowed_push_notifications_array;

--- a/engine/src/mbliphoneextra.mm
+++ b/engine/src/mbliphoneextra.mm
@@ -59,6 +59,10 @@ along with LiveCode.  If not see <http://www.gnu.org/licenses/>.  */
 
 #include <sys/xattr.h>
 
+#ifdef __IPHONE_14_0
+#import <AppTrackingTransparency/AppTrackingTransparency.h>
+#endif
+
 #include "mblstore.h"
 #include "mblsyntax.h"
 
@@ -517,6 +521,41 @@ bool MCSystemGetLaunchData(MCArrayRef &r_data)
 {
 	// Not implemented on iOS
 	return false;
+}
+
+bool MCSystemGetTrackingAuthorizationStatus (MCStringRef& r_status)
+{
+#ifdef __IPHONE_14_0
+    if (@available(iOS 14, *))
+    {
+        ATTrackingManagerAuthorizationStatus t_status = [ATTrackingManager trackingAuthorizationStatus];
+        switch (t_status)
+        {
+            case ATTrackingManagerAuthorizationStatusAuthorized:
+                //NSLog(@"ATTrackingManagerAuthorizationStatusAuthorized");
+                r_status = MCSTR("authorized");
+                break;
+            case ATTrackingManagerAuthorizationStatusDenied:
+                //NSLog(@"ATTrackingManagerAuthorizationStatusDenied");
+                r_status = MCSTR("denied");
+                break;
+            case ATTrackingManagerAuthorizationStatusRestricted:
+                //NSLog(@"ATTrackingManagerAuthorizationStatusRestricted");
+                r_status = MCSTR("restricted");
+                break;
+            case ATTrackingManagerAuthorizationStatusNotDetermined:
+                //NSLog(@"ATTrackingManagerAuthorizationStatusNotDetermined");
+                r_status = MCSTR("not determined");
+                break;
+        }
+        return true;
+    }
+    else
+#endif
+    {
+        r_status = MCSTR("not supported");
+        return false;
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/mblsyntax.h
+++ b/engine/src/mblsyntax.h
@@ -425,6 +425,8 @@ bool MCSystemSetNotificationBadgeValue (uint32_t r_badge_value);
 bool MCSystemGetDeviceToken (MCStringRef& r_device_token);
 bool MCSystemGetLaunchUrl (MCStringRef& r_launch_url);
 
+bool MCSystemGetTrackingAuthorizationStatus (MCStringRef& r_status);
+
 bool MCSystemGetLaunchData(MCArrayRef &r_lauch_data);
 
 bool MCSystemBeep(int32_t p_number_of_times);

--- a/engine/standalone.ios
+++ b/engine/standalone.ios
@@ -22,3 +22,4 @@ framework EventKit
 framework EventKitUI
 framework Security
 framework WebKit
+framework AppTrackingTransparency

--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -1614,7 +1614,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
          put "Portrait" into tIPadOrientations
       end if
    end if
-
+   
    local tUIStyle
    if not pSettings["ios,supports dark mode"] then
       put "<key>UIUserInterfaceStyle</key><string>Light</string>" into tUIStyle
@@ -1634,6 +1634,18 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    if tStatusBarStyle is "solid" then
       put "BlackOpaque" into tStatusBarStyle
       put true into tStatusBarSolid
+   end if
+   
+   ----------
+   
+   local tAppTrackingTransparency
+   if pSettings["ios,AppTrackingTransparency"] then
+      local tAppTrackingTransparencyMessage
+      put pSettings["ios,AppTrackingTransparencyMessage"] into tAppTrackingTransparencyMessage
+      put "<string>" before tAppTrackingTransparencyMessage
+      put "</string>" after tAppTrackingTransparencyMessage
+      put "<key>NSUserTrackingUsageDescription</key>" before tAppTrackingTransparencyMessage
+      put tAppTrackingTransparencyMessage into tAppTrackingTransparency
    end if
    
    ----------
@@ -1677,6 +1689,7 @@ private command revCreateMobilePlist pSettings, pAppBundle, pTarget, pFonts, pPl
    replace "${CUSTOM_FONTS}" with tCustomFonts in pPlist
    replace "${DISABLE_ATS}" with tDisableATS in pPlist
    replace "${HEALTHKIT}" with tHealthKit in pPlist
+   replace "${APP_TRACKING_TRANSPARENCY}" with tAppTrackingTransparency in pPlist
    replace "${UI_STYLE}" with tUIStyle in pPlist
    
    -- PM-2018-01-15: [[Bug 20852]] Get info about Xcode/SDK versions


### PR DESCRIPTION
This patch adds support for App Tracking Transparency. If the 'NSUserTrackingUsageDescription' key is present in the plist, the app shows an authorization dialog, asking the user to allow the app to track them.