### PR TITLE
[[ Bug 23240 ]] Fix engine lockup after execution error in modal stack

### DIFF
--- a/docs/notes/bugfix-23240.md
+++ b/docs/notes/bugfix-23240.md
@@ -1,0 +1,1 @@
+# Fix IDE lockup when an execution error occurs in a modal stack

--- a/engine/src/debug.h
+++ b/engine/src/debug.h
@@ -102,8 +102,8 @@ extern MCNameRef MClogmessage;
 struct MCExecValue;
 
 extern void MCB_setmsg(MCExecContext &ctxt, MCStringRef p_string);
-extern void MCB_message(MCExecContext &ctxt, MCNameRef message, MCParameter *p);
-extern void MCB_prepmessage(MCExecContext &ctxt, MCNameRef message, uint2 line, uint2 pos, uint2 id, MCStringRef p_info = kMCEmptyString);
+extern Exec_stat MCB_message(MCExecContext &ctxt, MCNameRef message, MCParameter *p);
+extern Exec_stat MCB_prepmessage(MCExecContext &ctxt, MCNameRef message, uint2 line, uint2 pos, uint2 id, MCStringRef p_info = kMCEmptyString);
 extern void MCB_break(MCExecContext &ctxt, uint2 line, uint2 pos);
 extern void MCB_trace(MCExecContext &ctxt, uint2 line, uint2 pos);
 extern bool MCB_error(MCExecContext &ctxt, uint2 line, uint2 pos, uint2 id);


### PR DESCRIPTION
This patch fixes an infinite loop that occurs when the "traceError"
message is sent and not handled.

Fixes https://quality.livecode.com/show_bug.cgi?id=23240