### PR TITLE
[[ Bug 23130 ]] Ensure the pick wheel is shown on iOS 14

### DIFF
--- a/docs/notes/bugfix-23130.md
+++ b/docs/notes/bugfix-23130.md
@@ -1,0 +1,1 @@
+# Ensure mobilePickDate shows the pick wheel on iOS 14+

--- a/engine/src/mbliphonepickdate.mm
+++ b/engine/src/mbliphonepickdate.mm
@@ -132,6 +132,12 @@ UIViewController *MCIPhoneGetViewController(void);
 		[datePicker setLocale:t_locale];
 		[datePicker setCalendar:[t_locale objectForKey:NSLocaleCalendar]];
 		[datePicker setTimeZone:[NSTimeZone localTimeZone]];
+#ifdef __IPHONE_14_0
+		if (@available(iOS 14, *))
+		{
+			[datePicker setPreferredDatePickerStyle: UIDatePickerStyleWheels];
+		}
+#endif
 		// set up the style and parameters for the date picker
 		if (p_style == nil || MCCStringEqual([p_style cStringUsingEncoding:NSMacOSRomanStringEncoding], "dateTime"))
 			[datePicker setDatePickerMode:UIDatePickerModeDateAndTime];


### PR DESCRIPTION
This patch ensures mobilePickDate shows the pick wheel on iOS 14