### PR TITLE
[[ Bug 23193 ]] Conditionally include AppTrackingTransparency framework

### DIFF
--- a/engine/bind-ios-standalone.sh
+++ b/engine/bind-ios-standalone.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
 
+read SDK_MAJORVERSION SDK_MINORVERSION <<<${SDK_NAME//[^0-9]/ }
+
 set -e
 
 case "$1" in
 	*-community.lcext)
-		DEPS_FILE="${SRCROOT}/standalone.ios"
+		if [[ $SDK_MAJORVERSION -lt 14 ]] ; then
+			DEPS_FILE="${SRCROOT}/standalone.ios"
+		else
+			DEPS_FILE="${SRCROOT}/standalone14.ios"
+		fi
 		;;
 	*-commercial.lcext)
-		DEPS_FILE="${SRCROOT}/../livecode/engine/standalone.ios"
+		if [[ $SDK_MAJORVERSION -lt 14 ]] ; then
+			DEPS_FILE="${SRCROOT}/../livecode/engine/standalone.ios"
+		else
+			DEPS_FILE="${SRCROOT}/../livecode/engine/standalone14.ios"
+		fi
 		;;
 esac
 

--- a/engine/engine.gyp
+++ b/engine/engine.gyp
@@ -289,12 +289,26 @@
 						
 						# Forces all dependencies to be linked properly
 						'type': 'shared_library',
+                        
+						'conditions':
+						[
+							[
+								'("11" not in target_sdk) and ("12" not in target_sdk) and ("13" not in target_sdk)',
+								{
+									'variables':
+									{
+										'deps_file': '${SRCROOT}/standalone14.ios',
+									},
+								},
+								{
+									'variables':
+									{
+										'deps_file': '${SRCROOT}/standalone.ios',
+									},
+								}
+							],
+						],
 						
-						'variables':
-						{
-							'deps_file': '${SRCROOT}/standalone.ios',
-						},
-
 						'xcode_settings':
 						{
 							'DEAD_CODE_STRIPPING': 'NO',

--- a/engine/kernel.gyp
+++ b/engine/kernel.gyp
@@ -187,7 +187,7 @@
                         },
                     ],
                     [
-                        'OS == "ios" and target_sdk >= "14.0"',
+                        'OS == "ios" and ("11" not in target_sdk) and ("12" not in target_sdk) and ("13" not in target_sdk)',
                         {
                             'libraries':
                             [

--- a/engine/standalone14.ios
+++ b/engine/standalone14.ios
@@ -22,3 +22,4 @@ framework EventKit
 framework EventKitUI
 framework Security
 framework WebKit
+framework AppTrackingTransparency


### PR DESCRIPTION
This patch ensures the AppTrackingTransparency framework is included only if the version of the target_sdk is 14+