### PR TITLE
[[ Bug 23237 ]] Ensure Android EGL configuration supports GLES 3.x

### DIFF
--- a/docs/notes/bugfix-23237.md
+++ b/docs/notes/bugfix-23237.md
@@ -1,0 +1,1 @@
+# Fix crash when using acceleratedRendering on Android x86 emulator

--- a/engine/src/java/com/runrev/android/OpenGLView.java
+++ b/engine/src/java/com/runrev/android/OpenGLView.java
@@ -35,6 +35,7 @@ public class OpenGLView extends SurfaceView implements SurfaceHolder.Callback
 	// Instance variables
 	
 	private static final int EGL_CONTEXT_CLIENT_VERSION = 0x00003098;
+	private static final int EGL_OPENGL_ES3_BIT = 0x00000040;
 	
 	private EGL10 m_egl;
 	private EGLDisplay m_egl_display;
@@ -78,6 +79,7 @@ public class OpenGLView extends SurfaceView implements SurfaceHolder.Callback
 	{
 		int[] t_config_spec;
 		t_config_spec = new int[] {
+			EGL10 . EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
 			EGL10 . EGL_RED_SIZE, r,
 			EGL10 . EGL_GREEN_SIZE, g,
 			EGL10 . EGL_BLUE_SIZE, b,


### PR DESCRIPTION
This patch updates the android OpenGLView class to request an EGL
configuration that supports GLES 3.x. This prevents a crash in the
Android x86 emulator when attempting to use gl functions that are not
supported by the default configuration.

Fixes https://quality.livecode.com/show_bug.cgi?id=23237