### PR TITLE
[[ Bug 23038 ]] Fix creation of color profiles on macOS

### DIFF
--- a/docs/notes/bugfix-23038.md
+++ b/docs/notes/bugfix-23038.md
@@ -1,0 +1,1 @@
+# Fix some images rendering as black in recent macOS versions

--- a/engine/src/mac-color.mm
+++ b/engine/src/mac-color.mm
@@ -72,7 +72,7 @@ void MCPlatformCreateColorTransform(const MCColorSpaceInfo& p_info, MCPlatformCo
 		CFDataRef t_data;
 		t_data = nil;
 		
-		t_success = nil != (t_data = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, (UInt8*)p_info.embedded.data, p_info.embedded.data_size, kCFAllocatorNull));
+		t_success = nil != (t_data = CFDataCreate(kCFAllocatorDefault, (UInt8*)p_info.embedded.data, p_info.embedded.data_size));
 		
 		if (t_success)
 			t_success = nil != (t_colorspace = CGColorSpaceCreateWithICCProfile(t_data));


### PR DESCRIPTION
This patch fixes an issue with the creation of color profiles from
embedded ICC information. Previously the NoCopy CFDataRef constructor
was being used to wrap the raw bytes to be passed to the relevant
CGColorSpaceRef constructor. However, the data wrapped in this way
could be released at any time, and in versions of macOS since
Mojave it appears that the OS defers copying the data thus causing
strange effects when the color profile is eventually applied. The
problem has been fixed by using the normal CFDataRef constructor
which copies the provided bytes.

Closes https://quality.livecode.com/show_bug.cgi?id=23038