### PR TITLE
[[ Bug 22791 ]] Fix error signing Mac standalones when app name contains accents

### DIFF
--- a/docs/notes/bugfix-22791.md
+++ b/docs/notes/bugfix-22791.md
@@ -1,0 +1,1 @@
+# Fix codesigning error saving Mac standalone app when the app name contains accented characters

--- a/engine/rsrc/Installer-Info.plist
+++ b/engine/rsrc/Installer-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleGetInfoString</key>

--- a/engine/rsrc/LiveCode-Info.plist
+++ b/engine/rsrc/LiveCode-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/engine/rsrc/Standalone-Info.plist
+++ b/engine/rsrc/Standalone-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
+	<string>en</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/ide-support/revsaveasstandalone.livecodescript
+++ b/ide-support/revsaveasstandalone.livecodescript
@@ -672,7 +672,7 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder, @xStandalonePa
    put sStandaloneSettingsA into tStandaloneSettingsA
    repeat for each key tTarget in sPlatformDirectoriesA["MacOSX"]
       put sPlatformDirectoriesA["MacOSX"][tTarget] into tTargetDir
-      put tTargetDir & sStandaloneSettingsA["name"] & ".app/Contents/MacOS/" into tDirectory
+      put tTargetDir & normalizeForDisk(sStandaloneSettingsA["name"]) & ".app/Contents/MacOS/" into tDirectory
       
       -- Ensure standalone settings script local is reset when building for subsequent targets
       put tStandaloneSettingsA into sStandaloneSettingsA
@@ -697,7 +697,7 @@ command revSaveAsMacStandalone pStack, pRestoreFileName, pFolder, @xStandalonePa
                & return & tEngineSourceFile
       end if
       
-      put tDirectory & sStandaloneSettingsA["name"] into tStandalonePath
+      put tDirectory & normalizeForDisk(sStandaloneSettingsA["name"]) into tStandalonePath
       
       put tStandalonePath into xStandalonePaths[tTarget]
       
@@ -1783,8 +1783,17 @@ end revSetMacOS
 --    plists as Mavericks doesn't like it!
 private function escapeForXml pString
    replace "&" with "&amp;" in pString
-   return pString
+   return normalizeText(pString, "NFD")
 end escapeForXml
+
+private function normalizeForDisk pString
+   if the platform is "MacOS" then
+      // Composed unicode chars can cause problems with codesign so we normalize them to NFD form
+      return normalizeText(pString, "NFD")
+   else
+      return pString
+   end if
+end normalizeForDisk
 
 #####################################################################
 # revSetStackProps is a combination of revRemoveProps and revSetProfiles


### PR DESCRIPTION
This patch fixes an error when using the codesign utility to sign Mac
standalones, when the app name contains accented characters. This is
due to codesign expecting unicode characters in the plist to be given
in decomposed form.

Fixes https://quality.livecode.com/show_bug.cgi?id=22791