### PR TITLE
[[ Bug 23220 ]] Ensure mouseUp is sent to image objects out of browse mode

### DIFF
--- a/docs/notes/bugfix-23220.md
+++ b/docs/notes/bugfix-23220.md
@@ -1,0 +1,1 @@
+# Ensure clicking in an image rect in pointer mode does not send mouseRelease instead of a mouseUp message

--- a/engine/src/image.cpp
+++ b/engine/src/image.cpp
@@ -465,11 +465,11 @@ Boolean MCImage::mup(uint2 which, bool p_release)
 		static_cast<MCMutableImageRep *>(m_rep) -> image_mup(which))
 		return True;
 
+	MCRectangle srect;
+	MCU_set_rect(srect, mx, my, 1, 1);
 	switch(getstack() -> gettool(this))
 	{
 	case T_BROWSE:
-		MCRectangle srect;
-		MCU_set_rect(srect, mx, my, 1, 1);
 		if (!p_release && maskrect(srect))
 			message_with_args(MCM_mouse_up, which);
 		else


### PR DESCRIPTION
This patch ensures that the mouseUp message is sent to image objects when the
tool is image or pointer and the mouse button is released inside the image. Previously,
use of an uninitialized rectangle (srect) caused the wrong message to be almost always
sent.
