### PR TITLE
[[ Bug 22400 ]] Allow http connections on Android browser

### DIFF
--- a/engine/rsrc/android-manifest.xml
+++ b/engine/rsrc/android-manifest.xml
@@ -20,6 +20,7 @@ ${USES_PERMISSION}${USES_FEATURE}
       android:windowSoftInputMode="stateHidden"
       android:launchMode="singleTask"
       android:hardwareAccelerated="${HARDWARE_ACCELERATED}">
+      ${ALLOW_HTTP_CONNECTIONS}
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/ide-support/revsaveasandroidstandalone.livecodescript
+++ b/ide-support/revsaveasandroidstandalone.livecodescript
@@ -599,6 +599,18 @@ private command revSaveAsMobileStandaloneMain pStack, pApkFile, pTarget, pSettin
       end if
       replace "${HARDWARE_ACCELERATED}" with tHardwareAccelerated in tManifest
       
+      // Allow http connections
+      local tAllowHttpConnections, tHasInternetPermission
+      if the keys of pSettings["android,application permissions"] contains "Internet" then
+         put "true" into tHasInternetPermission
+      end if
+      if pSettings["android,allow http"] and tHasInternetPermission then
+         put "android:usesCleartextTraffic=" & quote & "true" & quote into tAllowHttpConnections
+      else
+         put empty into tAllowHttpConnections
+      end if
+      replace "${ALLOW_HTTP_CONNECTIONS}" with tAllowHttpConnections in tManifest
+      
       put tManifest into url ("binfile:" & tManifestFile)
       
       local tAdditional


### PR DESCRIPTION
This patch allows http connections if the user checks the appropriate checkbox in the Android standalone settings.