### PR TITLE
[[ Bug 23234 ]] Fix iOS standalone build error when running from source

### DIFF
--- a/ide-support/revsaveasiosstandalone.livecodescript
+++ b/ide-support/revsaveasiosstandalone.livecodescript
@@ -535,7 +535,11 @@ private command revSaveAsMobileStandaloneMain pStack, pAppBundle, pTarget, pSett
             -- MM-2013-09-23: [[ iOS7 Support ]] Use g++ instead of llvm-g++-4.2. XCode 5.0 uses llvm 5.0.
             -- g++ appears to be sym-linked to the appropriate compiler in all SDKS.
             -- SN-2015-02-19: [[ Bug 14625 ]] The minimum iOS version is bound to the architecture
-            get shell("g++ -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion[tArch] && " -w " & quote & "@" & tLinkOptionsFile & quote)
+            
+            -- PM-2021-06-10: [[ Bug 23234 ]] g++ might not be symlinked correctly, so use full path to clang++ instead
+            local tCommand
+            put tSdkRoot & "/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++" into tCommand
+            get shell(tCommand & " -arch " & tArch && "-miphoneos-version-min=" & tiPhoneMinVersion[tArch] && " -w " & quote & "@" & tLinkOptionsFile & quote)
             
             put tArchSpecificEngineFile & space after tArchSpecificEngineList
             delete file tLinkOptionsFile


### PR DESCRIPTION
This patch fixes the error:

```
Failed to open macho file at 
/../Xcodes/Xcode_12_5_0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ 
for reading: Too many levels of symbolic links
```

It seems there is a chance `g++` is not symlinked correctly, so use the full path to `clang++` instead.

Closes https://quality.livecode.com/show_bug.cgi?id=23234