### PR TITLE
[Bugfix-23247] Remove references to HTML5 from post entry

### DIFF
--- a/docs/dictionary/command/post.lcdoc
+++ b/docs/dictionary/command/post.lcdoc
@@ -11,7 +11,7 @@ Associations: internet library
 
 Introduced: 1.0
 
-OS: mac, windows, linux, ios, android, html5
+OS: mac, windows, linux, ios, android
 
 Platforms: desktop, server, mobile
 
@@ -103,14 +103,6 @@ password "pass", use the following <statement> :
 > [RFC 1738](https://tools.ietf.org/html/rfc1738). Ensure that you
 > <URLEncode> any username and password fields appropriately for FTP
 > URLs.
-
-> *Cross-platform note:* The HTML5 engine only supports HTTP and HTTPs
-> protocols.
-
-> *Cross-platform note:* URLs fetched by the HTML5 engine from a domain
-> other than that of the hosting the page may be blocked by web browsers,
-> unless the server hosting the URL sets the "Access-Control-Origin" header
-> appropriately.
 
 References: post (command), write to socket (command),
 delete URL (command), read from socket (command), put (command),

--- a/docs/notes/bugfix-23247.md
+++ b/docs/notes/bugfix-23247.md
@@ -1,0 +1,1 @@
+# Removed all references to HTML5 from the post entry.


### PR DESCRIPTION
Removed HTML5 from the platforms and HTML5 platform notes as post does not work on HTML5.