### PR TITLE
[[ Bug 23224 ]] Fix compile error when building iOS with Xcode12.5

### DIFF
--- a/engine/src/mblhandlers.cpp
+++ b/engine/src/mblhandlers.cpp
@@ -4842,7 +4842,7 @@ static const MCPlatformMessageSpec s_platform_messages[] =
     {false, "mobileSetKeyboardDisplay", MCHandleSetKeyboardDisplay, nil},
     {false, "mobileGetKeyboardDisplay", MCHandleGetKeyboardDisplay, nil},
     
-	{nil, nil, nil}    
+	{false, nil, nil}    
 };
 
 bool MCIsPlatformMessage(MCNameRef handler_name)


### PR DESCRIPTION
This patch fixes the following compile error when building the iOS engines with Xcode 12.5:

```
/Users/administrator/Vulcan/slaves/build-mac-5-1/slave/try-community-universal-ios-iphoneos14_4/checkout/engine/src/mblhandlers.cpp:4845:3: error: type 'nullptr_t' cannot be narrowed to 'bool' in initializer list [-Wc++11-narrowing]
        {nil, nil, nil}    
         ^~~
```

Closes https://quality.livecode.com/show_bug.cgi?id=23224