### PR TITLE
[[ Bug 23208 ]] Ensure automatic window tabbing is not allowed

### DIFF
--- a/docs/notes/bugfix-23208.md
+++ b/docs/notes/bugfix-23208.md
@@ -1,0 +1,1 @@
+# Ensure new stacks always open in new windows on macOS

--- a/engine/src/mac-core.mm
+++ b/engine/src/mac-core.mm
@@ -355,6 +355,9 @@ static OSErr preDispatchAppleEvent(const AppleEvent *p_event, AppleEvent *p_repl
 									 selector:@selector(interfaceThemeChangedNotification:)
 								     name:@"AppleInterfaceThemeChangedNotification" object:nil];
     
+	if ([NSWindow respondsToSelector:@selector(allowsAutomaticWindowTabbing)])
+		[NSWindow setAllowsAutomaticWindowTabbing: NO];
+	
 	// We started up successfully, so queue the root runloop invocation
 	// message.
 	[self performSelector: @selector(runMainLoop) withObject: nil afterDelay: 0];


### PR DESCRIPTION
This patch ensures that new stacks will always open in new windows, and not in new tabs in the existing stack window. Also it fixes an issue where a stack window could have a double title bar.