### PR TITLE
[[ Bug 21615 ]] Fix emscripten release build error

### DIFF
--- a/engine/src/em-event.js
+++ b/engine/src/em-event.js
@@ -131,7 +131,7 @@ mergeInto(LibraryManager.library, {
 			});
 
 			// Add listener for changes to device pixel ratio
-			var matchQuery = `(resolution: ${window.devicePixelRatio}dppx)`;
+			var matchQuery = "(resolution: " + window.devicePixelRatio + "dppx)";
 			window.matchMedia(matchQuery).addListener(LiveCodeEvents._handleDevicePixelRatioChanged);
 
 			LiveCodeEvents._initialised = true;


### PR DESCRIPTION
This patch fixes an emscripten build error that occurs when building the
emscripten standalone in release mode. This is caused by the use of an
JavaScript feature (template literals) that is unrecognised by older
emscripten emsdk tools.