### PR TITLE
[Bug-23232] Correct code example in replace entry.

### DIFF
--- a/docs/dictionary/command/replace.lcdoc
+++ b/docs/dictionary/command/replace.lcdoc
@@ -56,7 +56,7 @@ replace only an exact <string> of text.
 > For example:
 
     put "x:y:y:y:y:x:" into tChangeMe
-    replace ":y:" with empty in tChangeMe
+    replace ":y:" with "::" in tChangeMe
     put tChangeMe -- returns x::y::y:x
     
 > If the goal were to remove every lone y within two colons that appears 

--- a/docs/notes/bugfix-23232.md
+++ b/docs/notes/bugfix-23232.md
@@ -1,0 +1,1 @@
+# Corrected code example in documentation for replace.


### PR DESCRIPTION
The code example to show an incorrect way to remove all of a certain character between two others was itself incorrect. Changing to match the intended output.