### PR TITLE
[[ Bug 23212 ]] Ask for proper permission before "mobileExportImageToAlbum" on Android 7+

### DIFF
--- a/docs/notes/bugfix-23212.md
+++ b/docs/notes/bugfix-23212.md
@@ -1,0 +1,1 @@
+# Ensure `mobileExportImageToAlbum` works on Android 7+ devices

--- a/engine/src/mblandroidmisc.cpp
+++ b/engine/src/mblandroidmisc.cpp
@@ -739,6 +739,10 @@ bool MCSystemExportImageToAlbum(MCStringRef& r_save_result, MCDataRef p_raw_data
     // SN-2015-01-05: [[ Bug 11417 ]] The file extension has a trailing '\n', which causes issues on Android.
     MCAutoStringRef t_android_filetype;
     MCStringCopySubstring(p_file_extension, MCRangeMake(0, MCStringGetLength(p_file_extension) - 1), &t_android_filetype);
+    
+    if (!MCAndroidCheckRuntimePermission(MCSTR("android.permission.WRITE_EXTERNAL_STORAGE")))
+        return false;
+    
     MCAndroidEngineCall("exportImageToAlbum", "xdxx", &r_save_result, p_raw_data, p_file_name, *t_android_filetype);
     
     return true;


### PR DESCRIPTION
This patch ensures the permission to access "Files and Media" is requested by the
user before calling "mobileExportImageToAlbum". This fixes a silent failure on Android 7+
devices.

Closes https://quality.livecode.com/show_bug.cgi?id=23212