### PR TITLE
only issue ulTickleMe for libURL sockets

### DIFF
--- a/ide-support/revliburl.livecodescript
+++ b/ide-support/revliburl.livecodescript
@@ -3979,7 +3979,8 @@ end ulStartTickle
 --------------------------
 on ulTickleMe
   ## safeguard against possible hangs in "wait for messages" loops
-  if the openSockets <> empty then
+    // MDW 2021.07.17 feature_ulEndTickle
+  if the keys of lvSocketToken is not empty then
     send "ulTickleMe" to me in 1 seconds
   else
     put empty into lvTickle


### PR DESCRIPTION
The ulTickleMe messages is currently issued once a second if there are any open sockets. This is overbroad, in that if I "accept connections on socket x" and then issue an http request (for example to query whether there are any updates) then the ulTickleMe message will continue in perpetuity rather than ending when the http request finishes. This patch checks for only libUrl sockets instead of for sockets in general. The ulTickleMe messages properly stop when the libUrl command ends.