### PR TITLE
[[ mergExt ]] Update pointer

### DIFF
--- a/builder/builder_utilities.livecodescript
+++ b/builder/builder_utilities.livecodescript
@@ -1,6 +1,6 @@
 ﻿script "BuilderUtilities"
 
-constant kMergExtVersion = "2021-2-2"
+constant kMergExtVersion = "2021-6-16"
 constant kTSNetVersion = "1.4.4"
 
 local sEngineDir


### PR DESCRIPTION
This patch updates the mergExt pointer to a version including builds for iOS
SDK 14.5.